### PR TITLE
feat: Defines/Represents support multi means/that

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Clause.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Clause.kt
@@ -526,7 +526,7 @@ fun validateForGroup(rawNode: Phase1Node): Validation<ForGroup> {
 
     val (sections) = node
 
-    val sectionMap: Map<String, Section>
+    val sectionMap: Map<String, List<Section>>
     try {
         sectionMap = identifySections(
             sections,
@@ -540,15 +540,15 @@ fun validateForGroup(rawNode: Phase1Node): Validation<ForGroup> {
     var forSection: ForSection? = null
     val forNode = sectionMap["for"]
 
-    when (val forEvaluation = validateForSection(forNode!!)) {
+    when (val forEvaluation = validateForSection(forNode!![0])) {
         is ValidationSuccess -> forSection = forEvaluation.value
         is ValidationFailure -> errors.addAll(forEvaluation.errors)
     }
 
     var whereSection: WhereSection? = null
-    if (sectionMap.containsKey("where")) {
-        val where = sectionMap["where"]
-        when (val whereValidation = validateWhereSection(where!!)) {
+    if (sectionMap.containsKey("where") && sectionMap["where"]!!.isNotEmpty()) {
+        val where = sectionMap["where"]!!
+        when (val whereValidation = validateWhereSection(where[0])) {
             is ValidationSuccess -> whereSection = whereValidation.value
             is ValidationFailure -> errors.addAll(whereValidation.errors)
         }
@@ -556,7 +556,7 @@ fun validateForGroup(rawNode: Phase1Node): Validation<ForGroup> {
 
     var thenSection: ThenSection? = null
     val then = sectionMap["then"]
-    when (val thenValidation = validateThenSection(then!!)) {
+    when (val thenValidation = validateThenSection(then!![0])) {
         is ValidationSuccess -> thenSection = thenValidation.value
         is ValidationFailure -> errors.addAll(thenValidation.errors)
     }
@@ -644,7 +644,7 @@ fun <G, S> validateSingleSectionGroup(
     }
 
     val (sections) = node
-    val sectionMap: Map<String, Section>
+    val sectionMap: Map<String, List<Section>>
     try {
         sectionMap = identifySections(
             sections,
@@ -657,7 +657,7 @@ fun <G, S> validateSingleSectionGroup(
 
     var section: S? = null
     val sect = sectionMap[sectionName]
-    when (val validation = validateSection(sect!!)) {
+    when (val validation = validateSection(sect!![0])) {
         is ValidationSuccess -> section = validation.value
         is ValidationFailure -> errors.addAll(validation.errors)
     }
@@ -691,7 +691,7 @@ private fun <G, S1, S2> validateDoubleSectionGroup(
 
     val (sections) = node
 
-    val sectionMap: Map<String, Section>
+    val sectionMap: Map<String, List<Section>>
     try {
         sectionMap = identifySections(
             sections, section1Name, section2Name
@@ -703,19 +703,19 @@ private fun <G, S1, S2> validateDoubleSectionGroup(
 
     var section1: S1? = null
     val sect1 = sectionMap[section1Name]
-    when (val section1Validation = validateSection1(sect1!!)) {
+    when (val section1Validation = validateSection1(sect1!![0])) {
         is ValidationSuccess -> section1 = section1Validation.value
         is ValidationFailure -> errors.addAll(section1Validation.errors)
     }
 
     var section2: S2? = null
     val sect2 = sectionMap[section2Name]
-    when (val section2Validation = validateSection2(sect2!!)) {
+    when (val section2Validation = validateSection2(sect2!![0])) {
         is ValidationSuccess -> section2 = section2Validation.value
         is ValidationFailure -> errors.addAll(section2Validation.errors)
     }
 
-    return if (!errors.isEmpty()) {
+    return if (errors.isNotEmpty()) {
         ValidationFailure(errors)
     } else ValidationSuccess(buildGroup(section1!!, section2!!,
             getRow(node), getColumn(node)))

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/MetaDataSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/MetaDataSection.kt
@@ -73,17 +73,11 @@ fun validateMetaDataSection(section: Section): Validation<MetaDataSection> {
     }
 
     val errors = mutableListOf<ParseError>()
-    val mappings = mutableListOf<MappingNode>()
     val items = mutableListOf<MetaDataItem>()
     for (arg in section.args) {
         if (isReferenceGroup(arg.chalkTalkTarget)) {
             when (val validation = validateMetaDataItem(arg)) {
                 is ValidationSuccess -> items.add(validation.value)
-                is ValidationFailure -> errors.addAll(validation.errors)
-            }
-        } else if (arg.chalkTalkTarget is Mapping) {
-            when (val validation = validateMappingNode(arg)) {
-                is ValidationSuccess -> mappings.add(validation.value)
                 is ValidationFailure -> errors.addAll(validation.errors)
             }
         } else if (isSingleSectionGroup(arg.chalkTalkTarget)) {
@@ -214,7 +208,7 @@ fun validateReferenceGroup(groupNode: Group): Validation<MetaDataItem> {
 
     val sections = group.sections
 
-    val sectionMap: Map<String, Section?>
+    val sectionMap: Map<String, List<Section>>
     try {
         sectionMap = identifySections(
                 sections, "reference"
@@ -224,7 +218,7 @@ fun validateReferenceGroup(groupNode: Group): Validation<MetaDataItem> {
         return ValidationFailure(errors)
     }
 
-    val rawReference = sectionMap["reference"]!!
+    val rawReference = sectionMap["reference"]!![0]
     var referenceSection: ReferenceSection? = null
     when (val validation = validateReferenceSection(rawReference)) {
         is ValidationSuccess -> referenceSection = validation.value
@@ -398,7 +392,7 @@ fun validateSourceItemGroup(groupNode: Group): Validation<SourceItemGroup> {
 
     val sections = group.sections
 
-    val sectionMap: Map<String, Section?>
+    val sectionMap: Map<String, List<Section>>
     try {
         sectionMap = identifySections(
                 sections, "source", "page?", "offset?", "content?"
@@ -408,7 +402,7 @@ fun validateSourceItemGroup(groupNode: Group): Validation<SourceItemGroup> {
         return ValidationFailure(errors)
     }
 
-    val rawSource = sectionMap["source"]!!
+    val rawSource = sectionMap["source"]!![0]
     var sourceSection: SourceItemSection? = null
     when (val validation = validateStringSection(rawSource, "source", ::SourceItemSection)) {
         is ValidationSuccess -> sourceSection = validation.value
@@ -417,8 +411,8 @@ fun validateSourceItemGroup(groupNode: Group): Validation<SourceItemGroup> {
 
     val rawPage = sectionMap["page"]
     var pageSection: PageItemSection? = null
-    if (rawPage != null) {
-        when (val validation = validateStringSection(rawPage, "page", ::PageItemSection)) {
+    if (rawPage != null && rawPage.isNotEmpty()) {
+        when (val validation = validateStringSection(rawPage[0], "page", ::PageItemSection)) {
             is ValidationSuccess -> pageSection = validation.value
             is ValidationFailure -> errors.addAll(validation.errors)
         }
@@ -426,8 +420,8 @@ fun validateSourceItemGroup(groupNode: Group): Validation<SourceItemGroup> {
 
     val rawOffset = sectionMap["offset"]
     var offsetSection: OffsetItemSection? = null
-    if (rawOffset != null) {
-        when (val validation = validateStringSection(rawOffset, "offset", ::OffsetItemSection)) {
+    if (rawOffset != null && rawOffset.isNotEmpty()) {
+        when (val validation = validateStringSection(rawOffset[0], "offset", ::OffsetItemSection)) {
             is ValidationSuccess -> offsetSection = validation.value
             is ValidationFailure -> errors.addAll(validation.errors)
         }
@@ -435,8 +429,8 @@ fun validateSourceItemGroup(groupNode: Group): Validation<SourceItemGroup> {
 
     val rawContent = sectionMap["content"]
     var contentSection: ContentItemSection? = null
-    if (rawContent != null) {
-        when (val validation = validateStringSection(rawContent, "content", ::ContentItemSection)) {
+    if (rawContent != null && rawContent.isNotEmpty()) {
+        when (val validation = validateStringSection(rawContent[0], "content", ::ContentItemSection)) {
             is ValidationSuccess -> contentSection = validation.value
             is ValidationFailure -> errors.addAll(validation.errors)
         }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Section.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Section.kt
@@ -278,7 +278,7 @@ fun validateMeansSection(node: Phase1Node) = validateClauseList(
     node,
     "means",
     false,
-        ::MeansSection
+    ::MeansSection
 )
 
 data class ResultSection(

--- a/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
@@ -255,7 +255,7 @@ fun replaceRepresents(
                     map[defIndirectVars[i]] = cmdVars[i]
                 }
 
-                val ifThen = buildIfThen(rep)
+                val ifThen = buildIfThens(rep)[0]
                 if (ifThen.ifSection.clauses.clauses.isEmpty()) {
                     for (c in ifThen.thenSection.clauses.clauses) {
                         newClauses.add(renameVars(c, map) as Clause)
@@ -305,7 +305,7 @@ fun replaceRepresents(
                     map[defIndirectVars[i]] = cmdVars[i]
                 }
 
-                val ifThen = buildIfThen(rep)
+                val ifThen = buildIfThens(rep)[0]
                 if (ifThen.ifSection.clauses.clauses.isEmpty()) {
                     for (c in ifThen.thenSection.clauses.clauses) {
                         newClauses.add(renameVars(c, map) as Clause)
@@ -462,7 +462,7 @@ fun replaceIsNodes(
                 map[defDirectVars[i]] = lhsVars[i]
             }
 
-            val ifThen = buildIfThen(def)
+            val ifThen = buildIfThens(def)[0]
             if (ifThen.ifSection.clauses.clauses.isEmpty()) {
                 for (thenClause in ifThen.thenSection.clauses.clauses) {
                     newClauses.add(renameVars(thenClause, map) as Clause)
@@ -496,57 +496,63 @@ fun toCanonicalForm(def: DefinesGroup) = DefinesGroup(
     id = def.id,
     definesSection = def.definesSection,
     assumingSection = null,
-    meansSection = MeansSection(
-        row = -1,
-        column = -1,
-        clauses = ClauseListNode(
-            row = -1,
-            column = -1,
-            clauses = listOf(buildIfThen(def))
+    meansSections = buildIfThens(def).map {
+        MeansSection(
+                row = -1,
+                column = -1,
+                clauses = ClauseListNode(
+                        row = -1,
+                        column = -1,
+                        clauses = listOf(it)
+                )
         )
-    ),
+    },
     aliasSection = def.aliasSection,
     metaDataSection = def.metaDataSection
 )
 
-fun buildIfThen(def: DefinesGroup) = IfGroup(
-        row = -1,
-        column = -1,
-    ifSection = IfSection(
+fun buildIfThens(def: DefinesGroup) = def.meansSections.map {
+    IfGroup(
             row = -1,
             column = -1,
-        clauses = def.assumingSection?.clauses
-            ?: ClauseListNode(
-                clauses = emptyList(),
-                row = -1,
-                column = -1
-            )
-    ),
-    thenSection = ThenSection(
-            row = -1,
-            column = -1,
-        clauses = def.meansSection.clauses
-    )
-)
-
-fun buildIfThen(rep: RepresentsGroup) = IfGroup(
-    row = -1,
-    column = -1,
-    ifSection = IfSection(
-            row = -1,
-            column = -1,
-        clauses = rep.assumingSection?.clauses
-            ?: ClauseListNode(
-                    clauses = emptyList(),
+            ifSection = IfSection(
                     row = -1,
-                    column = -1)
-    ),
-    thenSection = ThenSection(
-        row = -1,
-        column = -1,
-        clauses = rep.thatSection.clauses
+                    column = -1,
+                    clauses = def.assumingSection?.clauses
+                            ?: ClauseListNode(
+                                    clauses = emptyList(),
+                                    row = -1,
+                                    column = -1
+                            )
+            ),
+            thenSection = ThenSection(
+                    row = -1,
+                    column = -1,
+                    clauses = it.clauses
+            )
     )
-)
+}
+
+fun buildIfThens(rep: RepresentsGroup) = rep.thatSections.map {
+    IfGroup(
+            row = -1,
+            column = -1,
+            ifSection = IfSection(
+                    row = -1,
+                    column = -1,
+                    clauses = rep.assumingSection?.clauses
+                            ?: ClauseListNode(
+                                    clauses = emptyList(),
+                                    row = -1,
+                                    column = -1)
+            ),
+            thenSection = ThenSection(
+                    row = -1,
+                    column = -1,
+                    clauses = it.clauses
+            )
+    )
+}
 
 fun getDefinesDirectVars(def: DefinesGroup): List<String> {
     val vars = mutableListOf<String>()

--- a/src/main/resources/mathlingua.txt
+++ b/src/main/resources/mathlingua.txt
@@ -22,7 +22,10 @@ Defines: X
 means:
 . "$%X$ is well defined collection of objects"
 Metadata:
-. reference = "source: @AATA; page: 3; offset: 17"
+. reference:
+  . source: "@AATA"
+    page: "3"
+    offset: "17"
 
 
 [a \in X]
@@ -31,7 +34,10 @@ assuming: 'X is \set'
 that:
 . "$%a$ is an element of $%X$"
 Metadata:
-. reference = "source: @AATA; page: 4; offset: 18"
+. reference:
+  . source: "@AATA"
+    page: "4"
+    offset: "18"
 
 
 [A \subset B]
@@ -42,7 +48,10 @@ that:
   where: 'a \in A'
   then: 'a \in B'
 Metadata:
-. reference = "source: @AATA; page: 4; offset: 18"
+. reference:
+  . source: "@AATA"
+    page: "4"
+    offset: "18"
 
 
 [x \neq y]
@@ -57,7 +66,10 @@ that:
 . 'A \subset B'
 . 'A \neq B'
 Metadata:
-. reference = "source: @AATA; page: 4; offset: 18"
+. reference:
+  . source: "@AATA"
+    page: "4"
+    offset: "18"
 
 
 [\empty.set]
@@ -68,7 +80,10 @@ means:
   . exists: x
     suchThat: 'x \in E'
 Metadata:
-. reference = "source: @AATA; page: 4; offset: 18"
+. reference:
+  . source: "@AATA"
+    page: "4"
+    offset: "18"
 
 
 [A \union B]
@@ -80,7 +95,10 @@ means:
   . 'c \in A'
   . 'c \in B'
 Metadata:
-. reference = "source: @AATA; page: 4; offset: 18"
+. reference:
+  . source: "@AATA"
+    page: "4"
+    offset: "18"
 
 
 [A \intersect B]
@@ -91,7 +109,10 @@ means:
 . 'c \in A'
 . 'c \in B'
 Metadata:
-. reference = "source: @AATA; page: 4; offset: 18"
+. reference:
+  . source: "@AATA"
+    page: "4"
+    offset: "18"
 
 
 [\disjoint.set]
@@ -99,7 +120,10 @@ Defines: (A, B)
 assuming: 'A, B is \set'
 means: '(A \intersect B) = \empty.set'
 Metadata:
-. reference = "source: @AATA; page: 5; offset: 19"
+. reference:
+  . source: "@AATA"
+    page: "5"
+    offset: "19"
 
 
 [x \notin X]
@@ -118,7 +142,10 @@ means:
 . 'x \in U'
 . 'x \notin A'
 Metadata:
-. reference = "source: @AATA; page: 5; offset: 19"
+. reference:
+  . source: "@AATA"
+    page: "5"
+    offset: "19"
 
 
 [A \set.difference B]
@@ -128,7 +155,10 @@ means:
 . 'c \in A'
 . 'c \notin B'
 Metadata:
-. reference = "source: @AATA; page: 5; offset: 19"
+. reference:
+  . source: "@AATA"
+    page: "5"
+    offset: "19"
 
 
 [A \set.cartesian.product B]
@@ -138,7 +168,10 @@ means:
 . 'x \in A'
 . 'y \in B'
 Metadata:
-. reference = "source: @AATA; page: 6; offset: 20"
+. reference:
+  . source: "@AATA"
+    page: "6"
+    offset: "20"
 
 
 [\function.domain:of{f}]
@@ -150,7 +183,10 @@ assuming:
 means:
 . 'X := A'
 Metadata:
-. reference = "source: @AATA; page: 7; offset: 21"
+. reference:
+  . source: "@AATA"
+    page: "7"
+    offset: "21"
 
 
 [\function.range:of{f}]
@@ -161,7 +197,10 @@ means:
 Alias:
 . domain = "function.domain:of"
 Metadata:
-. reference = "source: @AATA; page: 7; offset: 21"
+. reference:
+  . source: "@AATA"
+    page: "7"
+    offset: "21"
 
 
 [\surjective \function:on{A}to{B}]
@@ -175,7 +214,10 @@ means:
     suchThat:
     . 'f(a) = b'
 Metadata:
-. reference = "source: @AATA; page: 8; offset: 22"
+. reference:
+  . source: "@AATA"
+    page: "8"
+    offset: "22"
 
 
 [\injective \function:on{A}to{B}]
@@ -188,7 +230,10 @@ means:
   . if: 'a1 \neq a2'
     then: 'f(a1) \neq f(a2)'
 Metadata:
-. reference = "source: @AATA; page: 8; offset: 22"
+. reference:
+  . source: "@AATA"
+    page: "8"
+    offset: "22"
 
 
 [\bijective \function]
@@ -196,7 +241,10 @@ Defines: f
 means:
 . 'f \is \injective \surjective \function'
 Metadata:
-. reference = "source: @AATA; page: 8; offset: 22"
+. reference:
+  . source: "@AATA"
+    page: "8"
+    offset: "22"
 
 
 [g \of f]
@@ -211,7 +259,10 @@ means:
 . 'h is \function:on{A}to{C}'
 . 'h(x) = g(f(x))'
 Metadata:
-. reference = "source: @AATA; page: 8; offset: 22"
+. reference:
+  . source: "@AATA"
+    page: "8"
+    offset: "22"
 
 
 [\permutation:of{S}]
@@ -219,7 +270,10 @@ Defines: f
 assuming: 'S is \set'
 means: 'f is \bijective \function:on{S}to{S}'
 Metadata:
-. reference = "source: @AATA; page: 9; offset: 23"
+. reference:
+  . source: "@AATA"
+    page: "9"
+    offset: "23"
 
 
 [\identity.function:on{A}]
@@ -230,7 +284,10 @@ means:
 . for: x
   then: 'f(x) = x'
 Metadata:
-. reference = "source: @AATA; page: 10; offset: 24"
+. reference:
+  . source: "@AATA"
+    page: "10"
+    offset: "24"
 
 
 [\inverse.function:of{f}]
@@ -243,7 +300,10 @@ means:
 . 'g is \function:on{B}to{A}'
 . '(g \of f) = \identity.function:on{A}'
 Metadata:
-. reference = "source: @AATA; page: 10; offset: 24"
+. reference:
+  . source: "@AATA"
+    page: "10"
+    offset: "24"
 
 
 [\equivalence.relation:on{X}]
@@ -270,7 +330,10 @@ means:
 Alias:
 . cross = "set.cartesian.product"
 Metadata:
-. reference = "source: @AATA; page: 11; offset: 25"
+. reference:
+  . source: "@AATA"
+    page: "11"
+    offset: "25"
 
 
 [\integer]
@@ -299,7 +362,10 @@ means:
 Alias:
 . cross = "set.cartesian.product"
 Metadata:
-. reference = "source: @AATA; page: 33; offset: 47"
+. reference:
+  . source: "@AATA"
+    page: "33"
+    offset: "47"
 
 
 [\group]
@@ -323,7 +389,10 @@ means:
     . 'b \in X'
     . 'a * b = b * a = e'
 Metadata:
-. reference = "source: @AATA; page: 34; offset: 48"
+. reference:
+  . source: "@AATA"
+    page: "34"
+    offset: "48"
 
 
 [\abelian \group]
@@ -335,7 +404,10 @@ means:
   then:
   . 'a * b = b * a'
 Metadata:
-. reference = "source: @AATA; page: 34; offset: 48"
+. reference:
+  . source: "@AATA"
+    page: "34"
+    offset: "48"
 
 
 [\matrix{m, n}:over{F}]
@@ -356,7 +428,10 @@ means:
   then: 'M(i, j) = 0'
 . 'M(i, i) = 1'
 Metadata:
-. reference = "source: @AATA; page: 35; offset: 49"
+. reference:
+  . source: "@AATA"
+    page: "35"
+    offset: "49"
 
 
 [A * B]
@@ -373,7 +448,10 @@ means:
 . exists: A
   suchThat: 'M * A = \identity.matrix'
 Metadata:
-. reference = "source: @AATA; page: 35; offset: 49"
+. reference:
+  . source: "@AATA"
+    page: "35"
+    offset: "49"
 
 
 [\general.linear.group{n}:over{F}]
@@ -386,7 +464,10 @@ assuming:
 means:
 . 'X = \set[M]{M}{M is \invertible.matrix}'
 Metadata:
-. reference = "source: @AATA; page: 35; offset: 49"
+. reference:
+  . source: "@AATA"
+    page: "35"
+    offset: "49"
 
 
 [\finite \set]
@@ -395,7 +476,10 @@ means:
 . 'X is \set'
 . "$%X$ has a finite number of elements"
 Metadata:
-. reference = "source: @AATA; page: 36; offset: 50"
+. reference:
+  . source: "@AATA"
+    page: "36"
+    offset: "50"
 
 
 [\infinite \set]
@@ -405,7 +489,10 @@ means:
 . not:
   . 'X is \finite \set'
 Metadata:
-. reference = "source: @AATA; page: 36; offset: 50"
+. reference:
+  . source: "@AATA"
+    page: "36"
+    offset: "50"
 
 
 [\set.cardinality:of{X}]
@@ -420,7 +507,10 @@ means:
 . 'G is \group'
 . 'X \is \finite \set'
 Metadata:
-. reference = "source: @AATA; page: 36; offset: 50"
+. reference:
+  . source: "@AATA"
+    page: "36"
+    offset: "50"
 
 
 [\infinite \group]
@@ -429,7 +519,10 @@ means:
 . 'G is \group'
 . 'X \is \infinite \set'
 Metadata:
-. reference = "source: @AATA; page: 36; offset: 50"
+. reference:
+  . source: "@AATA"
+    page: "36"
+    offset: "50"
 
 
 [\group.order:of{G := (X, *)}]
@@ -437,7 +530,10 @@ Defines: n
 assuming: 'G is \group'
 means: 'n = \set.cardinality:of{X}'
 Metadata:
-. reference = "source: @AATA; page: 36; offset: 50"
+. reference:
+  . source: "@AATA"
+    page: "36"
+    offset: "50"
 
 
 
@@ -465,7 +561,10 @@ means:
   . 'a*(b + c) = a*b + a*c'
   . '(a + b)*c = a*c + b*c'
 Metadata:
-. reference = "source: @AATA; page: 199; offset: 213"
+. reference:
+  . source: "@AATA"
+    page: "199"
+    offset: "213"
 
 
 [\with.unity \ring]
@@ -476,7 +575,10 @@ means:
   where: 'x \in X'
   then: '1*x = x*1 = x'
 Metadata:
-. reference = "source: @AATA; page: 199; offset: 213"
+. reference:
+  . source: "@AATA"
+    page: "199"
+    offset: "213"
 
 
 [\commutative \ring]
@@ -487,7 +589,10 @@ means:
   where: 'x, y \in X'
   then: 'x*y = y*x'
 Metadata:
-. reference = "source: @AATA; page: 199; offset: 213"
+. reference:
+  . source: "@AATA"
+    page: "199"
+    offset: "213"
 
 
 [\integral.domain]
@@ -504,7 +609,10 @@ means:
       . 'x = 0'
       . 'y = 0'
 Metadata:
-. reference = "source: @AATA; page: 200; offset: 214"
+. reference:
+  . source: "@AATA"
+    page: "200"
+    offset: "214"
 
 
 [\ring.unit:in{R := (X, +, *, 0, 1)}]
@@ -517,7 +625,10 @@ means:
   . 'b is \unique'
   . 'u*b = b*u = 1'
 Metadata:
-. reference = "source: @AATA; page: 200; offset: 214"
+. reference:
+  . source: "@AATA"
+    page: "200"
+    offset: "214"
 
 
 [\division \with.identity.ring]
@@ -531,7 +642,10 @@ means:
   then:
   . 'x is \ring.unit:in{R}'
 Metadata:
-. reference = "source: @AATA; page: 200; offset: 214"
+. reference:
+  . source: "@AATA"
+    page: "200"
+    offset: "214"
 
 
 [\field]
@@ -540,7 +654,10 @@ means:
 . '(X, +, *, 0) is \commutative \ring'
 . '(X, +, *, 0, 1) is \division \with.identity.ring'
 Metadata:
-. reference = "source: @AATA; page: 200; offset: 214"
+. reference:
+  . source: "@AATA"
+    page: "200"
+    offset: "214"
 
 
 [\transitive.relation:on{X}]
@@ -557,7 +674,10 @@ means:
     then:
     . 'a < c'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 2; offset: 11"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "2"
+    offset: "11"
 
 
 [\order.relation:on{F := (X, +, *, 0, 1)}]
@@ -586,7 +706,10 @@ means:
   . if: 'a < b'
     then: 'a * c < b * c'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 2; offset: 11"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "2"
+    offset: "11"
 
 
 [\ordered.field]
@@ -598,14 +721,20 @@ means:
   . 'F is \field'
   . '< is \order.relation:on{F}'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 2; offset: 11"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "2"
+    offset: "11"
 
 
 [\real.field]
 Defines: R := (X, +, *, 0, 1, <)
 means: 'R is \ordered.field'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 2; offset: 11"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "2"
+    offset: "11"
 
 
 [\reals]
@@ -615,7 +744,10 @@ means:
   where: 'Rb is \real.field'
   then: 'R := X'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 2; offset: 11"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "2"
+    offset: "11"
 
 
 [\real]
@@ -644,21 +776,30 @@ means:
 Defines: lt
 means: 'lt := <'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 2; offset: 11"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "2"
+    offset: "11"
 
 
 [a > b]
 Defines: >
 means: 'b < a'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 2; offset: 11"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "2"
+    offset: "11"
 
 
 [a \gt b]
 Defines: gt
 means: 'gt := >'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 2; offset: 11"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "2"
+    offset: "11"
 
 
 [a <= b]
@@ -668,7 +809,10 @@ means:
   . 'a < b'
   . 'a = b'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 2; offset: 11"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "2"
+    offset: "11"
 
 
 [a >= b]
@@ -678,7 +822,10 @@ means:
   . 'a > b'
   . 'a = b'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 2; offset: 11"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "2"
+    offset: "11"
 
 
 [\real.open.interval:on{a, b}]
@@ -709,9 +856,12 @@ means:
     . 'x \in I'
     . 'x \in D'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 5; offset: 14"
-. description = "Definition: A set $D$ is dense in the reals if every open
-                 interval $(a,b)$ contains a member of $D$."
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "5"
+    offset: "14"
+    content: "Definition: A set $D$ is dense in the reals if every open
+              interval $(a,b)$ contains a member of $D$."
 
 
 [\uniformly.continuous.function:on{S}]
@@ -731,12 +881,14 @@ means:
       . if: '\abs{x - y} < delta'
         then: '\abs{f(x) - f(y)} < epsilon'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 65; offset: 74"
-. description = "Definition: A function $f$ is uniformly continuous on a
-                 subset $S$ of its domain if, for every $\epsilon >0$, there
-                 is a $\delta>0$ such that $$ |f(x)-f(x')|<\epsilon \
-                 |x-x'|<\delta \ x,x'\in S. \eqno{ } $$"
-
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "65"
+    offset: "74"
+    content: "Definition: A function $f$ is uniformly continuous on a
+              subset $S$ of its domain if, for every $\epsilon >0$, there
+              is a $\delta>0$ such that $$ |f(x)-f(x')|<\epsilon \
+              |x-x'|<\delta \ x,x'\in S. \eqno{ } $$"
 
 
 [\real.bounded.below.sequence:by{a}]
@@ -748,12 +900,15 @@ means:
   then:
   . 'S(n) >= a'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 181; offset: 190"
-. description = "Definition: A sequence $\{s_n\}$ is bounded above if there
-                 is a real number $b$ such that $$ s_n\le b , $$ bounded
-                 below if there is a real number $a$ such that $$ s_n\ge a ,
-                 $$ or bounded if there is a real number $r$ such that $$
-                 |s_n|\le r . $$"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "181"
+    offset: "190"
+    content: "Definition: A sequence $\{s_n\}$ is bounded above if there
+              is a real number $b$ such that $$ s_n\le b , $$ bounded
+              below if there is a real number $a$ such that $$ s_n\ge a ,
+              $$ or bounded if there is a real number $r$ such that $$
+              |s_n|\le r . $$"
 
 
 
@@ -763,12 +918,15 @@ means:
 . exists: a
   suchThat: 'S is \real.bounded.below.sequence:by{a}'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 181; offset: 190"
-. description = "Definition: A sequence $\{s_n\}$ is bounded above if there
-                 is a real number $b$ such that $$ s_n\le b , $$ bounded
-                 below if there is a real number $a$ such that $$ s_n\ge a ,
-                 $$ or bounded if there is a real number $r$ such that $$
-                 |s_n|\le r . $$"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "181"
+    offset: "190"
+    content: "Definition: A sequence $\{s_n\}$ is bounded above if there
+              is a real number $b$ such that $$ s_n\le b , $$ bounded
+              below if there is a real number $a$ such that $$ s_n\ge a ,
+              $$ or bounded if there is a real number $r$ such that $$
+              |s_n|\le r . $$"
 
 
 [\real.bounded.above.sequence:by{b}]
@@ -780,12 +938,15 @@ means:
   then:
   . 'S(n) <= b'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 181; offset: 190"
-. description = "Definition: A sequence $\{s_n\}$ is bounded above if there
-                 is a real number $b$ such that $$ s_n\le b , $$ bounded
-                 below if there is a real number $a$ such that $$ s_n\ge a ,
-                 $$ or bounded if there is a real number $r$ such that $$
-                 |s_n|\le r . $$"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "181"
+    offset: "190"
+    content: "Definition: A sequence $\{s_n\}$ is bounded above if there
+              is a real number $b$ such that $$ s_n\le b , $$ bounded
+              below if there is a real number $a$ such that $$ s_n\ge a ,
+              $$ or bounded if there is a real number $r$ such that $$
+              |s_n|\le r . $$"
 
 
 [\real.bounded.above.sequence]
@@ -794,12 +955,15 @@ means:
 . exists: b
   suchThat: 'S is \real.bounded.above.sequence:by{b}'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 181; offset: 190"
-. description = "Definition: A sequence $\{s_n\}$ is bounded above if there
-                 is a real number $b$ such that $$ s_n\le b , $$ bounded
-                 below if there is a real number $a$ such that $$ s_n\ge a ,
-                 $$ or bounded if there is a real number $r$ such that $$
-                 |s_n|\le r . $$"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "181"
+    offset: "190"
+    content: "Definition: A sequence $\{s_n\}$ is bounded above if there
+              is a real number $b$ such that $$ s_n\le b , $$ bounded
+              below if there is a real number $a$ such that $$ s_n\ge a ,
+              $$ or bounded if there is a real number $r$ such that $$
+              |s_n|\le r . $$"
 
 
 [\real.bounded.sequence]
@@ -810,10 +974,13 @@ means:
   . 'S is \real.bounded.above.sequence:by{b}'
   . 'S is \real.bounded.below.sequence:by{a}'
 Metadata:
-. reference = "source: @TrenchRealAnalysis; page: 181; offset: 190"
-. description = "Definition: A sequence $\{s_n\}$ is bounded above if there
-                 is a real number $b$ such that $$ s_n\le b , $$ bounded
-                 below if there is a real number $a$ such that $$ s_n\ge a ,
-                 $$ or bounded if there is a real number $r$ such that $$
-                 |s_n|\le r . $$"
+. reference:
+  . source: "@TrenchRealAnalysis"
+    page: "181"
+    offset: "190"
+    content: "Definition: A sequence $\{s_n\}$ is bounded above if there
+              is a real number $b$ such that $$ s_n\le b , $$ bounded
+              below if there is a real number $a$ such that $$ s_n\ge a ,
+              $$ or bounded if there is a real number $r$ such that $$
+              |s_n|\le r . $$"
 


### PR DESCRIPTION
Now one can write:
```
[\something]
Defines: X
means:
. 'something'
means:
. 'somethingElse'
```
to support the case when there are multiple equivalent
ways to define something.  Represents has a similar multi
syntax supported for its `then` section.