### PR TITLE
chore: remove plugin versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,9 @@ buildscript {
 
 plugins {
     // for improved test output
-    id "com.adarshr.test-logger" version "1.7.0"
-    id "org.jlleitschuh.gradle.ktlint" version "8.2.0"
-    id "org.jlleitschuh.gradle.ktlint-idea" version "8.2.0"
+    id "com.adarshr.test-logger"
+    id "org.jlleitschuh.gradle.ktlint"
+    id "org.jlleitschuh.gradle.ktlint-idea"
 }
 
 apply plugin: 'kotlin'


### PR DESCRIPTION
Explicit plugin versions have been removed to support gradle
projects with subprojects.