### PR TITLE
chore: use flattened signatures

### DIFF
--- a/src/main/kotlin/mathlingua/common/MathLingua.kt
+++ b/src/main/kotlin/mathlingua/common/MathLingua.kt
@@ -47,7 +47,7 @@ class MathLingua {
     }
 
     fun signatureOf(group: TopLevelGroup) = getSignature(group)
-    fun signatureOf(command: Command) = getCommandSignature(command).toCode()
+    fun signatureOf(command: Command) = getCommandSignature(command)
 
     fun findAllCommands(node: Phase2Node) = locateAllCommands(node).toList().toTypedArray()
 

--- a/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
@@ -64,7 +64,7 @@ fun replaceSignatures(
     signature: String,
     replacement: String
 ) = texTalkNode.transform {
-    if (it is Command && getCommandSignature(it).toCode() == signature) {
+    if (it is Command && getCommandSignature(it) == signature) {
         TextTexTalkNode(type = TexTalkNodeType.Identifier, text = replacement, isVarArg = false)
     } else {
         texTalkNode

--- a/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
@@ -42,7 +42,7 @@ fun moveInlineCommandsToIsNode(
 ): RootTarget<Phase2Node, Phase2Node> {
     val knownDefSigs = defs.map { it.signature }.filterNotNull().toSet()
     fun realShouldProcessTex(root: TexTalkNode, node: TexTalkNode): Boolean {
-        if (node is Command && !knownDefSigs.contains(getCommandSignature(node).toCode())) {
+        if (node is Command && !knownDefSigs.contains(getCommandSignature(node))) {
             return false
         }
 
@@ -240,7 +240,7 @@ fun replaceRepresents(
             ) {
                 // a prefix command
                 val command = clause.texTalkRoot.value.children[0] as Command
-                val sig = getCommandSignature(command).toCode()
+                val sig = getCommandSignature(command)
 
                 if (!repMap.containsKey(sig)) {
                     return node
@@ -273,7 +273,7 @@ fun replaceRepresents(
                 val op = clause.texTalkRoot.value.children[1] as Command
                 val right = clause.texTalkRoot.value.children[2] as TextTexTalkNode
 
-                val sig = getCommandSignature(op).toCode()
+                val sig = getCommandSignature(op)
 
                 if (!repMap.containsKey(sig)) {
                     return node
@@ -379,7 +379,7 @@ fun replaceIsNodes(
             }
 
             val command = isNode.rhs.items[0].children[0] as Command
-            val sig = getCommandSignature(command).toCode()
+            val sig = getCommandSignature(command)
 
             if (!defMap.containsKey(sig)) {
                 newClauses.add(c)

--- a/src/main/kotlin/mathlingua/common/transform/VarUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/VarUtil.kt
@@ -133,7 +133,7 @@ private fun getVarsImpl(
 
 private fun getVarsImpl(texTalkNode: TexTalkNode, vars: MutableList<String>, inParams: Boolean) {
     if (inParams && texTalkNode is TextTexTalkNode) {
-        vars.add(texTalkNode.text)
+        vars.add(texTalkNode.text + if (texTalkNode.isVarArg) { "..." } else { "" })
     } else if (texTalkNode is ParametersTexTalkNode) {
         texTalkNode.forEach { getVarsImpl(it, vars, true) }
     } else {

--- a/src/main/kotlin/mathlingua/jvm/TexTalkPlayground.kt
+++ b/src/main/kotlin/mathlingua/jvm/TexTalkPlayground.kt
@@ -91,7 +91,7 @@ object TexTalkPlayground {
                         val sigBuilder = StringBuilder()
                         for (node in root.children) {
                             if (node is Command) {
-                                val sig = getCommandSignature(node).toCode()
+                                val sig = getCommandSignature(node)
                                 sigBuilder.append(sig)
                                 sigBuilder.append('\n')
                             }

--- a/src/test/kotlin/mathlingua/common/transform/SignatureUtilKtTest.kt
+++ b/src/test/kotlin/mathlingua/common/transform/SignatureUtilKtTest.kt
@@ -31,7 +31,7 @@ internal class SignatureUtilKtTest {
         val def = doc.defines[0]
         val stmt = def.id.toStatement()
         val signatures = findAllStatementSignatures(stmt)
-        assertThat(signatures).isEqualTo(setOf("\\xyz{?}"))
+        assertThat(signatures).isEqualTo(setOf("\\xyz{}"))
     }
 
     @Test
@@ -42,7 +42,7 @@ internal class SignatureUtilKtTest {
         val def = doc.defines[0]
         val stmt = def.id.toStatement()
         val signatures = findAllStatementSignatures(stmt)
-        assertThat(signatures).isEqualTo(setOf("\\abc.xyz{?}"))
+        assertThat(signatures).isEqualTo(setOf("\\abc.xyz{}"))
     }
 
     @Test


### PR DESCRIPTION
Now a command such as `\f[x, y]{a, b}` has a signature
`\f[]{}` instead of `\f[?,?]{?,?}`.  In addition, the command
`\f{x, y}{a, b}{c}...` has a signature `\f{}...`.  This is
done to easily support variadic arguments and groups.

In particular, commands are distinguished by their names and
shape (number of [] and {} groups and whether they contain a
variadic group {}...) instead of by all of those features as
well as the number of arguments in each group.