### PR TITLE
feat: support textalk single sub/sup params

### DIFF
--- a/src/main/kotlin/mathlingua/common/textalk/Ast.kt
+++ b/src/main/kotlin/mathlingua/common/textalk/Ast.kt
@@ -366,12 +366,24 @@ data class SubSupTexTalkNode(
         val builder = StringBuilder()
         if (sub != null) {
             builder.append("_")
-            builder.append(sub.toCode(interceptor))
+            if (sub.parameters.items.size == 1 &&
+                    sub.parameters.items[0].children.size == 1 &&
+                    sub.parameters.items[0].children[0].type == TexTalkNodeType.Identifier) {
+                builder.append(sub.parameters.items[0].children[0].toCode(interceptor))
+            } else {
+                builder.append(sub.toCode(interceptor))
+            }
         }
 
         if (sup != null) {
             builder.append("^")
-            builder.append(sup.toCode(interceptor))
+            if (sup.parameters.items.size == 1 &&
+                    sup.parameters.items[0].children.size == 1 &&
+                    sup.parameters.items[0].children[0].type == TexTalkNodeType.Identifier) {
+                builder.append(sup.parameters.items[0].children[0].toCode(interceptor))
+            } else {
+                builder.append(sup.toCode(interceptor))
+            }
         }
         return builder.toString()
     }

--- a/src/main/kotlin/mathlingua/common/textalk/TexTalkParser.kt
+++ b/src/main/kotlin/mathlingua/common/textalk/TexTalkParser.kt
@@ -221,9 +221,32 @@ class TexTalkParserImpl : TexTalkParser {
             val (_, _, row, column) = expect(TexTalkTokenType.Underscore)
 
             var grp: GroupTexTalkNode? = null
-            val curly = group(TexTalkNodeType.CurlyGroup)
-            if (curly != null) {
-                grp = curly
+            if (has(TexTalkTokenType.Identifier)) {
+                val id = next()
+                grp = GroupTexTalkNode(
+                        type = TexTalkNodeType.CurlyGroup,
+                        parameters = ParametersTexTalkNode(
+                                items = listOf(
+                                        ExpressionTexTalkNode(
+                                                children = listOf(
+                                                        TextTexTalkNode(
+                                                                type = TexTalkNodeType.Identifier,
+                                                                text = id.text,
+                                                                isVarArg = false
+                                                        )
+                                                )
+                                        )
+                                )
+                        ),
+                        isVarArg = false
+                )
+            }
+
+            if (grp == null) {
+                val curly = group(TexTalkNodeType.CurlyGroup)
+                if (curly != null) {
+                    grp = curly
+                }
             }
 
             if (grp == null) {
@@ -247,11 +270,34 @@ class TexTalkParserImpl : TexTalkParser {
             }
 
             val (_, _, row, column) = expect(TexTalkTokenType.Caret)
-            var grp: GroupTexTalkNode? = null
 
-            val curly = group(TexTalkNodeType.CurlyGroup)
-            if (curly != null) {
-                grp = curly
+            var grp: GroupTexTalkNode? = null
+            if (has(TexTalkTokenType.Identifier)) {
+                val id = next()
+                grp = GroupTexTalkNode(
+                        type = TexTalkNodeType.CurlyGroup,
+                        parameters = ParametersTexTalkNode(
+                                items = listOf(
+                                        ExpressionTexTalkNode(
+                                                children = listOf(
+                                                        TextTexTalkNode(
+                                                                type = TexTalkNodeType.Identifier,
+                                                                text = id.text,
+                                                                isVarArg = false
+                                                        )
+                                                )
+                                        )
+                                )
+                        ),
+                        isVarArg = false
+                )
+            }
+
+            if (grp == null) {
+                val curly = group(TexTalkNodeType.CurlyGroup)
+                if (curly != null) {
+                    grp = curly
+                }
             }
 
             if (grp == null) {

--- a/src/test/kotlin/mathlingua/common/textalk/TexTalkParserTest.kt
+++ b/src/test/kotlin/mathlingua/common/textalk/TexTalkParserTest.kt
@@ -37,6 +37,9 @@ internal class TexTalkParserTest {
 
                 val parser = newTexTalkParser()
                 val result = parser.parse(lexer)
+                for (err in result.errors) {
+                    println("ERROR: $err")
+                }
                 assertThat(result.errors.size).isEqualTo(0)
                 assertThat(result.root).isNotNull()
 

--- a/src/test/resources/golden-textalk.txt
+++ b/src/test/resources/golden-textalk.txt
@@ -94,7 +94,7 @@ abc
 \cos[x, y, z]_{a}^{b}
 -- EndInput:
 -- Output:
-\cos[x, y, z]_{a}^{b}
+\cos[x, y, z]_a^b
 -- EndOutput:
 
 
@@ -103,7 +103,7 @@ abc
 \cos[x, y, z]_{a}^{b}{x}
 -- EndInput:
 -- Output:
-\cos[x, y, z]_{a}^{b}{x}
+\cos[x, y, z]_a^b{x}
 -- EndOutput:
 
 
@@ -112,7 +112,7 @@ abc
 \cos[x, y, z]_{a}^{b}(x)
 -- EndInput:
 -- Output:
-\cos[x, y, z]_{a}^{b}(x)
+\cos[x, y, z]_a^b(x)
 -- EndOutput:
 
 
@@ -121,7 +121,7 @@ abc
 \cos[x, y, z]_{a}^{b}(x, y, z)
 -- EndInput:
 -- Output:
-\cos[x, y, z]_{a}^{b}(x, y, z)
+\cos[x, y, z]_a^b(x, y, z)
 -- EndOutput:
 
 
@@ -139,7 +139,34 @@ abc
 \some[x]_{a}^{b}{x}.compound.name(x).function[x]{a, b}
 -- EndInput:
 -- Output:
-\some[x]_{a}^{b}{x}.compound.name(x).function[x]{a, b}
+\some[x]_a^b{x}.compound.name(x).function[x]{a, b}
+-- EndOutput:
+
+
+-- Test: parses commands with a single bare sub param
+-- Input:
+\some[x]_a
+-- EndInput:
+-- Output:
+\some[x]_a
+-- EndOutput:
+
+
+-- Test: parses commands with a single bare sup param
+-- Input:
+\some[x]^a
+-- EndInput:
+-- Output:
+\some[x]^a
+-- EndOutput:
+
+
+-- Test: parses commands with a single bare sub param and a single bare sup param
+-- Input:
+\some[x]_a^b
+-- EndInput:
+-- Output:
+\some[x]_a^b
 -- EndOutput:
 
 


### PR DESCRIPTION
Now if a sub or a sup part of a command consists of only a
single identifier, curly braces do not need to be placed around
it.

That is, previously `a_{b}` would parse, but `a_b` would not.
Now, they are both supported.

In addition the `toCode` method does not print curly braces around
a sub or sup part of a command if and only if it contains a single
identifier.

That is, if `a_{b}` is parsed, and the `toCode` method is called
on the result, the output will be `a_b`.