### PR TITLE
feat: support expanding and gluing commands

### DIFF
--- a/src/main/kotlin/mathlingua/common/MathLingua.kt
+++ b/src/main/kotlin/mathlingua/common/MathLingua.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.newChalkTalkParser
 import mathlingua.common.chalktalk.phase2.Document
 import mathlingua.common.chalktalk.phase2.Phase2Node
 import mathlingua.common.chalktalk.phase2.validateDocument
+import mathlingua.common.transform.locateAllSignatures
 
 data class MathLinguaResult(val document: Document?, val errors: List<ParseError>)
 
@@ -46,6 +47,6 @@ class MathLingua {
     }
 
     fun findAllSignatures(node: Phase2Node): Array<String> {
-        return findAllSignatures(node).toList().toTypedArray()
+        return locateAllSignatures(node).toList().toTypedArray()
     }
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Group.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Group.kt
@@ -191,10 +191,10 @@ data class RepresentsGroup(
             signature = signature,
             id = id.transform(chalkTransformer) as Statement,
             representsSection = representsSection.transform(chalkTransformer) as RepresentsSection,
-            assumingSection = assumingSection?.transform(chalkTransformer) as AssumingSection,
+            assumingSection = assumingSection?.transform(chalkTransformer) as AssumingSection?,
             thatSection = thatSection.transform(chalkTransformer) as ThatSection,
-            aliasSection = aliasSection?.transform(chalkTransformer) as AliasSection,
-            metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection
+            aliasSection = aliasSection?.transform(chalkTransformer) as AliasSection?,
+            metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?
         ))
     }
 }

--- a/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
@@ -20,6 +20,7 @@ import mathlingua.common.Validation
 import mathlingua.common.chalktalk.phase2.Phase2Node
 import mathlingua.common.chalktalk.phase2.Statement
 import mathlingua.common.textalk.Command
+import mathlingua.common.textalk.CommandPart
 import mathlingua.common.textalk.ExpressionTexTalkNode
 import mathlingua.common.textalk.TexTalkNode
 import mathlingua.common.textalk.TexTalkNodeType
@@ -97,3 +98,25 @@ private fun findCommandsImpl(texTalkNode: TexTalkNode, commands: MutableList<Com
 
     texTalkNode.forEach { findCommandsImpl(it, commands) }
 }
+
+fun glueCommands(node: ExpressionTexTalkNode): ExpressionTexTalkNode {
+    val newChildren = mutableListOf<TexTalkNode>()
+    var i = 0
+    while (i < node.children.size) {
+        val child = node.children[i++]
+        if (child is Command) {
+            val parts = mutableListOf<CommandPart>()
+            parts.addAll(child.parts)
+            while (i < node.children.size && node.children[i] is Command) {
+                val cmd = node.children[i++] as Command
+                parts.addAll(cmd.parts)
+            }
+            newChildren.add(Command(parts = parts))
+
+        } else {
+            newChildren.add(child)
+        }
+    }
+    return ExpressionTexTalkNode(children = newChildren)
+}
+

