### PR TITLE
feat!: remove abstractions

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexer.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexer.kt
@@ -96,28 +96,6 @@ private class ChalkTalkLexerImpl(private var text: String) :
                 this.chalkTalkTokens!!.add(
                     Phase1Token(")", ChalkTalkTokenType.RParen, line, column)
                 )
-            } else if (c == '{' && i < text.length && text[i] == ':') {
-                this.chalkTalkTokens!!.add(
-                        Phase1Token(
-                            "{:",
-                            ChalkTalkTokenType.LCurlyColon,
-                            line,
-                            column
-                        )
-                )
-                i++ // move past the :
-                column++
-            } else if (c == ':' && i < text.length && text[i] == '}') {
-                this.chalkTalkTokens!!.add(
-                        Phase1Token(
-                                ":}",
-                                ChalkTalkTokenType.RColonCurly,
-                                line,
-                                column
-                        )
-                )
-                i++ // move past the }
-                column++
             } else if (c == '{') {
                 this.chalkTalkTokens!!.add(
                     Phase1Token("{", ChalkTalkTokenType.LCurly, line, column)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ast/Ast.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ast/Ast.kt
@@ -63,11 +63,6 @@ data class Argument(val chalkTalkTarget: Phase1Target) : Phase1Node {
                 buffer.append(chalkTalkTarget.toCode())
                 buffer.append("\n")
             }
-            is Aggregate -> {
-                buffer.append(buildIndent(level, true))
-                buffer.append(chalkTalkTarget.toCode())
-                buffer.append("\n")
-            }
             is Assignment -> {
                 buffer.append(buildIndent(level, true))
                 buffer.append(chalkTalkTarget.toCode())

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Clause.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Clause.kt
@@ -21,7 +21,6 @@ import mathlingua.common.Validation
 import mathlingua.common.ValidationFailure
 import mathlingua.common.ValidationSuccess
 import mathlingua.common.chalktalk.phase1.ast.Abstraction
-import mathlingua.common.chalktalk.phase1.ast.Aggregate
 import mathlingua.common.chalktalk.phase1.ast.Assignment
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase1.ast.Phase1Token
@@ -45,10 +44,6 @@ private val CLAUSE_VALIDATORS = listOf(
     ValidationPair(
         ::isAbstraction,
         ::validateAbstractionNode
-    ),
-    ValidationPair(
-        ::isAggregate,
-        ::validateAggregateNode
     ),
     ValidationPair(
         ::isTuple,
@@ -141,26 +136,6 @@ fun validateAbstractionNode(node: Phase1Node) = validateWrappedNode(node,
     "AbstractionNode",
     { it as? Abstraction },
     ::AbstractionNode
-)
-
-data class AggregateNode(
-    val aggregate: Aggregate,
-    override var row: Int,
-    override var column: Int
-) : Target() {
-    override fun forEach(fn: (node: Phase2Node) -> Unit) {}
-
-    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) = toCode(writer, isArg, indent, aggregate)
-
-    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
-}
-
-fun isAggregate(node: Phase1Node) = node is Aggregate
-
-fun validateAggregateNode(node: Phase1Node) = validateWrappedNode(node,
-    "AggregateNode",
-    { it as? Aggregate },
-    ::AggregateNode
 )
 
 data class TupleNode(

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/Section.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/Section.kt
@@ -26,7 +26,6 @@ private fun canBeOnOneLine(target: Target) =
         target is Identifier ||
         target is TupleNode ||
         target is AbstractionNode ||
-        target is AggregateNode ||
         target is AssignmentNode
 
 private fun appendTargetArgs(writer: CodeWriter, targets: List<Target>, indent: Int) {

--- a/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
@@ -415,9 +415,11 @@ fun replaceIsNodes(
                         }
                     }
                     is AbstractionNode -> {
-                        val name = v.abstraction.name.text
-                        if (!forVarMap.containsKey(name)) {
-                            forVarMap[name] = v
+                        for (part in v.abstraction.parts) {
+                            val name = part.name.text
+                            if (!forVarMap.containsKey(name)) {
+                                forVarMap[name] = v
+                            }
                         }
                     }
                     is Identifier -> {

--- a/src/main/kotlin/mathlingua/common/transform/VarUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/VarUtil.kt
@@ -21,7 +21,6 @@ import mathlingua.common.ValidationSuccess
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase1.ast.Phase1Token
 import mathlingua.common.chalktalk.phase2.AbstractionNode
-import mathlingua.common.chalktalk.phase2.AggregateNode
 import mathlingua.common.chalktalk.phase2.AssignmentNode
 import mathlingua.common.chalktalk.phase2.Identifier
 import mathlingua.common.chalktalk.phase2.Phase2Node
@@ -119,8 +118,6 @@ private fun getVarsImpl(
         vars.add(node.name)
     } else if (node is TupleNode) {
         getVarsImpl(node.tuple, vars)
-    } else if (node is AggregateNode) {
-        getVarsImpl(node.aggregate, vars)
     } else if (node is AbstractionNode) {
         getVarsImpl(node.abstraction, vars)
     } else if (node is AssignmentNode) {

--- a/src/main/resources/mathlingua.txt
+++ b/src/main/resources/mathlingua.txt
@@ -29,7 +29,7 @@ Metadata:
 
 
 [\set[x...]{form...}{condition}...]
-Defines: A := {: a... :}
+Defines: A := {a...}
 means:
 . 'a... := form...'
 . 'condition'
@@ -102,7 +102,7 @@ Metadata:
 
 
 [A \union B]
-Defines: C := {:c:}
+Defines: C := {c}
 assuming: 'A, B is \set'
 means:
 . 'C is \set'
@@ -118,7 +118,7 @@ Metadata:
 
 
 [A \intersect B]
-Defines: C := {:c:}
+Defines: C := {c}
 assuming: 'A, B is \set'
 means:
 . 'C is \set'
@@ -155,7 +155,7 @@ Metadata:
 
 
 [\complement:of{A}in{U}]
-Defines: X := {:x:}
+Defines: X := {x}
 assuming: 'A, U is \set'
 means:
 . 'x \in U'
@@ -169,7 +169,7 @@ Metadata:
 
 
 [A \set.difference B]
-Defines: C := {:c:}
+Defines: C := {c}
 assuming: 'A, B is \set'
 means:
 . 'c \in A'
@@ -183,7 +183,7 @@ Metadata:
 
 
 [A \set.cartesian.product B]
-Defines: C := {:x,y:}
+Defines: C := {x,y}
 assuming: 'A, B is \set'
 means:
 . 'x \in A'
@@ -332,7 +332,7 @@ Metadata:
 
 
 [\equivalence.relation:on{X}]
-Defines: R := {:a, b:}
+Defines: R := {a, b}
 assuming: 'X is \set'
 means:
 . 'R \subset (X \set.cartesian.product X)'

--- a/src/test/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexerTest.kt
+++ b/src/test/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexerTest.kt
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test
 internal class ChalkTalkLexerTest {
     @Test
     fun `correctly identifies tokens`() {
-        val text = "someName:'some statement'\"some text\". [some id],:=$1 #2 abc...xyz_{::}"
+        val text = "someName:'some statement'\"some text\". [some id],:=$1 #2 abc...xyz_"
         val lexer = newChalkTalkLexer(text)
         val actual: MutableList<Phase1Token> = ArrayList()
         while (lexer.hasNext()) {
@@ -51,8 +51,6 @@ internal class ChalkTalkLexerTest {
             Phase1Token(text = "abc...", type = ChalkTalkTokenType.Name, row = 0, column = 56),
             Phase1Token(text = "xyz", type = ChalkTalkTokenType.Name, row = 0, column = 62),
             Phase1Token(text = "_", type = ChalkTalkTokenType.Underscore, row = 0, column = 65),
-            Phase1Token(text = "{:", type = ChalkTalkTokenType.LCurlyColon, row = 0, column = 66),
-            Phase1Token(text = ":}", type = ChalkTalkTokenType.RColonCurly, row = 0, column = 68),
             Phase1Token(text = "<Indent>", type = ChalkTalkTokenType.Begin, row = 1, column = 0),
             Phase1Token(text = "<Unindent>", type = ChalkTalkTokenType.End, row = 1, column = 0)
         )


### PR DESCRIPTION
Instead `Abstraction`s can be used for aggregate like objects such
as sets or classes.  To support this, an `Abstraction` contains a
list of one or more `AbstractionPart`s.