### PR TITLE
feat: support sub params in abstractions

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexer.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexer.kt
@@ -84,6 +84,10 @@ private class ChalkTalkLexerImpl(private var text: String) :
                 this.chalkTalkTokens!!.add(
                     Phase1Token("=", ChalkTalkTokenType.Equals, line, column)
                 )
+            } else if (c == '_') {
+                this.chalkTalkTokens!!.add(
+                        Phase1Token("_", ChalkTalkTokenType.Underscore, line, column)
+                )
             } else if (c == '(') {
                 this.chalkTalkTokens!!.add(
                     Phase1Token("(", ChalkTalkTokenType.LParen, line, column)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ast/Phase1Target.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ast/Phase1Target.kt
@@ -152,9 +152,11 @@ data class Tuple(val items: List<TupleItem>) : AssignmentRhs() {
     ))
 }
 
-data class Abstraction(val name: Phase1Token,
-                       val subParams: List<Phase1Token>?,
-                       val params: List<Phase1Token>?) : TupleItem() {
+data class Abstraction(
+    val name: Phase1Token,
+    val subParams: List<Phase1Token>?,
+    val params: List<Phase1Token>?
+) : TupleItem() {
 
     override fun forEach(fn: (node: Phase1Node) -> Unit) {
         fn(name)

--- a/src/test/kotlin/TestUtil.kt
+++ b/src/test/kotlin/TestUtil.kt
@@ -18,12 +18,20 @@ package mathlingua
 
 import java.io.File
 
-data class TestCase(val name: String, val input: String, val expectedOutput: String)
+data class TestCase(val name: String,
+                    val input: String,
+                    val phase1Output: String,
+                    val phase2Output: String)
 
 const val TEST_NAME_PREFIX = "-- Test:"
-const val INPUT_PREFIX = "-- Input:"
-const val OUTPUT_PREFIX = "-- Output:"
-const val END_PREFIX = "-- End;"
+const val INPUT_START = "-- Input:"
+const val INPUT_END = "-- EndInput:"
+const val OUTPUT_START = "-- Output:"
+const val OUTPUT_END = "-- EndOutput:"
+const val OUTPUT_PHASE1_START = "-- Output(Phase1):"
+const val OUTPUT_PHASE1_END = "-- EndOutput(Phase1):"
+const val OUTPUT_PHASE2_START = "-- Output(Phase2):"
+const val OUTPUT_PHASE2_END = "-- EndOutput(Phase2):"
 
 fun loadTestCases(file: File): List<TestCase> {
     // This function is only used in tests, and thus
@@ -40,40 +48,55 @@ fun loadTestCases(file: File): List<TestCase> {
             i++
         }
 
+        fun readSection(start: String, end: String): String? {
+            if (i >= lines.size || lines[i] != start) {
+                return null
+            }
+
+            expectPrefix(start, lines[i], i + 1)
+            i++ // move past the start line
+
+            val buffer = StringBuilder()
+            while (i < lines.size && lines[i] != end) {
+                buffer.append(lines[i++])
+                buffer.append('\n')
+            }
+            expectPrefix(end, lines[i], i + 1)
+            i++ // move past the end line
+
+            return buffer.toString()
+        }
+
         val testNameLine = lines[i]
         expectPrefix(TEST_NAME_PREFIX, testNameLine, i + 1)
         val testName = trimPrefix(TEST_NAME_PREFIX, testNameLine)
         i++
 
-        val inputLine = lines[i]
-        expectPrefix(INPUT_PREFIX, inputLine, i + 1)
-        i++
+        val input = readSection(INPUT_START, INPUT_END)
+        val output = readSection(OUTPUT_START, OUTPUT_END)
+        val phase1Output = readSection(OUTPUT_PHASE1_START, OUTPUT_PHASE1_END)
+        val phase2Output = readSection(OUTPUT_PHASE2_START, OUTPUT_PHASE2_END)
 
-        val inputBuilder = StringBuilder()
-        while (i < lines.size && !hasPrefix(OUTPUT_PREFIX, lines[i])) {
-            inputBuilder.append(lines[i++])
-            inputBuilder.append("\n")
+        if (input == null) {
+            throw Exception("Line ${i+1}: Input not specified")
         }
 
-        val outputLine = lines[i]
-        expectPrefix(OUTPUT_PREFIX, outputLine, i + 1)
-        i++
-
-        val outputBuilder = StringBuilder()
-        while (i < lines.size && !hasPrefix(END_PREFIX, lines[i])) {
-            outputBuilder.append(lines[i++])
-            outputBuilder.append('\n')
+        if (output == null && (phase1Output == null || phase2Output == null)) {
+            throw Exception("Line ${i+1}: Output is not specified and " +
+                    "one of Phase1Output or Phase2Output is missing")
         }
 
-        val endLine = lines[i]
-        expectPrefix(END_PREFIX, endLine, i + 1)
-        i++
+        if (output != null && (phase1Output != null || phase2Output != null)) {
+            throw Exception("Line ${i+1}: Output is specified but so " +
+                    "is one of Phase1Output or Phase2Output")
+        }
 
         result.add(
             TestCase(
                 name = testName,
-                input = inputBuilder.toString(),
-                expectedOutput = outputBuilder.toString()
+                input = input,
+                phase1Output = (phase1Output ?: output)!!,
+                phase2Output = (phase2Output ?: output)!!
             )
         )
     }

--- a/src/test/kotlin/TestUtil.kt
+++ b/src/test/kotlin/TestUtil.kt
@@ -18,10 +18,12 @@ package mathlingua
 
 import java.io.File
 
-data class TestCase(val name: String,
-                    val input: String,
-                    val phase1Output: String,
-                    val phase2Output: String)
+data class TestCase(
+    val name: String,
+    val input: String,
+    val phase1Output: String,
+    val phase2Output: String
+)
 
 const val TEST_NAME_PREFIX = "-- Test:"
 const val INPUT_START = "-- Input:"
@@ -78,16 +80,16 @@ fun loadTestCases(file: File): List<TestCase> {
         val phase2Output = readSection(OUTPUT_PHASE2_START, OUTPUT_PHASE2_END)
 
         if (input == null) {
-            throw Exception("Line ${i+1}: Input not specified")
+            throw Exception("Line ${i + 1}: Input not specified")
         }
 
         if (output == null && (phase1Output == null || phase2Output == null)) {
-            throw Exception("Line ${i+1}: Output is not specified and " +
+            throw Exception("Line ${i + 1}: Output is not specified and " +
                     "one of Phase1Output or Phase2Output is missing")
         }
 
         if (output != null && (phase1Output != null || phase2Output != null)) {
-            throw Exception("Line ${i+1}: Output is specified but so " +
+            throw Exception("Line ${i + 1}: Output is specified but so " +
                     "is one of Phase1Output or Phase2Output")
         }
 

--- a/src/test/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexerTest.kt
+++ b/src/test/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexerTest.kt
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test
 internal class ChalkTalkLexerTest {
     @Test
     fun `correctly identifies tokens`() {
-        val text = "someName:'some statement'\"some text\". [some id],:=$1 #2 abc...xyz"
+        val text = "someName:'some statement'\"some text\". [some id],:=$1 #2 abc...xyz_"
         val lexer = newChalkTalkLexer(text)
         val actual: MutableList<Phase1Token> = ArrayList()
         while (lexer.hasNext()) {
@@ -50,6 +50,7 @@ internal class ChalkTalkLexerTest {
             Phase1Token(text = "#2", type = ChalkTalkTokenType.Name, row = 0, column = 53),
             Phase1Token(text = "abc...", type = ChalkTalkTokenType.Name, row = 0, column = 56),
             Phase1Token(text = "xyz", type = ChalkTalkTokenType.Name, row = 0, column = 62),
+            Phase1Token(text = "_", type = ChalkTalkTokenType.Underscore, row = 0, column = 65),
             Phase1Token(text = "<Indent>", type = ChalkTalkTokenType.Begin, row = 1, column = 0),
             Phase1Token(text = "<Unindent>", type = ChalkTalkTokenType.End, row = 1, column = 0)
         )

--- a/src/test/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkParserTest.kt
+++ b/src/test/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkParserTest.kt
@@ -37,10 +37,15 @@ internal class ChalkTalkParserTest {
 
                 val parser = newChalkTalkParser()
                 val result = parser.parse(lexer)
+                if (result.errors.isNotEmpty()) {
+                    for (err in result.errors) {
+                        println("ERROR: $err")
+                    }
+                }
                 assertThat(result.errors.size).isEqualTo(0)
                 assertThat(result.root).isNotNull()
 
-                assertThat(result.root!!.toCode()).isEqualTo(it.expectedOutput)
+                assertThat(result.root!!.toCode()).isEqualTo(it.phase1Output)
             }
         }
     }

--- a/src/test/kotlin/mathlingua/common/chalktalk/phase2/ChalkTalkParserTest.kt
+++ b/src/test/kotlin/mathlingua/common/chalktalk/phase2/ChalkTalkParserTest.kt
@@ -47,7 +47,7 @@ internal class ChalkTalkParserTest {
                 assert(validation is ValidationSuccess)
 
                 val doc = (validation as ValidationSuccess).value
-                assertThat(doc.toCode(false, 0).getCode().trim()).isEqualTo(it.expectedOutput.trim())
+                assertThat(doc.toCode(false, 0).getCode().trim()).isEqualTo(it.phase2Output.trim())
             }
         }
     }

--- a/src/test/kotlin/mathlingua/common/textalk/TexTalkParserTest.kt
+++ b/src/test/kotlin/mathlingua/common/textalk/TexTalkParserTest.kt
@@ -40,7 +40,7 @@ internal class TexTalkParserTest {
                 assertThat(result.errors.size).isEqualTo(0)
                 assertThat(result.root).isNotNull()
 
-                assertThat(result.root.toCode().trim()).isEqualTo(it.expectedOutput.trim())
+                assertThat(result.root.toCode().trim()).isEqualTo(it.phase1Output.trim())
             }
         }
     }

--- a/src/test/resources/golden-chalktalk.txt
+++ b/src/test/resources/golden-chalktalk.txt
@@ -1,32 +1,34 @@
-
 -- Test: parses single argument on same line
 -- Input:
 Result: x
+-- EndInput:
 -- Output:
 Result:
 . x
--- End;
+-- EndOutput:
 
 
 -- Test: parses single argument indented
 -- Input:
 Result:
 . x
+-- EndInput:
 -- Output:
 Result:
 . x
--- End;
+-- EndOutput:
 
 
 -- Test: parses multiple arguments single line
 -- Input:
 Result: a, b, c
+-- EndInput:
 -- Output:
 Result:
 . a
 . b
 . c
--- End;
+-- EndOutput:
 
 
 -- Test: parses multiple arguments indented
@@ -35,12 +37,13 @@ Result:
 . a
 . b
 . c
+-- EndInput:
 -- Output:
 Result:
 . a
 . b
 . c
--- End;
+-- EndOutput:
 
 
 -- Test: parses multiple arguments mixed indented
@@ -49,6 +52,7 @@ Result: a, b
 . c
 . d, e
 . f
+-- EndInput:
 -- Output:
 Result:
 . a
@@ -57,58 +61,211 @@ Result:
 . d
 . e
 . f
--- End;
+-- EndOutput:
 
 
 -- Test: parses text identifiers
 -- Input:
 Result: x
+-- EndInput:
 -- Output:
 Result:
 . x
--- End;
+-- EndOutput:
 
 
 -- Test: parses operator identifiers
 -- Input:
 Result: *
+-- EndInput:
 -- Output:
 Result:
 . *
--- End;
+-- EndOutput:
 
 
 -- Test: parses single var abstractions
 -- Input:
 Result: f(x)
+-- EndInput:
 -- Output:
 Result:
 . f(x)
--- End;
+-- EndOutput:
 
 
 -- Test: parses multi var abstractions
 -- Input:
 Result: f(x, y, z)
+-- EndInput:
 -- Output:
 Result:
 . f(x, y, z)
--- End;
+-- EndOutput:
 
 
 -- Test: parses names with ...
 -- Input:
 Result: abc...
+-- EndInput:
 -- Output:
 Result:
 . abc...
--- End;
+-- EndOutput:
 
 
 -- Test: parses nested names with ...
 -- Input:
 Result: f(abc...)
+-- EndInput:
 -- Output:
 Result:
 . f(abc...)
--- End;
+-- EndOutput:
+
+
+-- Test: parses abstractions with one sub param
+-- Input:
+Result:
+. for: a_n
+  then: b
+-- EndInput:
+-- Output(Phase1):
+Result:
+. for:
+  . a_n
+  then:
+  . b
+-- EndOutput(Phase1):
+-- Output(Phase2):
+Result:
+. for: a_n
+  then:
+  . b
+-- EndOutput(Phase2):
+
+
+-- Test: parses abstractions with multiple sub params
+-- Input:
+Result:
+. for: a_{x, y, z}
+  then: b
+-- EndInput:
+-- Output(Phase1):
+Result:
+. for:
+  . a_{x, y, z}
+  then:
+  . b
+-- EndOutput(Phase1):
+-- Output(Phase2):
+Result:
+. for: a_{x, y, z}
+  then:
+  . b
+-- EndOutput(Phase2):
+
+
+-- Test: parses abstractions with one sub param and multiple params
+-- Input:
+Result:
+. for: a_n(x, y)
+  then: b
+-- EndInput:
+-- Output(Phase1):
+Result:
+. for:
+  . a_n(x, y)
+  then:
+  . b
+-- EndOutput(Phase1):
+-- Output(Phase2):
+Result:
+. for: a_n(x, y)
+  then:
+  . b
+-- EndOutput(Phase2):
+
+
+-- Test: parses abstractions with multiple sub params and multiple params
+-- Input:
+Result:
+. for: a_{n, m}(x, y)
+  then: b
+-- EndInput:
+-- Output(Phase1):
+Result:
+. for:
+  . a_{n, m}(x, y)
+  then:
+  . b
+-- EndOutput(Phase1):
+-- Output(Phase2):
+Result:
+. for: a_{n, m}(x, y)
+  then:
+  . b
+-- EndOutput(Phase2):
+
+
+-- Test: parses abstractions with empty sub params and empty params
+-- Input:
+Result:
+. for: a_{}()
+  then: b
+-- EndInput:
+-- Output(Phase1):
+Result:
+. for:
+  . a_{}()
+  then:
+  . b
+-- EndOutput(Phase1):
+-- Output(Phase2):
+Result:
+. for: a_{}()
+  then:
+  . b
+-- EndOutput(Phase2):
+
+
+-- Test: parses abstractions with empty sub params and non-empty params
+-- Input:
+Result:
+. for: a_{}(x, y)
+  then: b
+-- EndInput:
+-- Output(Phase1):
+Result:
+. for:
+  . a_{}(x, y)
+  then:
+  . b
+-- EndOutput(Phase1):
+-- Output(Phase2):
+Result:
+. for: a_{}(x, y)
+  then:
+  . b
+-- EndOutput(Phase2):
+
+
+-- Test: parses abstractions with non-empty sub params and empty params
+-- Input:
+Result:
+. for: a_{n, m}()
+  then: b
+-- EndInput:
+-- Output(Phase1):
+Result:
+. for:
+  . a_{n, m}()
+  then:
+  . b
+-- EndOutput(Phase1):
+-- Output(Phase2):
+Result:
+. for: a_{n, m}()
+  then:
+  . b
+-- EndOutput(Phase2):

--- a/src/test/resources/golden-textalk.txt
+++ b/src/test/resources/golden-textalk.txt
@@ -2,190 +2,214 @@
 -- Test: parses identifiers
 -- Input:
 abc
+-- EndInput:
 -- Output:
 abc
--- End;
+-- EndOutput:
 
 
 -- Test: parses operators
 -- Input:
 **
+-- EndInput:
 -- Output:
 **
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command
 -- Input:
 \cos
+-- EndInput:
 -- Output:
 \cos
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command with {}
 -- Input:
 \cos{x}
+-- EndInput:
 -- Output:
 \cos{x}
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command with ()
 -- Input:
 \cos(x)
+-- EndInput:
 -- Output:
 \cos(x)
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command with {} and multi args
 -- Input:
 \cos{x, y, z}
+-- EndInput:
 -- Output:
 \cos{x, y, z}
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command with []
 -- Input:
 \cos[x]
+-- EndInput:
 -- Output:
 \cos[x]
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command with [] and {}
 -- Input:
 \cos[x]{a}
+-- EndInput:
 -- Output:
 \cos[x]{a}
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command with [] and multi args
 -- Input:
 \cos[x, y, z]
+-- EndInput:
 -- Output:
 \cos[x, y, z]
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command with [] and {} and multi args
 -- Input:
 \cos[x, y, z]{a, b, c}
+-- EndInput:
 -- Output:
 \cos[x, y, z]{a, b, c}
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command with [] and multi args and sub-sup
 -- Input:
 \cos[x, y, z]_{a}^{b}
+-- EndInput:
 -- Output:
 \cos[x, y, z]_{a}^{b}
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command with [] and multi args and sub-sup and {}
 -- Input:
 \cos[x, y, z]_{a}^{b}{x}
+-- EndInput:
 -- Output:
 \cos[x, y, z]_{a}^{b}{x}
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command with [] and multi args and sub-sup and ()
 -- Input:
 \cos[x, y, z]_{a}^{b}(x)
+-- EndInput:
 -- Output:
 \cos[x, y, z]_{a}^{b}(x)
--- End;
+-- EndOutput:
 
 
 -- Test: parses single name command with [] and multi args and sub-sup and () and multi args
 -- Input:
 \cos[x, y, z]_{a}^{b}(x, y, z)
+-- EndInput:
 -- Output:
 \cos[x, y, z]_{a}^{b}(x, y, z)
--- End;
+-- EndOutput:
 
 
 -- Test: parses compound name command
 -- Input:
 \some.compound.name
+-- EndInput:
 -- Output:
 \some.compound.name
--- End;
+-- EndOutput:
 
 
 -- Test: parses complex compound name
 -- Input:
 \some[x]_{a}^{b}{x}.compound.name(x).function[x]{a, b}
+-- EndInput:
 -- Output:
 \some[x]_{a}^{b}{x}.compound.name(x).function[x]{a, b}
--- End;
+-- EndOutput:
 
 
 -- Test: parses simple is statements
 -- Input:
 a is b
+-- EndInput:
 -- Output:
 a is b
--- End;
+-- EndOutput:
 
 
 -- Test: parses multi is statements
 -- Input:
 a, b, c is x, y, z
+-- EndInput:
 -- Output:
 a, b, c is x, y, z
--- End;
+-- EndOutput:
 
 
 -- Test: parses is statements with commands
 -- Input:
 x is \set
+-- EndInput:
 -- Output:
 x is \set
--- End;
+-- EndOutput:
 
 
 -- Test: parses is statements with multi commands
 -- Input:
 x is \compact \convex \set
+-- EndInput:
 -- Output:
 x is \compact \convex \set
--- End;
+-- EndOutput:
 
 
 -- Test: parses expressions
 -- Input:
 a + b^2 + \sin(x) - \frac{x}{y}
+-- EndInput:
 -- Output:
 a + b ^ 2 + \sin(x) - \frac{x}{y}
--- End;
+-- EndOutput:
 
 
 -- Test: parses expressions with parens
 -- Input:
 f(x + 2*(x + y)^2) + (a + b)/2
+-- EndInput:
 -- Output:
 f (x + 2 * (x + y) ^ 2) + (a + b) / 2
--- End;
+-- EndOutput:
 
 
 -- Test: handles varargs in identifiers
 -- Input:
 xyz... := f(abc... + x)
+-- EndInput:
 -- Output:
 xyz... := f (abc... + x)
--- End;
+-- EndOutput:
 
 
 -- Test: handles varargs in groups
 -- Input:
 \f{x}{y}...
+-- EndInput:
 -- Output:
 \f{x}{y}...
--- End;
+-- EndOutput:


### PR DESCRIPTION
The following new syntax for abstractions is supported
in chalktalk:
```
a_n
a_n()
a_n(x,y)

a_{n,m}
a_{n,m}()
a_{n,m}(x,y)
```