### PR TITLE
fix: fix a small error in ExpressionNode.toCode

### DIFF
--- a/src/main/kotlin/mathlingua/common/textalk/Ast.kt
+++ b/src/main/kotlin/mathlingua/common/textalk/Ast.kt
@@ -208,8 +208,12 @@ data class ExpressionTexTalkNode(val children: List<TexTalkNode>) : TexTalkNode 
         get() = TexTalkNodeType.Expression
 
     override fun toCode(interceptor: (node: TexTalkNode) -> String?): String {
+        val res = interceptor(this)
+        if (res != null) {
+            return res
+        }
+
         val builder = StringBuilder()
-        val children = children
         for (i in children.indices) {
             val child = children[i]
             builder.append(child.toCode(interceptor))


### PR DESCRIPTION
The interceptor given to `toCode` was incorrectly not invoked on
the ExpressionNode iteself.  As a result, interceptors could not
intercept the work of toCode at the ExpressionNode level.