--- a/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
@@ -177,6 +177,24 @@ fun glueCommands(node: Phase2Node): Phase2Node {
     return node.transform {
         if (it is Statement &&
             it.texTalkRoot.isSuccessful &&
+            it.texTalkRoot.value!!.children.all { c -> c is Command }) {
+            val exp = it.texTalkRoot.value
+            val cmds = getCommandsToGlue(exp)
+            val gluedCmds = glueCommands(cmds)
+            if (gluedCmds.size != 1) {
+                throw Error("Expected id $it to only contain a single glued command")
+            }
+            val newExp = ExpressionTexTalkNode(
+                children = listOf(
+                    gluedCmds[0]
+                )
+            )
+            Statement(
+                text = newExp.toCode(),
+                texTalkRoot = Validation.success(newExp)
+            )
+        } else if (it is Statement &&
+            it.texTalkRoot.isSuccessful &&
             it.texTalkRoot.value!!.children.size == 1 &&
             it.texTalkRoot.value.children[0] is IsTexTalkNode) {
             val isNode = it.texTalkRoot.value!!.children[0] as IsTexTalkNode

--- a/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
@@ -99,24 +99,23 @@ private fun findCommandsImpl(texTalkNode: TexTalkNode, commands: MutableList<Com
     texTalkNode.forEach { findCommandsImpl(it, commands) }
 }
 
-fun glueCommands(node: ExpressionTexTalkNode): ExpressionTexTalkNode {
-    val newChildren = mutableListOf<TexTalkNode>()
-    var i = 0
-    while (i < node.children.size) {
-        val child = node.children[i++]
-        if (child is Command) {
-            val parts = mutableListOf<CommandPart>()
-            parts.addAll(child.parts)
-            while (i < node.children.size && node.children[i] is Command) {
-                val cmd = node.children[i++] as Command
-                parts.addAll(cmd.parts)
-            }
-            newChildren.add(Command(parts = parts))
-
-        } else {
-            newChildren.add(child)
-        }
+fun glueCommands(commands: List<Command>): List<Command> {
+    if (commands.isEmpty()) {
+        return emptyList()
     }
-    return ExpressionTexTalkNode(children = newChildren)
-}
 
+    if (commands.size == 1) {
+        return listOf(commands.first())
+    }
+
+    val last = commands.last()
+    val newCommands = mutableListOf<Command>()
+    for (i in 0 until commands.size - 1) {
+        val cmd = commands[i]
+        val parts = mutableListOf<CommandPart>()
+        parts.addAll(cmd.parts)
+        parts.addAll(last.parts)
+        newCommands.add(Command(parts = parts))
+    }
+    return newCommands
+}

--- a/src/main/kotlin/mathlingua/common/transform/SignatureUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/SignatureUtil.kt
@@ -70,7 +70,7 @@ fun getCommandSignature(command: Command): Command {
     )
 }
 
-fun findAllSignatures(node: Phase2Node): Set<String> {
+fun locateAllSignatures(node: Phase2Node): Set<String> {
     val signatures = mutableSetOf<String>()
     findAllSignaturesImpl(node, signatures)
     return signatures

--- a/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
+++ b/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
@@ -1,7 +1,6 @@
 package mathlingua.jvm
 
 import mathlingua.common.MathLingua
-import mathlingua.common.chalktalk.phase2.Statement
 import mathlingua.common.transform.glueCommands
 import mathlingua.common.transform.separateIsStatements
 
@@ -9,7 +8,9 @@ object SignatureTestBed {
     @JvmStatic
     fun main(args: Array<String>) {
         val text = """
-            Result:
+            [\a \b]
+            Defines: f
+            means:
             . 'x, y is \a \b, \c'
         """.trimIndent()
         val result = MathLingua().parse(text)
@@ -20,8 +21,7 @@ object SignatureTestBed {
         println(text)
         println("----------------------------------------")
 
-        val res = result.document!!.results[0]
-        val stmt = res.resultSection.clauses.clauses[0] as Statement
-        println(glueCommands(separateIsStatements(res)).toCode(false, 0))
+        val def = result.document!!.defines[0]
+        println(glueCommands(separateIsStatements(def)).toCode(false, 0))
     }
 }

--- a/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
+++ b/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
@@ -3,10 +3,7 @@ package mathlingua.jvm
 import mathlingua.common.MathLingua
 import mathlingua.common.chalktalk.phase2.Statement
 import mathlingua.common.textalk.Command
-import mathlingua.common.textalk.CommandPart
-import mathlingua.common.textalk.ExpressionTexTalkNode
 import mathlingua.common.textalk.IsTexTalkNode
-import mathlingua.common.textalk.TexTalkNode
 import mathlingua.common.transform.glueCommands
 
 object SignatureTestBed {
@@ -14,7 +11,7 @@ object SignatureTestBed {
     fun main(args: Array<String>) {
         val text = """
             Result:
-            . 'x is \compact \set'
+            . 'x is \closed:on{A} \almost.bounded{B} \unique \thing'
         """.trimIndent()
         val result = MathLingua().parse(text)
         for (err in result.errors) {
@@ -30,6 +27,15 @@ object SignatureTestBed {
         val isNode = root.children[0] as IsTexTalkNode
         val rhsParameters = isNode.rhs
         val param = rhsParameters.items[0]
-        println(glueCommands(param).toCode())
+        val cmds = mutableListOf<Command>()
+        for (node in param.children) {
+            if (node is Command) {
+                cmds.add(node)
+            }
+        }
+        val newCmds = glueCommands(cmds)
+        for (cmd in newCmds) {
+            println(cmd.toCode())
+        }
     }
 }

--- a/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
+++ b/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
@@ -9,8 +9,8 @@ object SignatureTestBed {
     fun main(args: Array<String>) {
         val text = """
             [\a \b]
-            Defines: f
-            means:
+            Represents:
+            that:
             . 'x, y is \a \b, \c'
         """.trimIndent()
         val result = MathLingua().parse(text)
@@ -21,7 +21,7 @@ object SignatureTestBed {
         println(text)
         println("----------------------------------------")
 
-        val def = result.document!!.defines[0]
-        println(glueCommands(separateIsStatements(def)).toCode(false, 0))
+        val rep = result.document!!.represents[0]
+        println(glueCommands(separateIsStatements(rep)).toCode(false, 0))
     }
 }

--- a/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
+++ b/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
@@ -1,30 +1,20 @@
 package mathlingua.jvm
 
 import mathlingua.common.MathLingua
-import mathlingua.common.chalktalk.phase2.DefinesGroup
-import mathlingua.common.transform.replaceIsNodes
+import mathlingua.common.chalktalk.phase2.Statement
+import mathlingua.common.textalk.Command
+import mathlingua.common.textalk.CommandPart
+import mathlingua.common.textalk.ExpressionTexTalkNode
+import mathlingua.common.textalk.IsTexTalkNode
+import mathlingua.common.textalk.TexTalkNode
+import mathlingua.common.transform.glueCommands
 
 object SignatureTestBed {
     @JvmStatic
     fun main(args: Array<String>) {
         val text = """
-            [\continuous.function:on{X}]
-            Defines: f
-            assuming: 'f is \function'
-            means:
-            . for: x
-              where: 'x \in X'
-              then:
-              . '\limit[t]_{x}{f(t)} = f(x)'
-
-
             Result:
-            . for: g, A
-              where:
-              . 'A is \set'
-              . 'g is \differentiable.function:on{A}'
-              then:
-              . 'g is \continuous.function:on{A}'
+            . 'x is \compact \set'
         """.trimIndent()
         val result = MathLingua().parse(text)
         for (err in result.errors) {
@@ -34,22 +24,12 @@ object SignatureTestBed {
         println(text)
         println("----------------------------------------")
 
-        val defMap = mutableMapOf<String, DefinesGroup>()
-        val defs = result.document!!.defines
-        for (def in defs) {
-            val sig = def.signature
-            if (sig != null) {
-                defMap[sig] = def
-            }
-        }
-
         val res = result.document!!.results[0]
-
-        var count = 1
-        fun nextVar(): String {
-            return "#${count++}"
-        }
-
-        println(replaceIsNodes(res, defs) { true }.toCode(false, 0))
+        val stmt = res.resultSection.clauses.clauses[0] as Statement
+        val root = stmt.texTalkRoot.value!!
+        val isNode = root.children[0] as IsTexTalkNode
+        val rhsParameters = isNode.rhs
+        val param = rhsParameters.items[0]
+        println(glueCommands(param).toCode())
     }
 }

--- a/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
+++ b/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
@@ -2,16 +2,14 @@ package mathlingua.jvm
 
 import mathlingua.common.MathLingua
 import mathlingua.common.chalktalk.phase2.Statement
-import mathlingua.common.textalk.Command
-import mathlingua.common.textalk.IsTexTalkNode
-import mathlingua.common.transform.glueCommands
+import mathlingua.common.transform.separateIsStatements
 
 object SignatureTestBed {
     @JvmStatic
     fun main(args: Array<String>) {
         val text = """
             Result:
-            . 'x is \closed:on{A} \almost.bounded{B} \unique \thing'
+            . 'x, y, z is \a \b, \c \d, \e'
         """.trimIndent()
         val result = MathLingua().parse(text)
         for (err in result.errors) {
@@ -23,19 +21,6 @@ object SignatureTestBed {
 
         val res = result.document!!.results[0]
         val stmt = res.resultSection.clauses.clauses[0] as Statement
-        val root = stmt.texTalkRoot.value!!
-        val isNode = root.children[0] as IsTexTalkNode
-        val rhsParameters = isNode.rhs
-        val param = rhsParameters.items[0]
-        val cmds = mutableListOf<Command>()
-        for (node in param.children) {
-            if (node is Command) {
-                cmds.add(node)
-            }
-        }
-        val newCmds = glueCommands(cmds)
-        for (cmd in newCmds) {
-            println(cmd.toCode())
-        }
+        println(separateIsStatements(res).toCode(false, 0))
     }
 }

--- a/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
+++ b/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
@@ -2,6 +2,7 @@ package mathlingua.jvm
 
 import mathlingua.common.MathLingua
 import mathlingua.common.chalktalk.phase2.Statement
+import mathlingua.common.transform.glueCommands
 import mathlingua.common.transform.separateIsStatements
 
 object SignatureTestBed {
@@ -9,7 +10,7 @@ object SignatureTestBed {
     fun main(args: Array<String>) {
         val text = """
             Result:
-            . 'x, y, z is \a \b, \c \d, \e'
+            . 'x, y is \a \b, \c'
         """.trimIndent()
         val result = MathLingua().parse(text)
         for (err in result.errors) {
@@ -21,6 +22,6 @@ object SignatureTestBed {
 
         val res = result.document!!.results[0]
         val stmt = res.resultSection.clauses.clauses[0] as Statement
-        println(separateIsStatements(res).toCode(false, 0))
+        println(glueCommands(separateIsStatements(res)).toCode(false, 0))
     }
 }

--- a/src/main/kotlin/mathlingua/jvm/TreeViewMain.kt
+++ b/src/main/kotlin/mathlingua/jvm/TreeViewMain.kt
@@ -56,7 +56,7 @@ object TreeViewMain {
             println("Could not set the look and feel to Nimbus: $e")
         }
 
-        val fontSize = 16
+        val fontSize = 14
         val fontName = "Brass Mono"
         val font = Font(fontName, Font.PLAIN, fontSize)
         val boldFont = Font(fontName, Font.BOLD, fontSize)


### PR DESCRIPTION
For example the input:
```
[\a \b]
Represents:
that:
. 'x, y is \a \b, \c'
```
Expands and glues together as follows:
```
[\a.b]
Represents:
that:
. 'x is \a.b'
. 'x is \c'
. 'y is \a.b'
. 'y is \c'
```