### PR TITLE
fix: fix signature generation for multi commands

### DIFF
--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -3879,12 +3879,16 @@ var bundle = function (_, Kotlin) {
       return null;
     }
     var expressionNode = ensureNotNull(rootValidation.value);
+    var commandParts = ArrayList_init();
     tmp$ = expressionNode.children.iterator();
     while (tmp$.hasNext()) {
       var child = tmp$.next();
       if (Kotlin.isType(child, Command)) {
-        return getCommandSignature(child).toCode();
+        commandParts.addAll_brywnq$(child.parts);
       }
+    }
+    if (!commandParts.isEmpty()) {
+      return getCommandSignature(new Command(commandParts)).toCode();
     }
     return null;
   }

--- a/docs/data.js
+++ b/docs/data.js
@@ -27,35 +27,35 @@ window.MATHLINGUA_DATA = window.MATHLINGUA_DATA || [
   "keywords": ["a", "in", "x", "represents", "is", "set", "an", "element", "of", "reference", "=", "source", "aata", "page", "4"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\in"
 },
 {
   "text": "[A \\subset B]\nRepresents:\nassuming: 'A, B is \\set'\nthat:\n. for: a\n  where: 'a \\in A'\n  then: 'a \\in B'\nMetadata:\n. reference = \"source: @AATA; page: 4\"",
   "keywords": ["a", "subset", "b", "represents", "is", "set", "in", "reference", "=", "source", "aata", "page", "4"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\subset"
 },
 {
   "text": "[x \\neq y]\nRepresents:\nthat: 'x != y'",
   "keywords": ["x", "neq", "y", "represents", "!="],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\neq"
 },
 {
   "text": "[A \\proper.subset B]\nRepresents:\nassuming: 'A, B is \\set'\nthat:\n. 'A \\subset B'\n. 'A \\neq B'\nMetadata:\n. reference = \"source: @AATA; page: 4\"",
   "keywords": ["a", "proper", "subset", "b", "represents", "is", "set", "neq", "reference", "=", "source", "aata", "page", "4"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\proper.subset"
 },
 {
   "text": "[\\empty.set]\nRefines: E\nmeans:\n. not:\n  . exists: x\n    suchThat: 'x \\in E'\nMetadata:\n. reference = \"source: @AATA; page: 4\"",
   "keywords": ["empty", "set", "e", "x", "in", "reference", "=", "source", "aata", "page", "4"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\empty.set"
 },
 {
   "text": "[A \\union B]\nDefines: C := {c}\nassuming: 'A, B is \\set'\nmeans:\n. 'C is \\set'\n. or:\n  . 'c \\in A'\n  . 'c \\in B'\nMetadata:\n. reference = \"source: @AATA; page: 4\"",
@@ -83,7 +83,7 @@ window.MATHLINGUA_DATA = window.MATHLINGUA_DATA || [
   "keywords": ["x", "notin", "represents", "is", "set", "in"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\notin"
 },
 {
   "text": "[\\complement:of{A}in{U}]\nDefines: X := {x}\nassuming: 'A, U is \\set'\nmeans:\n. 'x \\in U'\n. 'x \\notin A'\nMetadata:\n. reference = \"source: @AATA; page: 5\"",
@@ -125,21 +125,21 @@ window.MATHLINGUA_DATA = window.MATHLINGUA_DATA || [
   "keywords": ["surjective", "function", "on", "a", "to", "b", "f", "in", "=", "reference", "source", "aata", "page", "8"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\surjective.function:on{?}to{?}"
 },
 {
   "text": "[\\injective \\function:on{A}to{B}]\nRefines: f\nmeans:\n. for: a1, a2\n  where: 'a1, a2 \\in A'\n  then:\n  . if: 'a1 \\neq a2'\n    then: 'f(a1) \\neq f(a2)'\nMetadata:\n. reference = \"source: @AATA; page: 8\"",
   "keywords": ["injective", "function", "on", "a", "to", "b", "f", "a1", "a2", "in", "neq", "reference", "=", "source", "aata", "page", "8"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\injective.function:on{?}to{?}"
 },
 {
   "text": "[\\bijective \\function]\nRefines: f\nmeans:\n. 'f \\is \\injective \\surjective \\function'\nMetadata:\n. reference = \"source: @AATA; page: 8\"",
   "keywords": ["bijective", "function", "f", "is", "injective", "surjective", "reference", "=", "source", "aata", "page", "8"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\bijective.function"
 },
 {
   "text": "[g \\of f]\nDefines: h(x)\nassuming:\n. for: A, B, C\n  where: 'A, B, C is \\set'\n  then:\n  . 'f is \\function:on{A}to{B}'\n  . 'g is \\function:on{B}to{C}'\nmeans:\n. 'h is \\function:on{A}to{C}'\n. 'h(x) = g(f(x))'\nMetadata:\n. reference = \"source: @AATA; page: 8\"",
@@ -216,7 +216,7 @@ window.MATHLINGUA_DATA = window.MATHLINGUA_DATA || [
   "keywords": ["abelian", "group", "g", "=", "x", "*", "a", "b", "in", "reference", "source", "aata", "page", "34"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\abelian.group"
 },
 {
   "text": "[\\matrix{m, n}:over{F}]\nDefines: M\nassuming:\n. 'F is \\set'\n. 'm, n is \\positive \\integer'\nmeans:\n. \"an $m$ by $n$ grid of elements\"",
@@ -230,7 +230,7 @@ window.MATHLINGUA_DATA = window.MATHLINGUA_DATA || [
   "keywords": ["identity", "matrix", "n", "m", "i", "j", "is", "positive", "integer", "neq", "=", "0", "1", "reference", "source", "aata", "page", "35"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\identity.matrix{?}"
 },
 {
   "text": "[A * B]\nDefines: *\nmeans:\n. if: 'A, B is \\matrix'\n  then: 'A * B is \\matrix'",
@@ -244,7 +244,7 @@ window.MATHLINGUA_DATA = window.MATHLINGUA_DATA || [
   "keywords": ["invertible", "matrix", "m", "a", "*", "=", "identity", "reference", "source", "aata", "page", "35"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\invertible.matrix"
 },
 {
   "text": "[\\general.linear.group{n}:over{F}]\nDefines: X\nassuming:\n. or:\n  . 'F = \\reals'\n  . 'F = \\complexes'\n. 'n is \\integer'\nmeans:\n. 'X = \\set[M]{M}{M is \\invertible.matrix}'\nMetadata:\n. reference = \"source: @AATA; page: 35\"",
@@ -258,14 +258,14 @@ window.MATHLINGUA_DATA = window.MATHLINGUA_DATA || [
   "keywords": ["finite", "set", "x", "has", "a", "number", "of", "elements", "reference", "=", "source", "aata", "page", "36"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\finite.set"
 },
 {
   "text": "[\\infinite \\set]\nRefines: X\nmeans:\n. not:\n  . 'X is \\finite \\set'\nMetadata:\n. reference = \"source: @AATA; page: 36\"",
   "keywords": ["infinite", "set", "x", "is", "finite", "reference", "=", "source", "aata", "page", "36"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\infinite.set"
 },
 {
   "text": "[\\set.cardinality:of{X}]\nDefines: n\nassuming: 'X is \\set'\nmeans: \"$n$ is the number of elements in $X$\"",
@@ -279,14 +279,14 @@ window.MATHLINGUA_DATA = window.MATHLINGUA_DATA || [
   "keywords": ["finite", "group", "g", "=", "x", "*", "is", "set", "reference", "source", "aata", "page", "36"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\finite.group"
 },
 {
   "text": "[\\infinite \\group]\nRefines: G := (X, *)\nmeans: 'X \\is \\infinite \\set'\nMetadata:\n. reference = \"source: @AATA; page: 36\"",
   "keywords": ["infinite", "group", "g", "=", "x", "*", "is", "set", "reference", "source", "aata", "page", "36"],
   "href": "null",
   "mobileHref": "null",
-  "signature": null
+  "signature": "\\infinite.group"
 },
 {
   "text": "[\\group.order:of{G := (X, *)}]\nDefines: n\nassuming: 'G is \\group'\nmeans: 'n = \\set.cardinality:of{X}'\nMetadata:\n. reference = \"source: @AATA; page: 36\"",

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Group.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Group.kt
@@ -22,13 +22,13 @@ import mathlingua.common.chalktalk.phase1.ast.*
 import mathlingua.common.textalk.*
 
 data class DefinesGroup(
-        val signature: String?,
-        val id: Statement,
-        val definesSection: DefinesSection,
-        val assumingSection: AssumingSection?,
-        val meansSection: MeansSection,
-        val aliasSection: AliasSection?,
-        val metaDataSection: MetaDataSection?
+    val signature: String?,
+    val id: Statement,
+    val definesSection: DefinesSection,
+    val assumingSection: AssumingSection?,
+    val meansSection: MeansSection,
+    val aliasSection: AliasSection?,
+    val metaDataSection: MetaDataSection?
 ) : Phase2Node {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
@@ -45,13 +45,13 @@ data class DefinesGroup(
 
     override fun toCode(isArg: Boolean, indent: Int): String {
         return toCode(
-                isArg,
-                indent,
-                id,
-                definesSection,
-                assumingSection,
-                meansSection,
-                metaDataSection
+            isArg,
+            indent,
+            id,
+            definesSection,
+            assumingSection,
+            meansSection,
+            metaDataSection
         )
     }
 
@@ -63,25 +63,25 @@ data class DefinesGroup(
 
         fun validate(groupNode: Group): Validation<DefinesGroup> {
             return validateDefinesLikeGroup(
-                    groupNode,
-                    "Defines",
-                    DefinesSection.Companion::validate,
-                    "means",
-                    MeansSection.Companion::validate,
-                    ::DefinesGroup
+                groupNode,
+                "Defines",
+                DefinesSection.Companion::validate,
+                "means",
+                MeansSection.Companion::validate,
+                ::DefinesGroup
             )
         }
     }
 }
 
 data class RefinesGroup(
-        val signature: String?,
-        val id: Statement,
-        val refinesSection: RefinesSection,
-        val assumingSection: AssumingSection?,
-        val meansSection: MeansSection,
-        val aliasSection: AliasSection?,
-        val metaDataSection: MetaDataSection?
+    val signature: String?,
+    val id: Statement,
+    val refinesSection: RefinesSection,
+    val assumingSection: AssumingSection?,
+    val meansSection: MeansSection,
+    val aliasSection: AliasSection?,
+    val metaDataSection: MetaDataSection?
 ) : Phase2Node {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
@@ -98,14 +98,14 @@ data class RefinesGroup(
 
     override fun toCode(isArg: Boolean, indent: Int): String {
         return toCode(
-                isArg,
-                indent,
-                id,
-                id,
-                refinesSection,
-                assumingSection,
-                meansSection,
-                metaDataSection
+            isArg,
+            indent,
+            id,
+            id,
+            refinesSection,
+            assumingSection,
+            meansSection,
+            metaDataSection
         )
     }
 
@@ -117,25 +117,25 @@ data class RefinesGroup(
 
         fun validate(groupNode: Group): Validation<RefinesGroup> {
             return validateDefinesLikeGroup(
-                    groupNode,
-                    "Refines",
-                    RefinesSection.Companion::validate,
-                    "means",
-                    MeansSection.Companion::validate,
-                    ::RefinesGroup
+                groupNode,
+                "Refines",
+                RefinesSection.Companion::validate,
+                "means",
+                MeansSection.Companion::validate,
+                ::RefinesGroup
             )
         }
     }
 }
 
 data class RepresentsGroup(
-        val signature: String?,
-        val id: Statement,
-        val representsSection: RepresentsSection,
-        val assumingSection: AssumingSection?,
-        val thatSection: ThatSection,
-        val aliasSection: AliasSection?,
-        val metaDataSection: MetaDataSection?
+    val signature: String?,
+    val id: Statement,
+    val representsSection: RepresentsSection,
+    val assumingSection: AssumingSection?,
+    val thatSection: ThatSection,
+    val aliasSection: AliasSection?,
+    val metaDataSection: MetaDataSection?
 ) : Phase2Node {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
@@ -152,13 +152,13 @@ data class RepresentsGroup(
 
     override fun toCode(isArg: Boolean, indent: Int): String {
         return toCode(
-                isArg,
-                indent,
-                id,
-                representsSection,
-                assumingSection,
-                thatSection,
-                metaDataSection
+            isArg,
+            indent,
+            id,
+            representsSection,
+            assumingSection,
+            thatSection,
+            metaDataSection
         )
     }
 
@@ -170,21 +170,21 @@ data class RepresentsGroup(
 
         fun validate(groupNode: Group): Validation<RepresentsGroup> {
             return validateDefinesLikeGroup(
-                    groupNode,
-                    "Represents",
-                    RepresentsSection.Companion::validate,
-                    "that",
-                    ThatSection.Companion::validate,
-                    ::RepresentsGroup
+                groupNode,
+                "Represents",
+                RepresentsSection.Companion::validate,
+                "that",
+                ThatSection.Companion::validate,
+                ::RepresentsGroup
             )
         }
     }
 }
 
 data class ResultGroup(
-        val resultSection: ResultSection,
-        val aliasSection: AliasSection?,
-        val metaDataSection: MetaDataSection?
+    val resultSection: ResultSection,
+    val aliasSection: AliasSection?,
+    val metaDataSection: MetaDataSection?
 ) : Phase2Node {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
@@ -206,19 +206,19 @@ data class ResultGroup(
 
         fun validate(groupNode: Group): Validation<ResultGroup> {
             return validateResultLikeGroup(
-                    groupNode,
-                    "Result",
-                    ResultSection.Companion::validate,
-                    ::ResultGroup
+                groupNode,
+                "Result",
+                ResultSection.Companion::validate,
+                ::ResultGroup
             )
         }
     }
 }
 
 data class AxiomGroup(
-        val axiomSection: AxiomSection,
-        val aliasSection: AliasSection?,
-        val metaDataSection: MetaDataSection?
+    val axiomSection: AxiomSection,
+    val aliasSection: AliasSection?,
+    val metaDataSection: MetaDataSection?
 ) : Phase2Node {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
@@ -240,19 +240,19 @@ data class AxiomGroup(
 
         fun validate(groupNode: Group): Validation<AxiomGroup> {
             return validateResultLikeGroup(
-                    groupNode,
-                    "Axiom",
-                    AxiomSection.Companion::validate,
-                    ::AxiomGroup
+                groupNode,
+                "Axiom",
+                AxiomSection.Companion::validate,
+                ::AxiomGroup
             )
         }
     }
 }
 
 data class ConjectureGroup(
-        val conjectureSection: ConjectureSection,
-        val aliasSection: AliasSection?,
-        val metaDataSection: MetaDataSection?
+    val conjectureSection: ConjectureSection,
+    val aliasSection: AliasSection?,
+    val metaDataSection: MetaDataSection?
 ) : Phase2Node {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
@@ -274,10 +274,10 @@ data class ConjectureGroup(
 
         fun validate(groupNode: Group): Validation<ConjectureGroup> {
             return validateResultLikeGroup(
-                    groupNode,
-                    "Conjecture",
-                    ConjectureSection.Companion::validate,
-                    ::ConjectureGroup
+                groupNode,
+                "Conjecture",
+                ConjectureSection.Companion::validate,
+                ::ConjectureGroup
             )
         }
     }
@@ -306,19 +306,19 @@ fun toCode(isArg: Boolean, indent: Int, id: Statement?, vararg sections: Phase2N
 }
 
 fun <G, S> validateResultLikeGroup(
-        groupNode: Group,
-        resultLikeName: String,
-        validateResultLikeSection: (section: Section) -> Validation<S>,
-        buildGroup: (sect: S, alias: AliasSection?, metadata: MetaDataSection?) -> G
+    groupNode: Group,
+    resultLikeName: String,
+    validateResultLikeSection: (section: Section) -> Validation<S>,
+    buildGroup: (sect: S, alias: AliasSection?, metadata: MetaDataSection?) -> G
 ): Validation<G> {
     val errors = ArrayList<ParseError>()
     val group = groupNode.resolve() as Group
     if (group.id != null) {
         errors.add(
-                ParseError(
-                        "A result, axiom, or conjecture cannot have an Id",
-                        AstUtils.getRow(group), AstUtils.getColumn(group)
-                )
+            ParseError(
+                "A result, axiom, or conjecture cannot have an Id",
+                AstUtils.getRow(group), AstUtils.getColumn(group)
+            )
         )
     }
 
@@ -327,7 +327,7 @@ fun <G, S> validateResultLikeGroup(
     val sectionMap: Map<String, Section?>
     try {
         sectionMap = SectionIdentifier.identifySections(
-                sections, resultLikeName, "Alias?", "Metadata?"
+            sections, resultLikeName, "Alias?", "Metadata?"
         )
     } catch (e: ParseError) {
         errors.add(ParseError(e.message, e.row, e.column))
@@ -369,20 +369,20 @@ fun <G, S> validateResultLikeGroup(
     return if (!errors.isEmpty()) {
         Validation.failure(errors)
     } else Validation
-            .success(buildGroup(resultLikeSection!!, aliasSection, metaDataSection))
+        .success(buildGroup(resultLikeSection!!, aliasSection, metaDataSection))
 }
 
 fun <G, S, E> validateDefinesLikeGroup(
-        groupNode: Group,
-        definesLikeSectionName: String,
-        validateDefinesLikeSection: (section: Section) -> Validation<S>,
-        endSectionName: String,
-        validateEndSection: (section: Section) -> Validation<E>,
-        buildGroup: (
-                signature: String?, id: Statement, definesLike: S,
-                assuming: AssumingSection?, end: E,
-                alias: AliasSection?, metadata: MetaDataSection?
-        ) -> G
+    groupNode: Group,
+    definesLikeSectionName: String,
+    validateDefinesLikeSection: (section: Section) -> Validation<S>,
+    endSectionName: String,
+    validateEndSection: (section: Section) -> Validation<E>,
+    buildGroup: (
+        signature: String?, id: Statement, definesLike: S,
+        assuming: AssumingSection?, end: E,
+        alias: AliasSection?, metadata: MetaDataSection?
+    ) -> G
 ): Validation<G> {
     val errors = ArrayList<ParseError>()
     val group = groupNode.resolve() as Group
@@ -393,8 +393,8 @@ fun <G, S, E> validateDefinesLikeGroup(
         // Convert it to look like a statement.
         val statementText = "'" + rawText.substring(1, rawText.length - 1) + "'"
         val stmtToken = ChalkTalkToken(
-                statementText, ChalkTalkTokenType.Statement,
-                row, column
+            statementText, ChalkTalkTokenType.Statement,
+            row, column
         )
         val idValidation = Statement.validate(stmtToken)
         if (idValidation.isSuccessful) {
@@ -404,10 +404,10 @@ fun <G, S, E> validateDefinesLikeGroup(
         }
     } else {
         errors.add(
-                ParseError(
-                        "A definition must have an Id",
-                        AstUtils.getRow(group), AstUtils.getColumn(group)
-                )
+            ParseError(
+                "A definition must have an Id",
+                AstUtils.getRow(group), AstUtils.getColumn(group)
+            )
         )
     }
 
@@ -416,8 +416,8 @@ fun <G, S, E> validateDefinesLikeGroup(
     val sectionMap: Map<String, Section?>
     try {
         sectionMap = SectionIdentifier.identifySections(
-                sections,
-                definesLikeSectionName, "assuming?", endSectionName, "Alias?", "Metadata?"
+            sections,
+            definesLikeSectionName, "assuming?", endSectionName, "Alias?", "Metadata?"
         )
     } catch (e: ParseError) {
         errors.add(ParseError(e.message, e.row, e.column))
@@ -479,14 +479,14 @@ fun <G, S, E> validateDefinesLikeGroup(
     return if (!errors.isEmpty()) {
         Validation.failure(errors)
     } else Validation
-            .success(
-                    buildGroup(
-                            getSignature(id!!),
-                            id, definesLikeSection!!,
-                            assumingSection, endSection!!,
-                            aliasSection, metaDataSection
-                    )
+        .success(
+            buildGroup(
+                getSignature(id!!),
+                id, definesLikeSection!!,
+                assumingSection, endSection!!,
+                aliasSection, metaDataSection
             )
+        )
 }
 
 fun <K, V> Map<K, V>.getOrNull(key: K): V? {
@@ -500,10 +500,15 @@ fun getSignature(stmt: Statement): String? {
     }
 
     val expressionNode = rootValidation.value!!
+    val commandParts = mutableListOf<CommandPart>()
     for (child in expressionNode.children) {
         if (child is Command) {
-            return getCommandSignature(child).toCode()
+            commandParts.addAll(child.parts)
         }
+    }
+
+    if (commandParts.isNotEmpty()) {
+        return getCommandSignature(Command(commandParts)).toCode()
     }
 
     return null
@@ -511,7 +516,7 @@ fun getSignature(stmt: Statement): String? {
 
 fun getCommandSignature(command: Command): Command {
     return Command(
-            parts = command.parts.map { getCommandPartForSignature(it) }
+        parts = command.parts.map { getCommandPartForSignature(it) }
     )
 }
 
@@ -521,37 +526,37 @@ fun <T> callOrNull(input: T?, fn: (t: T) -> T): T? {
 
 private fun getCommandPartForSignature(node: CommandPart): CommandPart {
     return CommandPart(
-            name = node.name,
-            square = callOrNull(node.square, ::getGroupNodeForSignature),
-            subSup = callOrNull(node.subSup, ::getSubSupForSignature),
-            groups = node.groups.map { getGroupNodeForSignature(it) },
-            namedGroups = node.namedGroups.map { getNamedGroupNodeForSignature(it) }
+        name = node.name,
+        square = callOrNull(node.square, ::getGroupNodeForSignature),
+        subSup = callOrNull(node.subSup, ::getSubSupForSignature),
+        groups = node.groups.map { getGroupNodeForSignature(it) },
+        namedGroups = node.namedGroups.map { getNamedGroupNodeForSignature(it) }
     )
 }
 
 private fun getSubSupForSignature(node: SubSupNode): SubSupNode {
     return SubSupNode(
-            sub = callOrNull(node.sub, ::getGroupNodeForSignature),
-            sup = callOrNull(node.sup, ::getGroupNodeForSignature)
+        sub = callOrNull(node.sub, ::getGroupNodeForSignature),
+        sup = callOrNull(node.sup, ::getGroupNodeForSignature)
     )
 }
 
 private fun getGroupNodeForSignature(node: GroupNode): GroupNode {
     return GroupNode(
-            type = node.type,
-            parameters = getParametersNodeForSignature(node.parameters)
+        type = node.type,
+        parameters = getParametersNodeForSignature(node.parameters)
     )
 }
 
 private fun getParametersNodeForSignature(node: ParametersNode): ParametersNode {
     return ParametersNode(
-            items = node.items.map { ExpressionNode(listOf(TextNode(NodeType.Identifier, "?"))) }
+        items = node.items.map { ExpressionNode(listOf(TextNode(NodeType.Identifier, "?"))) }
     )
 }
 
 private fun getNamedGroupNodeForSignature(node: NamedGroupNode): NamedGroupNode {
     return NamedGroupNode(
-            name = node.name,
-            group = getGroupNodeForSignature(node.group)
+        name = node.name,
+        group = getGroupNodeForSignature(node.group)
     )
 }

--- a/src/main/kotlin/mathlingua/jvm/HtmlDataGenerator.kt
+++ b/src/main/kotlin/mathlingua/jvm/HtmlDataGenerator.kt
@@ -44,7 +44,13 @@ object HtmlDataGenerator {
                 findKeywords(keywords, result.document)
                 if (result.document.defines.isNotEmpty()) {
                     signature = result.document.defines.first().signature
+                } else if (result.document.refines.isNotEmpty()) {
+                    signature = result.document.refines.first().signature
                 }
+                else if (result.document.represents.isNotEmpty()) {
+                    signature = result.document.represents.first().signature
+                }
+
                 val metadata: MetaDataSection?
                 if (result.document.defines.isNotEmpty()) {
                     metadata = result.document.defines.first().metaDataSection


### PR DESCRIPTION
Previously an id such as [\continuous \function] would have
its signature set as `\continuous`.  Now the signature is
correctly created as `\continuous.function`.