### PR TITLE
chore: add TopLevelGroup sealed class

### DIFF
--- a/src/main/kotlin/mathlingua/common/Shared.kt
+++ b/src/main/kotlin/mathlingua/common/Shared.kt
@@ -16,8 +16,6 @@
 
 package mathlingua.common
 
-import java.lang.StringBuilder
-import java.util.*
 import kotlin.collections.ArrayList
 
 data class ParseError(

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/AstUtils.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/AstUtils.kt
@@ -16,8 +16,6 @@
 
 package mathlingua.common.chalktalk.phase2
 
-import java.lang.IllegalArgumentException
-
 fun indentedString(useDot: Boolean, indent: Int, line: String): String {
     val builder = StringBuilder()
     for (i in 0 until indent - 2) {

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Document.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Document.kt
@@ -169,8 +169,8 @@ fun validateDocument(rawNode: Phase1Node): Validation<Document> {
         }
     }
 
-    var row = Integer.MAX_VALUE
-    var column = Integer.MAX_VALUE
+    var row = Int.MAX_VALUE
+    var column = Int.MAX_VALUE
 
     fun updateRowCol(nodes: List<Phase2Node>) {
         for (n in nodes) {

--- a/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
@@ -111,12 +111,12 @@ fun separateIsStatements(root: Phase2Node, follow: Phase2Node): RootTarget<Phase
                         newClauses.add(clause)
                     } else {
                         newClauses.addAll(separated.map {
-                            val root = ExpressionTexTalkNode(
+                            val expRoot = ExpressionTexTalkNode(
                                 children = listOf(it)
                             )
                             Statement(
-                                text = root.toCode(),
-                                texTalkRoot = ValidationSuccess(root),
+                                text = expRoot.toCode(),
+                                texTalkRoot = ValidationSuccess(expRoot),
                                 row = -1,
                                 column = -1
                             )

--- a/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
@@ -641,8 +641,8 @@ fun separateInfixOperatorStatements(root: Phase2Node, follow: Phase2Node): RootT
                 if (c is Statement) {
                     when (val validation = c.texTalkRoot) {
                         is ValidationSuccess -> {
-                            val root = validation.value
-                            for (expanded in getExpandedInfixOperators(root)) {
+                            val expRoot = validation.value
+                            for (expanded in getExpandedInfixOperators(expRoot)) {
                                 newClauses.add(Statement(
                                     text = expanded.toCode(),
                                     texTalkRoot = ValidationSuccess(expanded),


### PR DESCRIPTION
Now all top level groups (Result, Defines, ...) derive from the
sealed class `TopLevelGroup` and all have a `MetaDataSection`.