### PR TITLE
feat: toCode() accepts a CodeWriter

### DIFF
--- a/src/main/kotlin/mathlingua/common/MathLingua.kt
+++ b/src/main/kotlin/mathlingua/common/MathLingua.kt
@@ -34,7 +34,7 @@ class MathLingua {
         val (root, errors) = parser.parse(lexer)
         allErrors.addAll(errors)
 
-        if (root == null) {
+        if (root == null || allErrors.isNotEmpty()) {
             return ValidationFailure(allErrors)
         }
 

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/AliasSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/AliasSection.kt
@@ -32,17 +32,17 @@ data class AliasSection(
     Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = mappings.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "Alias:"))
-        builder.append('\n')
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("Alias")
+        writer.writeNewline()
         for (i in mappings.indices) {
-            builder.append(mappings[i].toCode(true, indent + 2))
+            writer.append(mappings[i], true, indent + 2)
             if (i != mappings.size - 1) {
-                builder.append('\n')
+                writer.writeNewline()
             }
         }
-        return builder.toString()
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(AliasSection(

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/AstUtils.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/AstUtils.kt
@@ -16,24 +16,6 @@
 
 package mathlingua.common.chalktalk.phase2
 
-fun indentedString(writer: CodeWriter, useDot: Boolean, indent: Int, line: String): CodeWriter {
-    for (i in 0 until indent - 2) {
-        writer.writeSpace()
-    }
-    if (indent - 2 >= 0) {
-        if (useDot) {
-            writer.writeDot()
-        } else {
-            writer.writeSpace()
-        }
-    }
-    if (indent - 1 >= 0) {
-        writer.writeSpace()
-    }
-    writer.writeDirect(line)
-    return writer
-}
-
 fun getChalkTalkAncestry(root: Phase2Node, node: Phase2Node): List<Phase2Node> {
     val path = mutableListOf<Phase2Node>()
     getChalkTalkAncestryImpl(root, node, path)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/AstUtils.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/AstUtils.kt
@@ -16,19 +16,22 @@
 
 package mathlingua.common.chalktalk.phase2
 
-fun indentedString(useDot: Boolean, indent: Int, line: String): String {
-    val builder = StringBuilder()
+fun indentedString(writer: CodeWriter, useDot: Boolean, indent: Int, line: String): CodeWriter {
     for (i in 0 until indent - 2) {
-        builder.append(' ')
+        writer.writeSpace()
     }
     if (indent - 2 >= 0) {
-        builder.append(if (useDot) '.' else ' ')
+        if (useDot) {
+            writer.writeDot()
+        } else {
+            writer.writeSpace()
+        }
     }
     if (indent - 1 >= 0) {
-        builder.append(' ')
+        writer.writeSpace()
     }
-    builder.append(line)
-    return builder.toString()
+    writer.writeDirect(line)
+    return writer
 }
 
 fun getChalkTalkAncestry(root: Phase2Node, node: Phase2Node): List<Phase2Node> {

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Clause.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Clause.kt
@@ -233,8 +233,11 @@ data class Identifier(
 ) : Target() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
-            indentedString(writer, isArg, indent, name + if (isVarArgs) "..." else "")
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeIdentifier(name, isVarArgs)
+        return writer
+    }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -291,8 +294,11 @@ data class Statement(
 ) : Clause() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
-            indentedString(writer, isArg, indent, "'$text'")
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeStatement(text, texTalkRoot)
+        return writer
+    }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -352,8 +358,11 @@ data class Text(
 ) : Clause() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
-            indentedString(writer, isArg, indent, text)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeText(text.removeSurrounding("\"", "\""))
+        return writer
+    }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Clause.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Clause.kt
@@ -130,7 +130,7 @@ data class AbstractionNode(
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int) = toCode(isArg, indent, abstraction)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) = toCode(writer, isArg, indent, abstraction)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -150,7 +150,7 @@ data class AggregateNode(
 ) : Target() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int) = toCode(isArg, indent, aggregate)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) = toCode(writer, isArg, indent, aggregate)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -170,7 +170,7 @@ data class TupleNode(
 ) : Target() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int) = toCode(isArg, indent, tuple)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) = toCode(writer, isArg, indent, tuple)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -190,7 +190,7 @@ data class AssignmentNode(
 ) : Target() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int) = toCode(isArg, indent, assignment)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) = toCode(writer, isArg, indent, assignment)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -211,7 +211,7 @@ data class MappingNode(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int) = toCode(isArg, indent, mapping)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) = toCode(writer, isArg, indent, mapping)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -233,8 +233,8 @@ data class Identifier(
 ) : Target() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int) =
