### PR TITLE
feat!: abstractions can be enclosed in {...}

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexer.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexer.kt
@@ -96,6 +96,28 @@ private class ChalkTalkLexerImpl(private var text: String) :
                 this.chalkTalkTokens!!.add(
                     Phase1Token(")", ChalkTalkTokenType.RParen, line, column)
                 )
+            } else if (c == '{' && i < text.length && text[i] == ':') {
+                this.chalkTalkTokens!!.add(
+                        Phase1Token(
+                            "{:",
+                            ChalkTalkTokenType.LCurlyColon,
+                            line,
+                            column
+                        )
+                )
+                i++ // move past the :
+                column++
+            } else if (c == ':' && i < text.length && text[i] == '}') {
+                this.chalkTalkTokens!!.add(
+                        Phase1Token(
+                                ":}",
+                                ChalkTalkTokenType.RColonCurly,
+                                line,
+                                column
+                        )
+                )
+                i++ // move past the }
+                column++
             } else if (c == '{') {
                 this.chalkTalkTokens!!.add(
                     Phase1Token("{", ChalkTalkTokenType.LCurly, line, column)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkParser.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkParser.kt
@@ -221,21 +221,28 @@ private class ChalkTalkParserImpl : ChalkTalkParser {
         }
 
         private fun aggregate(): Aggregate? {
-            if (!has(ChalkTalkTokenType.LCurly)) {
+            if (!has(ChalkTalkTokenType.LCurlyColon)) {
                 return null
             }
 
-            expect(ChalkTalkTokenType.LCurly)
-            val names = nameList(ChalkTalkTokenType.RCurly)
-            expect(ChalkTalkTokenType.RCurly)
+            expect(ChalkTalkTokenType.LCurlyColon)
+            val names = nameList(ChalkTalkTokenType.RColonCurly)
+            expect(ChalkTalkTokenType.RColonCurly)
 
             return Aggregate(names)
         }
 
         private fun abstraction(): Abstraction? {
             if (!hasHas(ChalkTalkTokenType.Name, ChalkTalkTokenType.LParen) &&
-                !hasHas(ChalkTalkTokenType.Name, ChalkTalkTokenType.Underscore)) {
+                !hasHas(ChalkTalkTokenType.Name, ChalkTalkTokenType.Underscore) &&
+                !has(ChalkTalkTokenType.LCurly)) {
                 return null
+            }
+
+            var isEnclosed = false
+            if (has(ChalkTalkTokenType.LCurly)) {
+                isEnclosed = true
+                next()
             }
 
             val id = expect(ChalkTalkTokenType.Name)
@@ -259,7 +266,11 @@ private class ChalkTalkParserImpl : ChalkTalkParser {
                 expect(ChalkTalkTokenType.RParen)
             }
 
-            return Abstraction(id, subParams, names)
+            if (isEnclosed) {
+                expect(ChalkTalkTokenType.RCurly)
+            }
+
+            return Abstraction(isEnclosed, id, subParams, names)
         }
 
         private fun name(): Phase1Token {

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ast/Phase1Target.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ast/Phase1Target.kt
@@ -34,6 +34,8 @@ enum class ChalkTalkTokenType {
     RParen,
     LCurly,
     RCurly,
+    LCurlyColon,
+    RColonCurly,
     Underscore
 }
 
@@ -153,6 +155,7 @@ data class Tuple(val items: List<TupleItem>) : AssignmentRhs() {
 }
 
 data class Abstraction(
+    val isEnclosed: Boolean,
     val name: Phase1Token,
     val subParams: List<Phase1Token>?,
     val params: List<Phase1Token>?
@@ -166,6 +169,9 @@ data class Abstraction(
 
     override fun toCode(): String {
         val builder = StringBuilder()
+        if (isEnclosed) {
+            builder.append('{')
+        }
         builder.append(name.toCode())
         if (subParams != null) {
             builder.append('_')
@@ -194,12 +200,17 @@ data class Abstraction(
             builder.append(')')
         }
 
+        if (isEnclosed) {
+            builder.append('}')
+        }
+
         return builder.toString()
     }
 
     override fun resolve() = this
 
     override fun transform(transformer: (node: Phase1Node) -> Phase1Node) = transformer(Abstraction(
+        isEnclosed = isEnclosed,
         name = name.transform(transformer) as Phase1Token,
         subParams = subParams?.map { it.transform(transformer) as Phase1Token },
         params = params?.map { it.transform(transformer) as Phase1Token }
@@ -212,14 +223,14 @@ data class Aggregate(val params: List<Phase1Token>) : AssignmentRhs() {
 
     override fun toCode(): String {
         val builder = StringBuilder()
-        builder.append('{')
+        builder.append("{:")
         for (i in params.indices) {
             builder.append(params[i].toCode())
             if (i != params.size - 1) {
                 builder.append(", ")
             }
         }
-        builder.append('}')
+        builder.append(":}")
         return builder.toString()
     }
 

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Document.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Document.kt
@@ -320,14 +320,14 @@ fun prettyPrintIdentifier(text: String): String {
 open class HtmlCodeWriter : CodeWriter {
     protected val builder = StringBuilder()
 
-        override fun append(node: Phase2Node, hasDot: Boolean, indent: Int) {
-            builder.append(node.toCode(hasDot, indent, newCodeWriter()).getCode())
-        }
+    override fun append(node: Phase2Node, hasDot: Boolean, indent: Int) {
+        builder.append(node.toCode(hasDot, indent, newCodeWriter()).getCode())
+    }
 
-        override fun writeHeader(header: String) {
-            builder.append("<span class='mathlingua-header'>")
-            builder.append(header)
-            builder.append(':')
+    override fun writeHeader(header: String) {
+        builder.append("<span class='mathlingua-header'>")
+        builder.append(header)
+        builder.append(':')
         builder.append("</span>")
     }
 

--- a/src/main/resources/mathlingua.txt
+++ b/src/main/resources/mathlingua.txt
@@ -29,7 +29,7 @@ Metadata:
 
 
 [\set[x...]{form...}{condition}...]
-Defines: A := {a...}
+Defines: A := {: a... :}
 means:
 . 'a... := form...'
 . 'condition'
@@ -102,7 +102,7 @@ Metadata:
 
 
 [A \union B]
-Defines: C := {c}
+Defines: C := {:c:}
 assuming: 'A, B is \set'
 means:
 . 'C is \set'
@@ -118,7 +118,7 @@ Metadata:
 
 
 [A \intersect B]
-Defines: C := {c}
+Defines: C := {:c:}
 assuming: 'A, B is \set'
 means:
 . 'C is \set'
@@ -155,7 +155,7 @@ Metadata:
 
 
 [\complement:of{A}in{U}]
-Defines: X := {x}
+Defines: X := {:x:}
 assuming: 'A, U is \set'
 means:
 . 'x \in U'
@@ -169,7 +169,7 @@ Metadata:
 
 
 [A \set.difference B]
-Defines: C := {c}
+Defines: C := {:c:}
 assuming: 'A, B is \set'
 means:
 . 'c \in A'
@@ -183,7 +183,7 @@ Metadata:
 
 
 [A \set.cartesian.product B]
-Defines: C := {x,y}
+Defines: C := {:x,y:}
 assuming: 'A, B is \set'
 means:
 . 'x \in A'
@@ -332,7 +332,7 @@ Metadata:
 
 
 [\equivalence.relation:on{X}]
-Defines: R := {a, b}
+Defines: R := {:a, b:}
 assuming: 'X is \set'
 means:
 . 'R \subset (X \set.cartesian.product X)'

--- a/src/test/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexerTest.kt
+++ b/src/test/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexerTest.kt
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test
 internal class ChalkTalkLexerTest {
     @Test
     fun `correctly identifies tokens`() {
-        val text = "someName:'some statement'\"some text\". [some id],:=$1 #2 abc...xyz_"
+        val text = "someName:'some statement'\"some text\". [some id],:=$1 #2 abc...xyz_{::}"
         val lexer = newChalkTalkLexer(text)
         val actual: MutableList<Phase1Token> = ArrayList()
         while (lexer.hasNext()) {
@@ -51,6 +51,8 @@ internal class ChalkTalkLexerTest {
             Phase1Token(text = "abc...", type = ChalkTalkTokenType.Name, row = 0, column = 56),
             Phase1Token(text = "xyz", type = ChalkTalkTokenType.Name, row = 0, column = 62),
             Phase1Token(text = "_", type = ChalkTalkTokenType.Underscore, row = 0, column = 65),
+            Phase1Token(text = "{:", type = ChalkTalkTokenType.LCurlyColon, row = 0, column = 66),
+            Phase1Token(text = ":}", type = ChalkTalkTokenType.RColonCurly, row = 0, column = 68),
             Phase1Token(text = "<Indent>", type = ChalkTalkTokenType.Begin, row = 1, column = 0),
             Phase1Token(text = "<Unindent>", type = ChalkTalkTokenType.End, row = 1, column = 0)
         )

--- a/src/test/resources/golden-chalktalk.txt
+++ b/src/test/resources/golden-chalktalk.txt
@@ -104,6 +104,69 @@ Result:
 -- EndOutput:
 
 
+-- Test: parses enclosed plain abstractions
+-- Input:
+Result:
+. for: {f}
+  then: x
+-- EndInput:
+-- Output(Phase1):
+Result:
+. for:
+  . {f}
+  then:
+  . x
+-- EndOutput(Phase1):
+-- Output(Phase2):
+Result:
+. for: {f}
+  then:
+  . x
+-- EndOutput(Phase2):
+
+
+-- Test: parses enclosed regular abstractions
+-- Input:
+Result:
+. for: {f(x)}
+  then: x
+-- EndInput:
+-- Output(Phase1):
+Result:
+. for:
+  . {f(x)}
+  then:
+  . x
+-- EndOutput(Phase1):
+-- Output(Phase2):
+Result:
+. for: {f(x)}
+  then:
+  . x
+-- EndOutput(Phase2):
+
+
+-- Test: parses enclosed abstractions with sub params
+-- Input:
+Result:
+. for: {a_i}
+  then: x
+-- EndInput:
+-- Output(Phase1):
+Result:
+. for:
+  . {a_i}
+  then:
+  . x
+-- EndOutput(Phase1):
+-- Output(Phase2):
+Result:
+. for: {a_i}
+  then:
+  . x
+-- EndOutput(Phase2):
+
+
 -- Test: parses names with ...
 -- Input:
 Result: abc...


### PR DESCRIPTION
This is used to indicate that the abstraction represents something
that can be indexed such as a sequence.

Also, now `{:x:}` is used to denote an abstraction instead of `{x}`.