### PR TITLE
chore: use explicit plugin versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,9 @@ buildscript {
 
 plugins {
     // for improved test output
-    id "com.adarshr.test-logger"
-    id "org.jlleitschuh.gradle.ktlint"
-    id "org.jlleitschuh.gradle.ktlint-idea"
+    id "com.adarshr.test-logger" version "1.7.0"
+    id "org.jlleitschuh.gradle.ktlint" version "8.2.0"
+    id "org.jlleitschuh.gradle.ktlint-idea" version "8.2.0"
 }
 
 apply plugin: 'kotlin'


### PR DESCRIPTION
The plugins used in the build.gradle file need to have explicit
version number specified.  Otherwise, the build will fail.