-            indentedString(isArg, indent, name + if (isVarArgs) "..." else "")
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            indentedString(writer, isArg, indent, name + if (isVarArgs) "..." else "")
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -291,7 +291,8 @@ data class Statement(
 ) : Clause() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int) = indentedString(isArg, indent, "'$text'")
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
+            = indentedString(writer, isArg, indent, "'$text'")
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -351,7 +352,8 @@ data class Text(
 ) : Clause() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int) = indentedString(isArg, indent, text)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
+            = indentedString(writer, isArg, indent, text)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -396,7 +398,8 @@ data class ExistsGroup(
         fn(suchThatSection)
     }
 
-    override fun toCode(isArg: Boolean, indent: Int) = toCode(isArg, indent, existsSection, suchThatSection)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            toCode(writer, isArg, indent, existsSection, suchThatSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(ExistsGroup(
         existsSection = existsSection.transform(chalkTransformer) as ExistsSection,
@@ -428,7 +431,8 @@ data class IfGroup(
         fn(thenSection)
     }
 
-    override fun toCode(isArg: Boolean, indent: Int) = toCode(isArg, indent, ifSection, thenSection)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
+            = toCode(writer, isArg, indent, ifSection, thenSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(IfGroup(
         ifSection = ifSection.transform(chalkTransformer) as IfSection,
@@ -460,7 +464,8 @@ data class IffGroup(
         fn(thenSection)
     }
 
-    override fun toCode(isArg: Boolean, indent: Int) = toCode(isArg, indent, iffSection, thenSection)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
+            = toCode(writer, isArg, indent, iffSection, thenSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(IffGroup(
         iffSection = iffSection.transform(chalkTransformer) as IffSection,
@@ -496,8 +501,8 @@ data class ForGroup(
         fn(thenSection)
     }
 
-    override fun toCode(isArg: Boolean, indent: Int) =
-            toCode(isArg, indent, forSection, whereSection, thenSection)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            toCode(writer, isArg, indent, forSection, whereSection, thenSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(ForGroup(
         forSection = forSection.transform(chalkTransformer) as ForSection,
@@ -574,7 +579,8 @@ data class NotGroup(
 ) : Clause() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = fn(notSection)
 
-    override fun toCode(isArg: Boolean, indent: Int) = notSection.toCode(isArg, indent)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
+            = notSection.toCode(isArg, indent, writer)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(NotGroup(
         notSection = notSection.transform(chalkTransformer) as NotSection,
@@ -597,7 +603,8 @@ data class OrGroup(
 ) : Clause() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = fn(orSection)
 
-    override fun toCode(isArg: Boolean, indent: Int) = orSection.toCode(isArg, indent)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
+            = orSection.toCode(isArg, indent, writer)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(OrGroup(
         orSection = orSection.transform(chalkTransformer) as OrSection,
@@ -744,23 +751,21 @@ private fun <Wrapped, Base> validateWrappedNode(
     return ValidationSuccess(build(base, getRow(node), getColumn(node)))
 }
 
-fun toCode(isArg: Boolean, indent: Int, phase1Node: Phase1Node): String {
-    val builder = StringBuilder()
-    builder.append(indentedString(isArg, indent, ""))
-    builder.append(phase1Node.toCode())
-    return builder.toString()
+fun toCode(writer: CodeWriter, isArg: Boolean, indent: Int, phase1Node: Phase1Node): CodeWriter {
+    writer.writeIndent(isArg, indent)
+    writer.writePhase1Node(phase1Node)
+    return writer
 }
 
-fun toCode(isArg: Boolean, indent: Int, vararg sections: Phase2Node?): String {
-    val builder = StringBuilder()
+fun toCode(writer: CodeWriter, isArg: Boolean, indent: Int, vararg sections: Phase2Node?): CodeWriter {
     for (i in sections.indices) {
         val sect = sections[i]
         if (sect != null) {
-            builder.append(sect.toCode(isArg && i == 0, indent))
+            writer.append(sect, isArg && i == 0, indent)
             if (i != sections.size - 1) {
-                builder.append('\n')
+                writer.writeNewline()
             }
         }
     }
-    return builder.toString()
+    return writer
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Clause.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Clause.kt
@@ -291,8 +291,8 @@ data class Statement(
 ) : Clause() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
-            = indentedString(writer, isArg, indent, "'$text'")
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            indentedString(writer, isArg, indent, "'$text'")
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -352,8 +352,8 @@ data class Text(
 ) : Clause() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
-            = indentedString(writer, isArg, indent, text)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            indentedString(writer, isArg, indent, text)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -431,8 +431,8 @@ data class IfGroup(
         fn(thenSection)
     }
 
-    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
-            = toCode(writer, isArg, indent, ifSection, thenSection)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            toCode(writer, isArg, indent, ifSection, thenSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(IfGroup(
         ifSection = ifSection.transform(chalkTransformer) as IfSection,
@@ -464,8 +464,8 @@ data class IffGroup(
         fn(thenSection)
     }
 
-    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
-            = toCode(writer, isArg, indent, iffSection, thenSection)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            toCode(writer, isArg, indent, iffSection, thenSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(IffGroup(
         iffSection = iffSection.transform(chalkTransformer) as IffSection,
@@ -579,8 +579,8 @@ data class NotGroup(
 ) : Clause() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = fn(notSection)
 
-    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
-            = notSection.toCode(isArg, indent, writer)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            notSection.toCode(isArg, indent, writer)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(NotGroup(
         notSection = notSection.transform(chalkTransformer) as NotSection,
@@ -603,8 +603,8 @@ data class OrGroup(
 ) : Clause() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = fn(orSection)
 
-    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
-            = orSection.toCode(isArg, indent, writer)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            orSection.toCode(isArg, indent, writer)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(OrGroup(
         orSection = orSection.transform(chalkTransformer) as OrSection,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ClauseListNode.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ClauseListNode.kt
@@ -25,15 +25,14 @@ data class ClauseListNode(
         clauses.forEach(fn)
     }
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         for (i in clauses.indices) {
-            builder.append(clauses[i].toCode(true, indent))
+            writer.append(clauses[i], true, indent)
             if (i != clauses.size - 1) {
-                builder.append('\n')
+                writer.writeNewline()
             }
         }
-        return builder.toString()
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node): Phase2Node {

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Document.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Document.kt
@@ -18,6 +18,7 @@ package mathlingua.common.chalktalk.phase2
 
 import mathlingua.common.*
 import mathlingua.common.chalktalk.phase1.ast.*
+import mathlingua.common.textalk.ExpressionTexTalkNode
 
 interface CodeWriter {
     fun append(node: Phase2Node, hasDot: Boolean, indent: Int)
@@ -29,8 +30,10 @@ interface CodeWriter {
     fun writeIndent(hasDot: Boolean, indent: Int)
     fun writePhase1Node(phase1Node: Phase1Node)
     fun writeId(id: Statement)
+    fun writeStatement(stmtText: String, root: Validation<ExpressionTexTalkNode>)
+    fun writeIdentifier(name: String, isVarArgs: Boolean)
     fun writeText(text: String)
-    fun writeDirect(str: String)
+    fun writeDirect(text: String)
     fun getCode(): String
 }
 
@@ -304,15 +307,26 @@ class TextCodeWriter : CodeWriter {
         builder.append('"')
     }
 
-    override fun writeDirect(str: String) {
-        builder.append(str)
+    override fun writeStatement(stmtText: String, root: Validation<ExpressionTexTalkNode>) {
+        builder.append("'$stmtText'")
+    }
+
+    override fun writeIdentifier(name: String, isVarArgs: Boolean) {
+        builder.append(name)
+        if (isVarArgs) {
+            builder.append("...")
+        }
+    }
+
+    override fun writeDirect(text: String) {
+        builder.append(text)
     }
 
     override fun getCode() = builder.toString()
 }
 
 fun main(args: Array<String>) {
-    val code = """
+    val code1 = """
         [a \in b]
         Defines: f(x)
         means:
@@ -324,8 +338,12 @@ fun main(args: Array<String>) {
     val code2 = """
         Result: a
     """.trimIndent()
+    val code3 = """
+        ProtoResult:
+        . "This is some text"
+    """.trimIndent()
     val ml = MathLingua()
-    when (val validation = ml.parse(code)) {
+    when (val validation = ml.parse(code1)) {
         is ValidationSuccess -> {
             val writer = TextCodeWriter()
             validation.value.toCode(false, 0, writer)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Group.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Group.kt
@@ -371,7 +371,7 @@ fun validateConjectureGroup(groupNode: Group) = validateResultLikeGroup(
 fun toCode(writer: CodeWriter, isArg: Boolean, indent: Int, id: Statement?, vararg sections: Phase2Node?): CodeWriter {
     var useAsArg = isArg
     if (id != null) {
-        writer.writeIndent(isArg, indent);
+        writer.writeIndent(isArg, indent)
         writer.writeId(id)
         writer.writeNewline()
         useAsArg = false

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Group.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Group.kt
@@ -45,7 +45,7 @@ data class SourceGroup(
         }
     }
 
-    override fun toCode(isArg: Boolean, indent: Int) = toCode(isArg, indent,
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) = toCode(writer, isArg, indent,
         Statement(
                 id,
                 ValidationFailure(emptyList()),
@@ -160,11 +160,12 @@ data class DefinesGroup(
         }
     }
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         val sections = mutableListOf(definesSection, assumingSection)
         sections.addAll(meansSections)
         sections.add(metaDataSection)
         return toCode(
+                writer,
                 isArg,
                 indent,
                 id,
@@ -220,11 +221,12 @@ data class RepresentsGroup(
         }
     }
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         val sections = mutableListOf(representsSection, assumingSection)
         sections.addAll(thatSections)
         sections.add(metaDataSection)
         return toCode(
+                writer,
                 isArg,
                 indent,
                 id,
@@ -271,8 +273,8 @@ data class ResultGroup(
         }
     }
 
-    override fun toCode(isArg: Boolean, indent: Int) =
-            toCode(isArg, indent, null, resultSection, metaDataSection)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            toCode(writer, isArg, indent, null, resultSection, metaDataSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(ResultGroup(
         resultSection = resultSection.transform(chalkTransformer) as ResultSection,
@@ -307,8 +309,8 @@ data class AxiomGroup(
         }
     }
 
-    override fun toCode(isArg: Boolean, indent: Int) =
-            toCode(isArg, indent, null, axiomSection, metaDataSection)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            toCode(writer, isArg, indent, null, axiomSection, metaDataSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
         chalkTransformer(AxiomGroup(
@@ -344,8 +346,8 @@ data class ConjectureGroup(
         }
     }
 
-    override fun toCode(isArg: Boolean, indent: Int) =
-            toCode(isArg, indent, null, conjectureSection, metaDataSection)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            toCode(writer, isArg, indent, null, conjectureSection, metaDataSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
         chalkTransformer(ConjectureGroup(
@@ -366,26 +368,27 @@ fun validateConjectureGroup(groupNode: Group) = validateResultLikeGroup(
     ::ConjectureGroup
 )
 
-fun toCode(isArg: Boolean, indent: Int, id: Statement?, vararg sections: Phase2Node?): String {
-    val builder = StringBuilder()
+fun toCode(writer: CodeWriter, isArg: Boolean, indent: Int, id: Statement?, vararg sections: Phase2Node?): CodeWriter {
     var useAsArg = isArg
     if (id != null) {
-        builder.append(indentedString(isArg, indent, "[${id.text}]\n"))
+        writer.writeIndent(isArg, indent);
+        writer.writeId(id)
+        writer.writeNewline()
         useAsArg = false
     }
 
     for (i in 0 until sections.size) {
         val sect = sections[i]
         if (sect != null) {
-            builder.append(sect.toCode(useAsArg, indent))
+            writer.append(sect, useAsArg, indent)
             useAsArg = false
             if (i != sections.size - 1) {
-                builder.append('\n')
+                writer.writeNewline()
             }
         }
     }
 
-    return builder.toString()
+    return writer
 }
 
 class ProtoGroup(
@@ -401,8 +404,8 @@ class ProtoGroup(
         }
     }
 
-    override fun toCode(isArg: Boolean, indent: Int) =
-            toCode(isArg, indent, null, textSection, metaDataSection)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            toCode(writer, isArg, indent, null, textSection, metaDataSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(ProtoGroup(

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/MetaDataSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/MetaDataSection.kt
@@ -184,8 +184,8 @@ data class ReferenceGroup(
 ) : MetaDataItem() {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = fn(referenceSection)
 
-    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter)
-            = referenceSection.toCode(isArg, indent, writer)
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+            referenceSection.toCode(isArg, indent, writer)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(ReferenceGroup(

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Section.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Section.kt
@@ -29,7 +29,7 @@ private fun canBeOnOneLine(target: Target) =
         target is AggregateNode ||
         target is AssignmentNode
 
-private fun appendTargetArgs(builder: StringBuilder, targets: List<Target>, indent: Int) {
+private fun appendTargetArgs(writer: CodeWriter, targets: List<Target>, indent: Int) {
     var i = 0
     while (i < targets.size) {
         val lineItems = mutableListOf<Target>()
@@ -37,14 +37,15 @@ private fun appendTargetArgs(builder: StringBuilder, targets: List<Target>, inde
             lineItems.add(targets[i++])
         }
         if (lineItems.isEmpty()) {
-            builder.append('\n')
-            builder.append(targets[i++].toCode(true, indent))
+            writer.writeNewline()
+            writer.append(targets[i++], true, indent)
         } else {
-            builder.append(' ')
+            writer.writeSpace()
             for (j in lineItems.indices) {
-                builder.append(lineItems[j].toCode(false, 0))
+                writer.append(lineItems[j], false, 0)
                 if (j != lineItems.size - 1) {
-                    builder.append(", ")
+                    writer.writeComma()
+                    writer.writeSpace()
                 }
             }
         }
@@ -58,14 +59,14 @@ data class AssumingSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "assuming:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("assuming")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -90,11 +91,11 @@ data class DefinesSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = targets.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "Defines:"))
-        appendTargetArgs(builder, targets, indent + 2)
-        return builder.toString()
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("Defines")
+        appendTargetArgs(writer, targets, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -119,11 +120,11 @@ data class RefinesSection(
     Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = targets.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "Refines:"))
-        appendTargetArgs(builder, targets, indent + 2)
-        return builder.toString()
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("Refines")
+        appendTargetArgs(writer, targets, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -146,7 +147,11 @@ data class RepresentsSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
-    override fun toCode(isArg: Boolean, indent: Int) = indentedString(isArg, indent, "Represents:")
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("Represents")
+        return writer
+    }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
@@ -198,11 +203,11 @@ data class ExistsSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = identifiers.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "exists:"))
-        appendTargetArgs(builder, identifiers, indent + 2)
-        return builder.toString()
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("exists")
+        appendTargetArgs(writer, identifiers, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -226,11 +231,11 @@ data class ForSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = targets.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "for:"))
-        appendTargetArgs(builder, targets, indent + 2)
-        return builder.toString()
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("for")
+        appendTargetArgs(writer, targets, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -254,14 +259,14 @@ data class MeansSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = fn(clauses)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "means:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("means")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(MeansSection(
@@ -285,14 +290,14 @@ data class ResultSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "Result:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("Result")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -317,14 +322,14 @@ data class AxiomSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "Axiom:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("Axiom")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -349,14 +354,14 @@ data class ConjectureSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "Conjecture:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("Conjecture")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -381,14 +386,14 @@ data class SuchThatSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "suchThat:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("suchThat")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -413,14 +418,14 @@ data class ThatSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "that:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("that")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -445,14 +450,14 @@ data class IfSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "if:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("if")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -477,14 +482,14 @@ data class IffSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "iff:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("iff")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(IffSection(
@@ -508,14 +513,14 @@ data class ThenSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "then:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("then")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(ThenSection(
@@ -539,14 +544,14 @@ data class WhereSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "where:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("where")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -571,14 +576,14 @@ data class NotSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "not:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("not")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -603,14 +608,14 @@ data class OrSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "or:"))
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("or")
         if (clauses.clauses.isNotEmpty()) {
-            builder.append('\n')
+            writer.writeNewline()
         }
-        builder.append(clauses.toCode(true, indent + 2))
-        return builder.toString()
+        writer.append(clauses, true, indent + 2)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
@@ -637,11 +642,13 @@ data class TextSection(
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
     }
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "$name:\n"))
-        builder.append(indentedString(true, indent + 2, text))
-        return builder.toString()
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader(name)
+        writer.writeNewline()
+        writer.writeIndent(true, indent + 2)
+        writer.writeDirect(text)
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/SourceSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/SourceSection.kt
@@ -36,17 +36,17 @@ data class SourceSection(
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = items.forEach(fn)
 
-    override fun toCode(isArg: Boolean, indent: Int): String {
-        val builder = StringBuilder()
-        builder.append(indentedString(isArg, indent, "Source:"))
-        builder.append('\n')
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("Source")
+        writer.writeNewline()
         for (i in items.indices) {
-            builder.append(items[i].toCode(true, indent + 2))
+            writer.append(items[i], true, indent + 2)
             if (i != items.size - 1) {
-                builder.append('\n')
+                writer.writeNewline()
             }
         }
-        return builder.toString()
+        return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)

--- a/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
@@ -622,12 +622,12 @@ fun fullExpandComplete(doc: Document, maxSteps: Int = 10): Document {
     val snapshots = mutableSetOf<String>()
 
     var transformed = doc
-    var previousCode = transformed.toCode(false, 0)
+    var previousCode = transformed.toCode(false, 0).getCode()
     snapshots.add(previousCode)
 
     for (i in 0 until maxSteps) {
         transformed = fullExpandOnce(transformed)
-        val code = transformed.toCode(false, 0)
+        val code = transformed.toCode(false, 0).getCode()
         if (snapshots.contains(code) || previousCode == code) {
             break
         }

--- a/src/main/kotlin/mathlingua/jvm/Playground.kt
+++ b/src/main/kotlin/mathlingua/jvm/Playground.kt
@@ -145,7 +145,7 @@ object Playground {
 
                 val newDoc = expandAtNode(doc, nearestNode, doc.defines, doc.represents)
 
-                outputArea.text = newDoc.toCode(false, 0)
+                outputArea.text = newDoc.toCode(false, 0).getCode()
                 outputTree.model = DefaultTreeModel(toTreeNode(newDoc))
             }
         }
@@ -265,7 +265,7 @@ object Playground {
                             transformed = fullExpandComplete(doc)
                         }
 
-                        outputArea.text = transformed.toCode(false, 0)
+                        outputArea.text = transformed.toCode(false, 0).getCode()
                         outputTree.model = DefaultTreeModel(toTreeNode(transformed))
                         val numRows = phase2Tree.rowCount
                         if (numRows > 0) {
@@ -377,7 +377,7 @@ object Playground {
 data class Phase2Value(val value: Phase2Node, val showCode: Boolean) {
     override fun toString(): String {
         return if (showCode) {
-            value.toCode(false, 0) + " (${value.row}, ${value.column})"
+            value.toCode(false, 0).getCode() + " (${value.row}, ${value.column})"
         } else {
             value.javaClass.simpleName +
                     " (${value.row}, ${value.column})"

--- a/src/test/kotlin/mathlingua/common/chalktalk/phase2/ChalkTalkParserTest.kt
+++ b/src/test/kotlin/mathlingua/common/chalktalk/phase2/ChalkTalkParserTest.kt
@@ -47,7 +47,7 @@ internal class ChalkTalkParserTest {
                 assert(validation is ValidationSuccess)
 
                 val doc = (validation as ValidationSuccess).value
-                assertThat(doc.toCode(false, 0).trim()).isEqualTo(it.expectedOutput.trim())
+                assertThat(doc.toCode(false, 0).getCode().trim()).isEqualTo(it.expectedOutput.trim())
             }
         }
     }


### PR DESCRIPTION
A `CodeWriter` is provided to `Phase2Node.toCode` that does
the actual writing.  This allows the same logic to be used
to serialize a `Phase2Node` into MathLingua, HTML, or other
formats by just providing different `CodeWriter`s.