### PR TITLE
feat: phase2 toCode places targets on same line

### DIFF
--- a/src/main/kotlin/mathlingua/common/Shared.kt
+++ b/src/main/kotlin/mathlingua/common/Shared.kt
@@ -16,6 +16,10 @@
 
 package mathlingua.common
 
+import java.lang.StringBuilder
+import java.util.*
+import kotlin.collections.ArrayList
+
 data class ParseError(
     override val message: String,
     val row: Int,
@@ -50,4 +54,45 @@ class Queue<T> : Iterable<T> {
     fun isEmpty() = data.isEmpty()
 
     override fun iterator() = data.iterator()
+}
+
+private fun tokenize(text: String): List<String> {
+    val tokens = mutableListOf<String>()
+    var i = 0
+    while (i < text.length) {
+        if (text[i] == ' ') {
+            val buffer = StringBuilder()
+            while (i < text.length && text[i] == ' ') {
+                buffer.append(text[i++])
+            }
+            tokens.add(buffer.toString())
+        } else {
+            val buffer = StringBuilder()
+            while (i < text.length && text[i] != ' ') {
+                buffer.append(text[i++])
+            }
+            tokens.add(buffer.toString())
+        }
+    }
+    return tokens
+}
+
+private fun justify(text: String, width: Int): List<String> {
+    val tokens = tokenize(text)
+    val lines = mutableListOf<String>()
+    var i = 0
+    while (i < tokens.size) {
+        val curLine = StringBuilder()
+        while (curLine.isEmpty() && tokens[i].isBlank()) {
+            i++
+        }
+        while (i < tokens.size && curLine.length + tokens[i].length <= width) {
+            curLine.append(tokens[i++])
+        }
+        if (curLine.isEmpty()) {
+            curLine.append(tokens[i++])
+        }
+        lines.add(curLine.toString())
+    }
+    return lines
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Section.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Section.kt
@@ -25,11 +25,31 @@ import mathlingua.common.chalktalk.phase1.ast.Section
 import mathlingua.common.chalktalk.phase1.ast.getColumn
 import mathlingua.common.chalktalk.phase1.ast.getRow
 
+private fun canBeOnOneLine(target: Target) =
+        target is Identifier ||
+        target is TupleNode ||
+        target is AbstractionNode ||
+        target is AggregateNode ||
+        target is AssignmentNode
+
 private fun appendTargetArgs(builder: StringBuilder, targets: List<Target>, indent: Int) {
-    for (i in targets.indices) {
-        builder.append(targets[i].toCode(true, indent))
-        if (i != targets.size - 1) {
+    var i = 0
+    while (i < targets.size) {
+        val lineItems = mutableListOf<Target>()
+        while (i < targets.size && canBeOnOneLine(targets[i])) {
+            lineItems.add(targets[i++])
+        }
+        if (lineItems.isEmpty()) {
             builder.append('\n')
+            builder.append(targets[i++].toCode(true, indent))
+        } else {
+            builder.append(' ')
+            for (j in lineItems.indices) {
+                builder.append(lineItems[j].toCode(false, 0))
+                if (j != lineItems.size - 1) {
+                    builder.append(", ")
+                }
+            }
         }
     }
 }
@@ -76,7 +96,6 @@ data class DefinesSection(
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "Defines:"))
-        builder.append('\n')
         appendTargetArgs(builder, targets, indent + 2)
         return builder.toString()
     }
@@ -106,7 +125,6 @@ data class RefinesSection(
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "Refines:"))
-        builder.append('\n')
         appendTargetArgs(builder, targets, indent + 2)
         return builder.toString()
     }
@@ -186,7 +204,6 @@ data class ExistsSection(
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "exists:"))
-        builder.append('\n')
         appendTargetArgs(builder, identifiers, indent + 2)
         return builder.toString()
     }
@@ -215,7 +232,6 @@ data class ForSection(
     override fun toCode(isArg: Boolean, indent: Int): String {
         val builder = StringBuilder()
         builder.append(indentedString(isArg, indent, "for:"))
-        builder.append('\n')
         appendTargetArgs(builder, targets, indent + 2)
         return builder.toString()
     }


### PR DESCRIPTION
Previously given the code
```
Result:
. for: x, y
  then: a
```
the `toCode` method on the parsed input would return
```
Result:
. for:
  . x
  . y
  then:
  . a
```
Now it returns
```
Result:
. for: x, y
  then:
  . a
```