### PR TITLE
fix: redundant if:then: not produced

### DIFF
--- a/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
@@ -240,7 +240,15 @@ fun replaceRepresents(
                 map[defIndirectVars[i]] = cmdVars[i]
             }
 
-            newClauses.add(renameVars(buildIfThen(rep), map) as Clause)
+            val ifThen = buildIfThen(rep)
+            val res = if (ifThen.ifSection.clauses.clauses.isEmpty() &&
+                ifThen.thenSection.clauses.clauses.size == 1) {
+                ifThen.thenSection.clauses.clauses[0]
+            } else {
+                ifThen
+            }
+
+            newClauses.add(renameVars(res, map) as Clause)
         }
 
         return ClauseListNode(clauses = newClauses)
@@ -315,7 +323,15 @@ fun replaceIsNodes(
             map[defDirectVars[i]] = lhsVars[i]
         }
 
-        return renameVars(buildIfThen(def), map)
+        val ifThen = buildIfThen(def)
+        val res = if (ifThen.ifSection.clauses.clauses.isEmpty() &&
+            ifThen.thenSection.clauses.clauses.size == 1) {
+            ifThen.thenSection.clauses.clauses[0]
+        } else {
+            ifThen
+        }
+
+        return renameVars(res, map)
     }
 
     return node.transform(::chalkTransformer)


### PR DESCRIPTION
The input:
```
[\bounded.function]
Defines: f
means:
. exists: M
  suchThat:
  . for: x
    then: '\abs{f(x)} \leq M'

Result:
. for: g
  where: 'g is \bounded.function'
  then:
  . for: h
    where: 'h := 2*g'
    then: 'h is \bounded.function'
```
Produces:
```
[\bounded.function]
Defines:
. f
means:
. exists:
  . M
  suchThat:
  . for:
    . x
    then:
    . '\abs{f(x)} \leq M'

Result:
. for:
  . g
  where:
  . exists:
    . M
    suchThat:
    . for:
      . x
      then:
      . '\abs{g (x)} \leq M'
  then:
  . for:
    . h
    where:
    . 'h := 2*g'
    then:
    . exists:
      . M
      suchThat:
      . for:
        . x
        then:
        . '\abs{h (x)} \leq M'

```
Prior to this commit, the code would contain:
```
. exists:
  . M
  suchThat:
  . if:
    then:
    . for:
      . x
      then:
      . '\abs{h (x)} \leq M'
```