### PR TITLE
feat: textalk var names map to compound types

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/AstUtils.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/AstUtils.kt
@@ -30,3 +30,30 @@ fun indentedString(useDot: Boolean, indent: Int, line: String): String {
     builder.append(line)
     return builder.toString()
 }
+
+fun getChalkTalkAncestry(root: Phase2Node, node: Phase2Node): List<Phase2Node> {
+    val path = mutableListOf<Phase2Node>()
+    getChalkTalkAncestryImpl(root, node, path)
+    // 'node' itself shouldn't be in the ancestry
+    if (path.isNotEmpty()) {
+        path.removeAt(path.size - 1)
+    }
+    return path.reversed()
+}
+
+private fun getChalkTalkAncestryImpl(root: Phase2Node, node: Phase2Node, path: MutableList<Phase2Node>) {
+    if (root == node) {
+        path.add(node)
+        return
+    }
+
+    path.add(root)
+    root.forEach {
+        if (path.isEmpty() || path.last() != node) {
+            getChalkTalkAncestryImpl(it, node, path)
+        }
+    }
+    if (path.isEmpty() || path.last() != node) {
+        path.removeAt(path.size - 1)
+    }
+}

--- a/src/main/kotlin/mathlingua/common/textalk/Ast.kt
+++ b/src/main/kotlin/mathlingua/common/textalk/Ast.kt
@@ -410,9 +410,9 @@ enum class TexTalkTokenType {
     Invalid
 }
 
-fun getAncestry(root: TexTalkNode, node: TexTalkNode): List<TexTalkNode> {
+fun getTexTalkAncestry(root: TexTalkNode, node: TexTalkNode): List<TexTalkNode> {
     val path = mutableListOf<TexTalkNode>()
-    getAncestryImpl(root, node, path)
+    getTexTalkAncestryImpl(root, node, path)
     // 'node' itself shouldn't be in the ancestry
     if (path.isNotEmpty()) {
         path.removeAt(path.size - 1)
@@ -420,7 +420,7 @@ fun getAncestry(root: TexTalkNode, node: TexTalkNode): List<TexTalkNode> {
     return path.reversed()
 }
 
-private fun getAncestryImpl(root: TexTalkNode, node: TexTalkNode, path: MutableList<TexTalkNode>) {
+private fun getTexTalkAncestryImpl(root: TexTalkNode, node: TexTalkNode, path: MutableList<TexTalkNode>) {
     if (root == node) {
         path.add(node)
         return
@@ -429,7 +429,7 @@ private fun getAncestryImpl(root: TexTalkNode, node: TexTalkNode, path: MutableL
     path.add(root)
     root.forEach {
         if (path.isEmpty() || path.last() != node) {
-            getAncestryImpl(it, node, path)
+            getTexTalkAncestryImpl(it, node, path)
         }
     }
     if (path.isEmpty() || path.last() != node) {


### PR DESCRIPTION
Given the input:
```
[\something]
Defines: G := (X, *)
means:
. 'X is \set'
. '* is \operator'

Result:
. for: H := (Y, +)
  then:
  . 'H is \something'
```
that `replaceIsNodes()` transforms this to:
```
[\something]
Defines:
. G := (X, *)
means:
. 'X is \set'
. '* is \operator'

Result:
. for:
  . H := (Y, +)
  then:
  . 'Y is \set'
  . '+ is \operator'
```
Note that in the result, that `H := (Y, +)` is in a for group.
Thus, the statement 'H is \something' uses `Y` and `+` when the
definition of `\something` is inlined.