### PR TITLE
fix: fix two replacement bugs

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Section.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Section.kt
@@ -40,7 +40,9 @@ data class AssumingSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "assuming:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -226,7 +228,9 @@ data class MeansSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "means:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -253,7 +257,9 @@ data class ResultSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "Result:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -280,7 +286,9 @@ data class AxiomSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "Axiom:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -307,7 +315,9 @@ data class ConjectureSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "Conjecture:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -334,7 +344,9 @@ data class SuchThatSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "suchThat:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -361,7 +373,9 @@ data class ThatSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "that:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -388,7 +402,9 @@ data class IfSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "if:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -415,7 +431,9 @@ data class IffSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "iff:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -442,7 +460,9 @@ data class ThenSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "then:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -469,7 +489,9 @@ data class WhereSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "where:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -496,7 +518,9 @@ data class NotSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "not:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }
@@ -523,7 +547,9 @@ data class OrSection(val clauses: ClauseListNode) : Phase2Node {
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "or:"))
-        builder.append('\n')
+        if (clauses.clauses.isNotEmpty()) {
+            builder.append('\n')
+        }
         builder.append(clauses.toCode(true, indent + 2))
         return builder.toString()
     }

--- a/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
@@ -50,7 +50,7 @@ fun replaceCommands(
     node: Phase2Node,
     cmdToReplacement: Map<Command, String>,
     shouldProcessChalk: (node: Phase2Node) -> Boolean,
-    shouldProcessTex: (node: TexTalkNode) -> Boolean
+    shouldProcessTex: (root: TexTalkNode, node: TexTalkNode) -> Boolean
 ): Phase2Node {
     return node.transform {
         if (!shouldProcessChalk(it) || it !is Statement) {
@@ -61,7 +61,7 @@ fun replaceCommands(
                 it
             } else {
                 val root = it.texTalkRoot.value!!
-                val newRoot = replaceCommands(root, cmdToReplacement, shouldProcessTex) as ExpressionTexTalkNode
+                val newRoot = replaceCommands(root, root, cmdToReplacement, shouldProcessTex) as ExpressionTexTalkNode
                 Statement(
                     text = newRoot.toCode(),
                     texTalkRoot = Validation.success(newRoot)
@@ -73,11 +73,12 @@ fun replaceCommands(
 
 fun replaceCommands(
     texTalkNode: TexTalkNode,
+    root: TexTalkNode,
     cmdToReplacement: Map<Command, String>,
-    shouldProcess: (node: TexTalkNode) -> Boolean
+    shouldProcess: (root: TexTalkNode, node: TexTalkNode) -> Boolean
 ): TexTalkNode {
     return texTalkNode.transform {
-        if (!shouldProcess(it) || it !is Command) {
+        if (!shouldProcess(root, it) || it !is Command) {
             it
         } else {
             if (!cmdToReplacement.containsKey(it)) {

--- a/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
@@ -20,6 +20,7 @@ import mathlingua.common.Validation
 import mathlingua.common.chalktalk.phase2.Clause
 import mathlingua.common.chalktalk.phase2.ClauseListNode
 import mathlingua.common.chalktalk.phase2.DefinesGroup
+import mathlingua.common.chalktalk.phase2.Document
 import mathlingua.common.chalktalk.phase2.ForGroup
 import mathlingua.common.chalktalk.phase2.ForSection
 import mathlingua.common.chalktalk.phase2.Identifier
@@ -202,33 +203,46 @@ fun replaceRepresents(
             return node
         }
 
-        if (node !is Statement) {
+        if (node !is ClauseListNode) {
             return node
         }
 
-        if (!node.texTalkRoot.isSuccessful ||
-            node.texTalkRoot.value!!.children.size != 1 ||
-            node.texTalkRoot.value.children[0] !is Command) {
-            return node
+        val newClauses = mutableListOf<Clause>()
+
+        for (clause in node.clauses) {
+            if (clause !is Statement) {
+                newClauses.add(clause)
+                continue
+            }
+
+            if (!clause.texTalkRoot.isSuccessful ||
+                clause.texTalkRoot.value!!.children.size != 1 ||
+                clause.texTalkRoot.value.children[0] !is Command
+            ) {
+                newClauses.add(clause)
+                continue
+            }
+
+            val command = clause.texTalkRoot.value.children[0] as Command
+            val sig = getCommandSignature(command).toCode()
+
+            if (!repMap.containsKey(sig)) {
+                return node
+            }
+
+            val rep = repMap[sig]!!
+            val cmdVars = getVars(command)
+            val defIndirectVars = getRepresentsIdVars(rep)
+
+            val map = mutableMapOf<String, String>()
+            for (i in cmdVars.indices) {
+                map[defIndirectVars[i]] = cmdVars[i]
+            }
+
+            newClauses.add(renameVars(buildIfThen(rep), map) as Clause)
         }
 
-        val command = node.texTalkRoot.value.children[0] as Command
-        val sig = getCommandSignature(command).toCode()
-
-        if (!repMap.containsKey(sig)) {
-            return node
-        }
-
-        val rep = repMap[sig]!!
-        val cmdVars = getVars(command)
-        val defIndirectVars = getRepresentsIdVars(rep)
-
-        val map = mutableMapOf<String, String>()
-        for (i in cmdVars.indices) {
-            map[defIndirectVars[i]] = cmdVars[i]
-        }
-
-        return renameVars(buildIfThen(rep), map)
+        return ClauseListNode(clauses = newClauses)
     }
 
     return node.transform(::chalkTransformer)
@@ -366,4 +380,32 @@ fun getRepresentsIdVars(rep: RepresentsGroup): List<String> {
         vars.addAll(getVars(rep.id.texTalkRoot.value!!))
     }
     return vars
+}
+
+fun fullExpandOnce(doc: Document): Document {
+    var transformed = separateIsStatements(doc)
+    transformed = glueCommands(transformed)
+    transformed = moveInlineCommandsToIsNode(doc.defines, transformed, { true }, { root, node -> true })
+    transformed = replaceRepresents(transformed, doc.represents, { true })
+    return replaceIsNodes(transformed, doc.defines, { true }) as Document
+}
+
+fun fullExpandComplete(doc: Document, maxSteps: Int = 10): Document {
+    val snapshots = mutableSetOf<String>()
+
+    var transformed = doc
+    var previousCode = transformed.toCode(false, 0)
+    snapshots.add(previousCode)
+
+    for (i in 0 until maxSteps) {
+        transformed = fullExpandOnce(transformed)
+        val code = transformed.toCode(false, 0)
+        if (snapshots.contains(code) || previousCode == code) {
+            break
+        }
+        previousCode = code
+        snapshots.add(previousCode)
+    }
+
+    return transformed
 }

--- a/src/main/kotlin/mathlingua/jvm/Playground.kt
+++ b/src/main/kotlin/mathlingua/jvm/Playground.kt
@@ -33,9 +33,11 @@ import mathlingua.common.transform.separateIsStatements
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants
 import java.awt.BorderLayout
+import java.awt.FlowLayout
 import java.awt.Font
 import java.awt.event.KeyEvent
 import java.awt.event.KeyListener
+import javax.swing.JCheckBox
 import javax.swing.JFrame
 import javax.swing.JPanel
 import javax.swing.JScrollPane
@@ -74,6 +76,19 @@ object Playground {
 
         val signaturesList = JTextArea(20, 20)
         signaturesList.font = font
+
+        val separateIsBox = JCheckBox("Separate is statements", true)
+        val glueCommands = JCheckBox("Glue commands", true)
+        val moveInLineIs = JCheckBox("Move inline is statements", true)
+        val replaceReps = JCheckBox("Replace represents", true)
+        val replaceIsNodes = JCheckBox("Replace is nodes", true)
+
+        val statusPanel = JPanel(FlowLayout(FlowLayout.LEFT))
+        statusPanel.add(separateIsBox)
+        statusPanel.add(glueCommands)
+        statusPanel.add(moveInLineIs)
+        statusPanel.add(replaceReps)
+        statusPanel.add(replaceIsNodes)
 
         val errorArea = JTextArea()
         errorArea.font = font
@@ -173,11 +188,27 @@ object Playground {
                         }
                         signaturesList.text = sigBuilder.toString()
 
-                        var transformed = separateIsStatements(doc)
-                        transformed = glueCommands(transformed)
-                        transformed = moveInlineCommandsToIsNode(doc.defines, transformed, { true }, { true })
-                        transformed = replaceRepresents(transformed, doc.represents, { true })
-                        transformed = replaceIsNodes(transformed, doc.defines, { true })
+                        var transformed = doc as Phase2Node
+
+                        if (separateIsBox.isSelected) {
+                            transformed = separateIsStatements(doc)
+                        }
+
+                        if (glueCommands.isSelected) {
+                            transformed = glueCommands(transformed)
+                        }
+
+                        if (moveInLineIs.isSelected) {
+                            transformed = moveInlineCommandsToIsNode(doc.defines, transformed, { true }, { root, node -> true })
+                        }
+
+                        if (replaceReps.isSelected) {
+                            transformed = replaceRepresents(transformed, doc.represents, { true })
+                        }
+
+                        if (replaceIsNodes.isSelected) {
+                            transformed = replaceIsNodes(transformed, doc.defines, { true })
+                        }
 
                         outputArea.text = transformed.toCode(false, 0)
                         phase2Tree.model = DefaultTreeModel(toTreeNode(doc))
@@ -216,6 +247,7 @@ object Playground {
 
         val mainPanel = JPanel(BorderLayout())
         mainPanel.add(treePane, BorderLayout.CENTER)
+        mainPanel.add(statusPanel, BorderLayout.SOUTH)
 
         val frame = JFrame()
         frame.setSize(1300, 900)

--- a/src/main/kotlin/mathlingua/jvm/Playground.kt
+++ b/src/main/kotlin/mathlingua/jvm/Playground.kt
@@ -25,6 +25,7 @@ import mathlingua.common.chalktalk.phase2.Phase2Node
 import mathlingua.common.chalktalk.phase2.Statement
 import mathlingua.common.chalktalk.phase2.validateDocument
 import mathlingua.common.textalk.TexTalkNode
+import mathlingua.common.transform.fullExpandComplete
 import mathlingua.common.transform.glueCommands
 import mathlingua.common.transform.moveInlineCommandsToIsNode
 import mathlingua.common.transform.replaceIsNodes
@@ -83,12 +84,24 @@ object Playground {
         val replaceReps = JCheckBox("Replace represents", true)
         val replaceIsNodes = JCheckBox("Replace is nodes", true)
 
+        val completeExpand = JCheckBox("Complete expansion", false)
+        completeExpand.addActionListener {
+            if (completeExpand.isSelected) {
+                separateIsBox.isSelected = false
+                glueCommands.isSelected = false
+                moveInLineIs.isSelected = false
+                replaceReps.isSelected = false
+                replaceIsNodes.isSelected = false
+            }
+        }
+
         val statusPanel = JPanel(FlowLayout(FlowLayout.LEFT))
         statusPanel.add(separateIsBox)
         statusPanel.add(glueCommands)
         statusPanel.add(moveInLineIs)
         statusPanel.add(replaceReps)
         statusPanel.add(replaceIsNodes)
+        statusPanel.add(completeExpand)
 
         val errorArea = JTextArea()
         errorArea.font = font
@@ -208,6 +221,10 @@ object Playground {
 
                         if (replaceIsNodes.isSelected) {
                             transformed = replaceIsNodes(transformed, doc.defines, { true })
+                        }
+
+                        if (completeExpand.isSelected) {
+                            transformed = fullExpandComplete(doc)
                         }
 
                         outputArea.text = transformed.toCode(false, 0)

--- a/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
+++ b/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
@@ -28,9 +28,9 @@ object SignatureTestBed {
         println(text)
         println("----------------------------------------")
 
-        val res = result.document!!.results[0]
-        println(moveInlineCommandsToIsNode(result.document!!.defines, res, { true }, {
-            it is Command && getCommandSignature(it).toCode() == "\\continuous.function"
-        }).toCode(false, 0))
+//        val res = result.document!!.results[0]
+//        println(moveInlineCommandsToIsNode(result.document!!.defines, res, { true }, {
+//            it is Command && getCommandSignature(it).toCode() == "\\continuous.function"
+//        }).toCode(false, 0))
     }
 }

--- a/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
+++ b/src/main/kotlin/mathlingua/jvm/SignatureTestBed.kt
@@ -1,9 +1,6 @@
 package mathlingua.jvm
 
 import mathlingua.common.MathLingua
-import mathlingua.common.textalk.Command
-import mathlingua.common.transform.getCommandSignature
-import mathlingua.common.transform.moveInlineCommandsToIsNode
 
 object SignatureTestBed {
     @JvmStatic


### PR DESCRIPTION
When inline commands were processed, commands in an 'is' node
were processed, which is incorrect.  Now they are not.

The `Phase2.toCode()` methods have been updated to handle the
cases where the node doesn't have any ClauseList arguments.

Now replacing a `Represents:` group works as expected.  Previously,
it threw a `ClassCastException`.