### PR TITLE
chore: enable CI on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
This is needed so that the CI is run when PRs land on master.