### PR TITLE
feat: the chalktalk ast is immutable

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/Phase2Node.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/Phase2Node.kt
@@ -20,8 +20,6 @@ import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.MathLinguaCodeWriter
 
 interface Phase2Node {
-    var row: Int
-    var column: Int
     fun forEach(fn: (node: Phase2Node) -> Unit)
     fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter = MathLinguaCodeWriter()): CodeWriter
     fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node): Phase2Node

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/AbstractionNode.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/AbstractionNode.kt
@@ -16,16 +16,13 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Abstraction
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 
-data class AbstractionNode(
-    val abstraction: Abstraction,
-    override var row: Int,
-    override var column: Int
-) : Target {
+data class AbstractionNode(val abstraction: Abstraction) : Target {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
@@ -36,7 +33,9 @@ data class AbstractionNode(
 
 fun isAbstraction(node: Phase1Node) = node is Abstraction
 
-fun validateAbstractionNode(node: Phase1Node) = validateWrappedNode(node,
+fun validateAbstractionNode(node: Phase1Node, tracker: MutableLocationTracker) = validateWrappedNode(
+        tracker,
+        node,
         "AbstractionNode",
         { it as? Abstraction },
         ::AbstractionNode

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/AssignmentNode.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/AssignmentNode.kt
@@ -16,16 +16,13 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Assignment
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 
-data class AssignmentNode(
-    val assignment: Assignment,
-    override var row: Int,
-    override var column: Int
-) : Target {
+data class AssignmentNode(val assignment: Assignment) : Target {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) = toCode(writer, isArg, indent, assignment)
@@ -35,7 +32,8 @@ data class AssignmentNode(
 
 fun isAssignment(node: Phase1Node) = node is Assignment
 
-fun validateAssignmentNode(node: Phase1Node) = validateWrappedNode(
+fun validateAssignmentNode(node: Phase1Node, tracker: MutableLocationTracker) = validateWrappedNode(
+        tracker,
         node,
         "AssignmentNode",
         { it as? Assignment },

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/ClauseListNode.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/ClauseListNode.kt
@@ -19,11 +19,7 @@ package mathlingua.common.chalktalk.phase2.ast.clause
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 
-data class ClauseListNode(
-    val clauses: List<Clause>,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class ClauseListNode(val clauses: List<Clause>) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         clauses.forEach(fn)
     }
@@ -40,9 +36,7 @@ data class ClauseListNode(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node): Phase2Node {
         return chalkTransformer(ClauseListNode(
-                clauses = clauses.map { it.transform(chalkTransformer) as Clause },
-                row = row,
-                column = column
+                clauses = clauses.map { it.transform(chalkTransformer) as Clause }
         ))
     }
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/ExistsGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/ExistsGroup.kt
@@ -16,6 +16,7 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
@@ -26,9 +27,7 @@ import mathlingua.common.chalktalk.phase2.ast.section.validateSuchThatSection
 
 data class ExistsGroup(
     val existsSection: ExistsSection,
-    val suchThatSection: SuchThatSection,
-    override var row: Int,
-    override var column: Int
+    val suchThatSection: SuchThatSection
 ) : Clause {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(existsSection)
@@ -40,15 +39,14 @@ data class ExistsGroup(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(ExistsGroup(
             existsSection = existsSection.transform(chalkTransformer) as ExistsSection,
-            suchThatSection = suchThatSection.transform(chalkTransformer) as SuchThatSection,
-            row = row,
-            column = column
+            suchThatSection = suchThatSection.transform(chalkTransformer) as SuchThatSection
     ))
 }
 
 fun isExistsGroup(node: Phase1Node) = firstSectionMatchesName(node, "exists")
 
-fun validateExistsGroup(node: Phase1Node) = validateDoubleSectionGroup(
+fun validateExistsGroup(node: Phase1Node, tracker: MutableLocationTracker) = validateDoubleSectionGroup(
+        tracker,
         node,
         "exists",
         ::validateExistsSection,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/IdStatement.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/IdStatement.kt
@@ -16,9 +16,7 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
-import mathlingua.common.Validation
-import mathlingua.common.ValidationFailure
-import mathlingua.common.ValidationSuccess
+import mathlingua.common.*
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
@@ -26,9 +24,7 @@ import mathlingua.common.textalk.ExpressionTexTalkNode
 
 data class IdStatement(
     val text: String,
-    val texTalkRoot: Validation<ExpressionTexTalkNode>,
-    override var row: Int,
-    override var column: Int
+    val texTalkRoot: Validation<ExpressionTexTalkNode>
 ) : Clause {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
@@ -42,19 +38,15 @@ data class IdStatement(
 
     fun toStatement() = Statement(
             text = text,
-            texTalkRoot = texTalkRoot,
-            row = row,
-            column = column
+            texTalkRoot = texTalkRoot
     )
 }
 
-fun validateIdStatement(rawNode: Phase1Node): Validation<IdStatement> =
-        when (val validation = validateStatement(rawNode)) {
-            is ValidationSuccess -> ValidationSuccess(IdStatement(
+fun validateIdStatement(rawNode: Phase1Node, tracker: MutableLocationTracker): Validation<IdStatement> =
+        when (val validation = validateStatement(rawNode, tracker)) {
+            is ValidationSuccess -> validationSuccess(tracker, rawNode, IdStatement(
                     text = validation.value.text,
-                    texTalkRoot = validation.value.texTalkRoot,
-                    row = validation.value.row,
-                    column = validation.value.column
+                    texTalkRoot = validation.value.texTalkRoot
             ))
-            is ValidationFailure -> ValidationFailure(validation.errors)
+            is ValidationFailure -> validationFailure(validation.errors)
         }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Identifier.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Identifier.kt
@@ -16,19 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
-import mathlingua.common.ParseError
-import mathlingua.common.Validation
-import mathlingua.common.ValidationFailure
-import mathlingua.common.ValidationSuccess
+import mathlingua.common.*
 import mathlingua.common.chalktalk.phase1.ast.*
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 
 data class Identifier(
     val name: String,
-    val isVarArgs: Boolean,
-    override var row: Int,
-    override var column: Int
+    val isVarArgs: Boolean
 ) : Target {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
@@ -43,7 +38,7 @@ data class Identifier(
 
 fun isIdentifier(node: Phase1Node) = node is Phase1Token && node.type === ChalkTalkTokenType.Name
 
-fun validateIdentifier(rawNode: Phase1Node): Validation<Identifier> {
+fun validateIdentifier(rawNode: Phase1Node, tracker: MutableLocationTracker): Validation<Identifier> {
     val node = rawNode.resolve()
 
     val errors = ArrayList<ParseError>()
@@ -54,7 +49,7 @@ fun validateIdentifier(rawNode: Phase1Node): Validation<Identifier> {
                         getRow(node), getColumn(node)
                 )
         )
-        return ValidationFailure(errors)
+        return validationFailure(errors)
     }
 
     val (text, type, row, column) = node
@@ -65,7 +60,7 @@ fun validateIdentifier(rawNode: Phase1Node): Validation<Identifier> {
                         row, column
                 )
         )
-        return ValidationFailure(errors)
+        return validationFailure(errors)
     }
 
     var realText = text
@@ -75,12 +70,12 @@ fun validateIdentifier(rawNode: Phase1Node): Validation<Identifier> {
         isVarArgs = true
     }
 
-    return ValidationSuccess(
+    return validationSuccess(
+            tracker,
+            rawNode,
             Identifier(
                     name = realText,
-                    isVarArgs = isVarArgs,
-                    row = getRow(node),
-                    column = getColumn(node)
+                    isVarArgs = isVarArgs
             )
     )
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/IfGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/IfGroup.kt
@@ -16,6 +16,7 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
@@ -26,9 +27,7 @@ import mathlingua.common.chalktalk.phase2.ast.section.validateThenSection
 
 data class IfGroup(
     val ifSection: IfSection,
-    val thenSection: ThenSection,
-    override var row: Int,
-    override var column: Int
+    val thenSection: ThenSection
 ) : Clause {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(ifSection)
@@ -40,15 +39,14 @@ data class IfGroup(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(IfGroup(
             ifSection = ifSection.transform(chalkTransformer) as IfSection,
-            thenSection = thenSection.transform(chalkTransformer) as ThenSection,
-            row = row,
-            column = column
+            thenSection = thenSection.transform(chalkTransformer) as ThenSection
     ))
 }
 
 fun isIfGroup(node: Phase1Node) = firstSectionMatchesName(node, "if")
 
-fun validateIfGroup(node: Phase1Node) = validateDoubleSectionGroup(
+fun validateIfGroup(node: Phase1Node, tracker: MutableLocationTracker) = validateDoubleSectionGroup(
+        tracker,
         node,
         "if",
         ::validateIfSection,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/IffGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/IffGroup.kt
@@ -16,6 +16,7 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
@@ -26,9 +27,7 @@ import mathlingua.common.chalktalk.phase2.ast.section.validateThenSection
 
 data class IffGroup(
     val iffSection: IffSection,
-    val thenSection: ThenSection,
-    override var row: Int,
-    override var column: Int
+    val thenSection: ThenSection
 ) : Clause {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(iffSection)
@@ -40,15 +39,14 @@ data class IffGroup(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(IffGroup(
             iffSection = iffSection.transform(chalkTransformer) as IffSection,
-            thenSection = thenSection.transform(chalkTransformer) as ThenSection,
-            row = row,
-            column = column
+            thenSection = thenSection.transform(chalkTransformer) as ThenSection
     ))
 }
 
 fun isIffGroup(node: Phase1Node) = firstSectionMatchesName(node, "iff")
 
-fun validateIffGroup(node: Phase1Node) = validateDoubleSectionGroup(
+fun validateIffGroup(node: Phase1Node, tracker: MutableLocationTracker) = validateDoubleSectionGroup(
+        tracker,
         node,
         "iff",
         ::validateIffSection,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/MappingNode.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/MappingNode.kt
@@ -16,16 +16,13 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Mapping
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 
-data class MappingNode(
-    val mapping: Mapping,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class MappingNode(val mapping: Mapping) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) = toCode(writer, isArg, indent, mapping)
@@ -35,7 +32,8 @@ data class MappingNode(
 
 fun isMapping(node: Phase1Node) = node is Mapping
 
-fun validateMappingNode(node: Phase1Node) = validateWrappedNode(
+fun validateMappingNode(node: Phase1Node, tracker: MutableLocationTracker) = validateWrappedNode(
+        tracker,
         node,
         "MappingNode",
         { it as? Mapping },

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/NotGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/NotGroup.kt
@@ -16,32 +16,28 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.section.NotSection
 import mathlingua.common.chalktalk.phase2.ast.section.validateNotSection
 
-data class NotGroup(
-    val notSection: NotSection,
-    override var row: Int,
-    override var column: Int
-) : Clause {
+data class NotGroup(val notSection: NotSection) : Clause {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = fn(notSection)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
             notSection.toCode(isArg, indent, writer)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(NotGroup(
-            notSection = notSection.transform(chalkTransformer) as NotSection,
-            row = row,
-            column = column
+            notSection = notSection.transform(chalkTransformer) as NotSection
     ))
 }
 
 fun isNotGroup(node: Phase1Node) = firstSectionMatchesName(node, "not")
 
-fun validateNotGroup(node: Phase1Node) = validateSingleSectionGroup(
+fun validateNotGroup(node: Phase1Node, tracker: MutableLocationTracker) = validateSingleSectionGroup(
+        tracker,
         node, "not", ::NotGroup,
         ::validateNotSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/OrGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/OrGroup.kt
@@ -16,32 +16,28 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.section.OrSection
 import mathlingua.common.chalktalk.phase2.ast.section.validateOrSection
 
-data class OrGroup(
-    val orSection: OrSection,
-    override var row: Int,
-    override var column: Int
-) : Clause {
+data class OrGroup(val orSection: OrSection) : Clause {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = fn(orSection)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
             orSection.toCode(isArg, indent, writer)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(OrGroup(
-            orSection = orSection.transform(chalkTransformer) as OrSection,
-            row = row,
-            column = column
+            orSection = orSection.transform(chalkTransformer) as OrSection
     ))
 }
 
 fun isOrGroup(node: Phase1Node) = firstSectionMatchesName(node, "or")
 
-fun validateOrGroup(node: Phase1Node) = validateSingleSectionGroup(
+fun validateOrGroup(node: Phase1Node, tracker: MutableLocationTracker) = validateSingleSectionGroup(
+        tracker,
         node, "or", ::OrGroup,
         ::validateOrSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Text.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Text.kt
@@ -16,19 +16,12 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
-import mathlingua.common.ParseError
-import mathlingua.common.Validation
-import mathlingua.common.ValidationFailure
-import mathlingua.common.ValidationSuccess
+import mathlingua.common.*
 import mathlingua.common.chalktalk.phase1.ast.*
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 
-data class Text(
-    val text: String,
-    override var row: Int,
-    override var column: Int
-) : Clause {
+data class Text(val text: String) : Clause {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -42,7 +35,7 @@ data class Text(
 
 fun isText(node: Phase1Node) = node is Phase1Token && node.type === ChalkTalkTokenType.String
 
-fun validateText(rawNode: Phase1Node): Validation<Text> {
+fun validateText(rawNode: Phase1Node, tracker: MutableLocationTracker): Validation<Text> {
     val node = rawNode.resolve()
 
     val errors = ArrayList<ParseError>()
@@ -63,8 +56,8 @@ fun validateText(rawNode: Phase1Node): Validation<Text> {
                         row, column
                 )
         )
-        return ValidationFailure(errors)
+        return validationFailure(errors)
     }
 
-    return ValidationSuccess(Text(text, getRow(node), getColumn(node)))
+    return validationSuccess(tracker, rawNode, Text(text))
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/TupleNode.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/TupleNode.kt
@@ -16,16 +16,13 @@
 
 package mathlingua.common.chalktalk.phase2.ast.clause
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase1.ast.Tuple
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 
-data class TupleNode(
-    val tuple: Tuple,
-    override var row: Int,
-    override var column: Int
-) : Target {
+data class TupleNode(val tuple: Tuple) : Target {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) = toCode(writer, isArg, indent, tuple)
@@ -35,7 +32,9 @@ data class TupleNode(
 
 fun isTuple(node: Phase1Node) = node is Tuple
 
-fun validateTupleNode(node: Phase1Node) = validateWrappedNode(node,
+fun validateTupleNode(node: Phase1Node, tracker: MutableLocationTracker) = validateWrappedNode(
+        tracker,
+        node,
         "TupleNode",
         { it as? Tuple },
         ::TupleNode

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/AssumingSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/AssumingSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class AssumingSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class AssumingSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -41,13 +38,12 @@ data class AssumingSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(AssumingSection(
-                    clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-                    row = row,
-                    column = column
+                    clauses = clauses.transform(chalkTransformer) as ClauseListNode
             ))
 }
 
-fun validateAssumingSection(node: Phase1Node) = validateClauseList(
+fun validateAssumingSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "assuming",
         false,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/AxiomSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/AxiomSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class AxiomSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class AxiomSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -41,13 +38,12 @@ data class AxiomSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(AxiomSection(
-                    clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-                    row = row,
-                    column = column
+                    clauses = clauses.transform(chalkTransformer) as ClauseListNode
             ))
 }
 
-fun validateAxiomSection(node: Phase1Node) = validateClauseList(
+fun validateAxiomSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "Axiom",
         false,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ConjectureSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ConjectureSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class ConjectureSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class ConjectureSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -41,13 +38,12 @@ data class ConjectureSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(ConjectureSection(
-                    clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-                    row = row,
-                    column = column
+                    clauses = clauses.transform(chalkTransformer) as ClauseListNode
             ))
 }
 
-fun validateConjectureSection(node: Phase1Node) = validateClauseList(
+fun validateConjectureSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "Conjecture",
         false,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/DefinesSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/DefinesSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.*
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.Target
 import mathlingua.common.chalktalk.phase2.ast.clause.validateTargetList
 
-data class DefinesSection(
-    val targets: List<Target>,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class DefinesSection(val targets: List<Target>) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = targets.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -38,13 +35,12 @@ data class DefinesSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(DefinesSection(
-                    targets = targets.map { it.transform(chalkTransformer) as Target },
-                    row = row,
-                    column = column
+                    targets = targets.map { it.transform(chalkTransformer) as Target }
             ))
 }
 
-fun validateDefinesSection(node: Phase1Node) = validateTargetList(
+fun validateDefinesSection(node: Phase1Node, tracker: MutableLocationTracker) = validateTargetList(
+        tracker,
         node,
         "Defines",
         ::DefinesSection

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ExistsSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ExistsSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.*
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.Target
 import mathlingua.common.chalktalk.phase2.ast.clause.validateTargetList
 
-data class ExistsSection(
-    val identifiers: List<Target>,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class ExistsSection(val identifiers: List<Target>) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = identifiers.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -38,13 +35,12 @@ data class ExistsSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(ExistsSection(
-                    identifiers = identifiers.map { it.transform(chalkTransformer) as Target },
-                    row = row,
-                    column = column
+                    identifiers = identifiers.map { it.transform(chalkTransformer) as Target }
             ))
 }
 
-fun validateExistsSection(node: Phase1Node) = validateTargetList(
+fun validateExistsSection(node: Phase1Node, tracker: MutableLocationTracker) = validateTargetList(
+        tracker,
         node,
         "exists",
         ::ExistsSection

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ForSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ForSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.*
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.Target
 import mathlingua.common.chalktalk.phase2.ast.clause.validateTargetList
 
-data class ForSection(
-    val targets: List<Target>,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class ForSection(val targets: List<Target>) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = targets.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -38,13 +35,12 @@ data class ForSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(ForSection(
-                    targets = targets.map { it.transform(chalkTransformer) as Target },
-                    row = row,
-                    column = column
+                    targets = targets.map { it.transform(chalkTransformer) as Target }
             ))
 }
 
-fun validateForSection(node: Phase1Node) = validateTargetList(
+fun validateForSection(node: Phase1Node, tracker: MutableLocationTracker) = validateTargetList(
+        tracker,
         node,
         "for",
         ::ForSection

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/IfSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/IfSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class IfSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class IfSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -41,13 +38,12 @@ data class IfSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(IfSection(
-                    clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-                    row = row,
-                    column = column
+                    clauses = clauses.transform(chalkTransformer) as ClauseListNode
             ))
 }
 
-fun validateIfSection(node: Phase1Node) = validateClauseList(
+fun validateIfSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "if",
         true,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/IffSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/IffSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class IffSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class IffSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -40,13 +37,12 @@ data class IffSection(
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(IffSection(
-            clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-            row = row,
-            column = column
+            clauses = clauses.transform(chalkTransformer) as ClauseListNode
     ))
 }
 
-fun validateIffSection(node: Phase1Node) = validateClauseList(
+fun validateIffSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "iff",
         true,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/MeansSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/MeansSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class MeansSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class MeansSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = fn(clauses)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -40,13 +37,12 @@ data class MeansSection(
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(MeansSection(
-            clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-            row = row,
-            column = column
+            clauses = clauses.transform(chalkTransformer) as ClauseListNode
     ))
 }
 
-fun validateMeansSection(node: Phase1Node) = validateClauseList(
+fun validateMeansSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "means",
         false,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/NotSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/NotSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class NotSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class NotSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -41,13 +38,12 @@ data class NotSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(NotSection(
-                    clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-                    row = row,
-                    column = column
+                    clauses = clauses.transform(chalkTransformer) as ClauseListNode
             ))
 }
 
-fun validateNotSection(node: Phase1Node) = validateClauseList(
+fun validateNotSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "not",
         false,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/OrSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/OrSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class OrSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class OrSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -41,13 +38,12 @@ data class OrSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(OrSection(
-                    clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-                    row = row,
-                    column = column
+                    clauses = clauses.transform(chalkTransformer) as ClauseListNode
             ))
 }
 
-fun validateOrSection(node: Phase1Node) = validateClauseList(
+fun validateOrSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "or",
         false,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/RefinesSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/RefinesSection.kt
@@ -16,18 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.*
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.Target
 import mathlingua.common.chalktalk.phase2.ast.clause.validateTargetList
 
-data class RefinesSection(
-    val targets: List<Target>,
-    override var row: Int,
-    override var column: Int
-) :
-        Phase2Node {
+data class RefinesSection(val targets: List<Target>) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = targets.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -39,13 +35,12 @@ data class RefinesSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(RefinesSection(
-                    targets = targets.map { it.transform(chalkTransformer) as Target },
-                    row = row,
-                    column = column
+                    targets = targets.map { it.transform(chalkTransformer) as Target }
             ))
 }
 
-fun validateRefinesSection(node: Phase1Node) = validateTargetList(
+fun validateRefinesSection(node: Phase1Node, tracker: MutableLocationTracker) = validateTargetList(
+        tracker,
         node,
         "Refines",
         ::RefinesSection

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/RepresentsSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/RepresentsSection.kt
@@ -16,10 +16,7 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
-import mathlingua.common.ParseError
-import mathlingua.common.Validation
-import mathlingua.common.ValidationFailure
-import mathlingua.common.ValidationSuccess
+import mathlingua.common.*
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase1.ast.Section
 import mathlingua.common.chalktalk.phase1.ast.getColumn
@@ -27,10 +24,7 @@ import mathlingua.common.chalktalk.phase1.ast.getRow
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 
-data class RepresentsSection(
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+class RepresentsSection : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -42,7 +36,7 @@ data class RepresentsSection(
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
 
-fun validateRepresentsSection(node: Phase1Node): Validation<RepresentsSection> {
+fun validateRepresentsSection(node: Phase1Node, tracker: MutableLocationTracker): Validation<RepresentsSection> {
     val errors = ArrayList<ParseError>()
     if (node !is Section) {
         errors.add(
@@ -73,11 +67,8 @@ fun validateRepresentsSection(node: Phase1Node): Validation<RepresentsSection> {
     }
 
     return if (errors.isNotEmpty()) {
-        ValidationFailure(errors)
+        validationFailure(errors)
     } else {
-        ValidationSuccess(RepresentsSection(
-                row = getRow(node),
-                column = getColumn(node)
-        ))
+        validationSuccess(tracker, node, RepresentsSection())
     }
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ResultSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ResultSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class ResultSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class ResultSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -41,13 +38,12 @@ data class ResultSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(ResultSection(
-                    clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-                    row = row,
-                    column = column
+                    clauses = clauses.transform(chalkTransformer) as ClauseListNode
             ))
 }
 
-fun validateResultSection(node: Phase1Node) = validateClauseList(
+fun validateResultSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "Result",
         false,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/SuchThatSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/SuchThatSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class SuchThatSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class SuchThatSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -41,13 +38,12 @@ data class SuchThatSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(SuchThatSection(
-                    clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-                    row = row,
-                    column = column
+                    clauses = clauses.transform(chalkTransformer) as ClauseListNode
             ))
 }
 
-fun validateSuchThatSection(node: Phase1Node) = validateClauseList(
+fun validateSuchThatSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "suchThat",
         false,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/TextSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/TextSection.kt
@@ -16,19 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
-import mathlingua.common.ParseError
-import mathlingua.common.Validation
-import mathlingua.common.ValidationFailure
-import mathlingua.common.ValidationSuccess
+import mathlingua.common.*
 import mathlingua.common.chalktalk.phase1.ast.*
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 
 data class TextSection(
     val name: String,
-    val text: String,
-    override var row: Int,
-    override var column: Int
+    val text: String
 ) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
     }
@@ -48,7 +43,8 @@ data class TextSection(
 
 fun validateTextSection(
     rawNode: Phase1Node,
-    name: String
+    name: String,
+    tracker: MutableLocationTracker
 ): Validation<TextSection> {
     val node = rawNode.resolve()
     val row = getRow(node)
@@ -82,7 +78,7 @@ fun validateTextSection(
                         row, column
                 )
         )
-        return ValidationFailure(errors)
+        return validationFailure(errors)
     }
 
     val arg = sect.args[0].chalkTalkTarget
@@ -94,13 +90,14 @@ fun validateTextSection(
     }
 
     return if (errors.isNotEmpty()) {
-        ValidationFailure(errors)
+        validationFailure(errors)
     } else {
-        ValidationSuccess(TextSection(
-                name = name,
-                text = (arg as Phase1Token).text,
-                row = row,
-                column = column
-        ))
+        validationSuccess(
+                tracker,
+                rawNode,
+                TextSection(
+                    name = name,
+                    text = (arg as Phase1Token).text
+                ))
     }
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ThatSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ThatSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class ThatSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class ThatSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -41,13 +38,12 @@ data class ThatSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(ThatSection(
-                    clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-                    row = row,
-                    column = column
+                    clauses = clauses.transform(chalkTransformer) as ClauseListNode
             ))
 }
 
-fun validateThatSection(node: Phase1Node) = validateClauseList(
+fun validateThatSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "that",
         false,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ThenSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/ThenSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class ThenSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class ThenSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -40,13 +37,12 @@ data class ThenSection(
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(ThenSection(
-            clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-            row = row,
-            column = column
+            clauses = clauses.transform(chalkTransformer) as ClauseListNode
     ))
 }
 
-fun validateThenSection(node: Phase1Node) = validateClauseList(
+fun validateThenSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "then",
         false,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/WhereSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/WhereSection.kt
@@ -16,17 +16,14 @@
 
 package mathlingua.common.chalktalk.phase2.ast.section
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
-data class WhereSection(
-    val clauses: ClauseListNode,
-    override var row: Int,
-    override var column: Int
-) : Phase2Node {
+data class WhereSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -41,13 +38,12 @@ data class WhereSection(
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(WhereSection(
-                    clauses = clauses.transform(chalkTransformer) as ClauseListNode,
-                    row = row,
-                    column = column
+                    clauses = clauses.transform(chalkTransformer) as ClauseListNode
             ))
 }
 
-fun validateWhereSection(node: Phase1Node) = validateClauseList(
+fun validateWhereSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        tracker,
         node,
         "where",
         false,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/AxiomGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/AxiomGroup.kt
@@ -16,6 +16,7 @@
 
 package mathlingua.common.chalktalk.phase2.ast.toplevel
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Group
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
@@ -29,9 +30,7 @@ import mathlingua.common.chalktalk.phase2.ast.section.validateAxiomSection
 data class AxiomGroup(
     val axiomSection: AxiomSection,
     val aliasSection: AliasSection?,
-    override val metaDataSection: MetaDataSection?,
-    override var row: Int,
-    override var column: Int
+    override val metaDataSection: MetaDataSection?
 ) : TopLevelGroup(metaDataSection) {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
@@ -48,15 +47,14 @@ data class AxiomGroup(
             chalkTransformer(AxiomGroup(
                     axiomSection = axiomSection.transform(chalkTransformer) as AxiomSection,
                     aliasSection = aliasSection?.transform(chalkTransformer) as AliasSection,
-                    metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection,
-                    row = row,
-                    column = column
+                    metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection
             ))
 }
 
 fun isAxiomGroup(node: Phase1Node) = firstSectionMatchesName(node, "Axiom")
 
-fun validateAxiomGroup(groupNode: Group) = validateResultLikeGroup(
+fun validateAxiomGroup(groupNode: Group, tracker: MutableLocationTracker) = validateResultLikeGroup(
+        tracker,
         groupNode,
         "Axiom",
         ::validateAxiomSection,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/ConjectureGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/ConjectureGroup.kt
@@ -16,6 +16,7 @@
 
 package mathlingua.common.chalktalk.phase2.ast.toplevel
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Group
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
@@ -29,9 +30,7 @@ import mathlingua.common.chalktalk.phase2.ast.section.validateConjectureSection
 data class ConjectureGroup(
     val conjectureSection: ConjectureSection,
     val aliasSection: AliasSection?,
-    override val metaDataSection: MetaDataSection?,
-    override var row: Int,
-    override var column: Int
+    override val metaDataSection: MetaDataSection?
 ) : TopLevelGroup(metaDataSection) {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
@@ -48,15 +47,14 @@ data class ConjectureGroup(
             chalkTransformer(ConjectureGroup(
                     conjectureSection = conjectureSection.transform(chalkTransformer) as ConjectureSection,
                     aliasSection = aliasSection?.transform(chalkTransformer) as AliasSection,
-                    metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection,
-                    row = row,
-                    column = column
+                    metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection
             ))
 }
 
 fun isConjectureGroup(node: Phase1Node) = firstSectionMatchesName(node, "Conjecture")
 
-fun validateConjectureGroup(groupNode: Group) = validateResultLikeGroup(
+fun validateConjectureGroup(groupNode: Group, tracker: MutableLocationTracker) = validateResultLikeGroup(
+        tracker,
         groupNode,
         "Conjecture",
         ::validateConjectureSection,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/DefinesGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/DefinesGroup.kt
@@ -16,6 +16,7 @@
 
 package mathlingua.common.chalktalk.phase2.ast.toplevel
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Group
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
@@ -31,9 +32,7 @@ data class DefinesGroup(
     val assumingSection: AssumingSection?,
     val meansSections: List<MeansSection>,
     val aliasSection: AliasSection?,
-    override val metaDataSection: MetaDataSection?,
-    override var row: Int,
-    override var column: Int
+    override val metaDataSection: MetaDataSection?
 ) : TopLevelGroup(metaDataSection) {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
@@ -68,15 +67,14 @@ data class DefinesGroup(
             assumingSection = assumingSection?.transform(chalkTransformer) as AssumingSection?,
             meansSections = meansSections.map { chalkTransformer(it) as MeansSection },
             aliasSection = aliasSection?.transform(chalkTransformer) as AliasSection?,
-            metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?,
-            row = row,
-            column = column
+            metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?
     ))
 }
 
 fun isDefinesGroup(node: Phase1Node) = firstSectionMatchesName(node, "Defines")
 
-fun validateDefinesGroup(groupNode: Group) = validateDefinesLikeGroup(
+fun validateDefinesGroup(groupNode: Group, tracker: MutableLocationTracker) = validateDefinesLikeGroup(
+        tracker,
         groupNode,
         "Defines",
         ::validateDefinesSection,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/RepresentsGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/RepresentsGroup.kt
@@ -16,6 +16,7 @@
 
 package mathlingua.common.chalktalk.phase2.ast.toplevel
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Group
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
@@ -31,9 +32,7 @@ data class RepresentsGroup(
     val assumingSection: AssumingSection?,
     val thatSections: List<ThatSection>,
     val aliasSection: AliasSection?,
-    override val metaDataSection: MetaDataSection?,
-    override var row: Int,
-    override var column: Int
+    override val metaDataSection: MetaDataSection?
 ) : TopLevelGroup(metaDataSection) {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
@@ -68,15 +67,14 @@ data class RepresentsGroup(
             assumingSection = assumingSection?.transform(chalkTransformer) as AssumingSection?,
             thatSections = thatSections.map { chalkTransformer(it) as ThatSection },
             aliasSection = aliasSection?.transform(chalkTransformer) as AliasSection?,
-            metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?,
-            row = row,
-            column = column
+            metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?
     ))
 }
 
 fun isRepresentsGroup(node: Phase1Node) = firstSectionMatchesName(node, "Represents")
 
-fun validateRepresentsGroup(groupNode: Group) = validateDefinesLikeGroup(
+fun validateRepresentsGroup(groupNode: Group, tracker: MutableLocationTracker) = validateDefinesLikeGroup(
+        tracker,
         groupNode,
         "Represents",
         ::validateRepresentsSection,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/ResultGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/ResultGroup.kt
@@ -16,6 +16,7 @@
 
 package mathlingua.common.chalktalk.phase2.ast.toplevel
 
+import mathlingua.common.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Group
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
@@ -29,9 +30,7 @@ import mathlingua.common.chalktalk.phase2.ast.section.validateResultSection
 data class ResultGroup(
     val resultSection: ResultSection,
     val aliasSection: AliasSection?,
-    override val metaDataSection: MetaDataSection?,
-    override var row: Int,
-    override var column: Int
+    override val metaDataSection: MetaDataSection?
 ) : TopLevelGroup(metaDataSection) {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
@@ -47,15 +46,14 @@ data class ResultGroup(
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(ResultGroup(
             resultSection = resultSection.transform(chalkTransformer) as ResultSection,
             metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?,
-            aliasSection = aliasSection?.transform(chalkTransformer) as AliasSection?,
-            row = row,
-            column = column
+            aliasSection = aliasSection?.transform(chalkTransformer) as AliasSection?
     ))
 }
 
 fun isResultGroup(node: Phase1Node) = firstSectionMatchesName(node, "Result")
 
-fun validateResultGroup(groupNode: Group) = validateResultLikeGroup(
+fun validateResultGroup(groupNode: Group, tracker: MutableLocationTracker) = validateResultLikeGroup(
+        tracker,
         groupNode,
         "Result",
         ::validateResultSection,

--- a/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/CommandUtil.kt
@@ -31,6 +31,7 @@ import mathlingua.common.textalk.ParametersTexTalkNode
 import mathlingua.common.textalk.TexTalkNode
 import mathlingua.common.textalk.TexTalkNodeType
 import mathlingua.common.textalk.TextTexTalkNode
+import mathlingua.common.validationSuccess
 
 data class RootTarget<R, T>(val root: R, val target: T)
 
@@ -91,9 +92,7 @@ internal fun replaceCommands(
                 val newRoot = replaceCommands(root, root, cmdToReplacement, shouldProcessTex) as ExpressionTexTalkNode
                 Statement(
                         text = newRoot.toCode(),
-                        texTalkRoot = ValidationSuccess(newRoot),
-                        row = -1,
-                        column = -1
+                        texTalkRoot = validationSuccess(newRoot)
                 )
             }
         }
@@ -143,9 +142,7 @@ internal fun separateIsStatements(root: Phase2Node, follow: Phase2Node): RootTar
                             )
                             Statement(
                                     text = expRoot.toCode(),
-                                    texTalkRoot = ValidationSuccess(expRoot),
-                                    row = -1,
-                                    column = -1
+                                    texTalkRoot = validationSuccess(expRoot)
                             )
                         })
                     }
@@ -153,11 +150,7 @@ internal fun separateIsStatements(root: Phase2Node, follow: Phase2Node): RootTar
                     newClauses.add(clause)
                 }
             }
-            val result = ClauseListNode(
-                    clauses = newClauses,
-                    row = -1,
-                    column = -1
-            )
+            val result = ClauseListNode(clauses = newClauses)
             if (newFollow == null && hasChild(it, follow)) {
                 newFollow = result
             }
@@ -228,9 +221,7 @@ internal fun glueCommands(root: Phase2Node, follow: Phase2Node): RootTarget<Phas
             )
             val result = Statement(
                     text = newExp.toCode(),
-                    texTalkRoot = ValidationSuccess(newExp),
-                    row = -1,
-                    column = -1
+                    texTalkRoot = validationSuccess(newExp)
             )
             if (newFollow == null && hasChild(it, follow)) {
                 newFollow = result
@@ -267,9 +258,7 @@ internal fun glueCommands(root: Phase2Node, follow: Phase2Node): RootTarget<Phas
             )
             val result = Statement(
                     text = newExp.toCode(),
-                    texTalkRoot = ValidationSuccess(newExp),
-                    row = -1,
-                    column = -1
+                    texTalkRoot = validationSuccess(newExp)
             )
             if (newFollow == null && hasChild(it, follow)) {
                 newFollow = result

--- a/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
@@ -33,6 +33,7 @@ import mathlingua.common.textalk.TexTalkNode
 import mathlingua.common.textalk.TexTalkNodeType
 import mathlingua.common.textalk.TextTexTalkNode
 import mathlingua.common.textalk.getTexTalkAncestry
+import mathlingua.common.validationSuccess
 
 internal fun getKey(node: Phase2Node): String {
     val str = node.toString()
@@ -80,11 +81,7 @@ internal fun moveInlineCommandsToIsNode(
                     newClauses.add(c)
                 }
             }
-            val result = ClauseListNode(
-                    clauses = newClauses,
-                    row = -1,
-                    column = -1
-            )
+            val result = ClauseListNode(clauses = newClauses)
             if (newTarget == null && hasChild(it, target)) {
                 newTarget = result
             }
@@ -145,25 +142,15 @@ internal fun moveStatementInlineCommandsToIsNode(
     }
 
     return ForGroup(
-            row = -1,
-            column = -1,
             forSection = ForSection(
                     targets = cmdsToProcess.map {
                         Identifier(
                                 name = cmdToReplacement[it]!!,
-                                row = -1,
-                                column = -1,
                                 isVarArgs = false)
-                    },
-                    row = -1,
-                    column = -1
+                    }
             ),
             whereSection = WhereSection(
-                    row = -1,
-                    column = -1,
                     clauses = ClauseListNode(
-                            row = -1,
-                            column = -1,
                             clauses = cmdsToProcess.map {
                                 val isNode = IsTexTalkNode(
                                         lhs = ParametersTexTalkNode(
@@ -189,10 +176,8 @@ internal fun moveStatementInlineCommandsToIsNode(
                                 )
 
                                 Statement(
-                                        row = -1,
-                                        column = -1,
                                         text = isNode.toCode(),
-                                        texTalkRoot = ValidationSuccess(
+                                        texTalkRoot = validationSuccess(
                                                 ExpressionTexTalkNode(
                                                         children = listOf(isNode)
                                                 )
@@ -202,11 +187,7 @@ internal fun moveStatementInlineCommandsToIsNode(
                     )
             ),
             thenSection = ThenSection(
-                    row = -1,
-                    column = -1,
                     clauses = ClauseListNode(
-                            row = -1,
-                            column = -1,
                             clauses = listOf(newNode)
                     )
             )
@@ -323,11 +304,7 @@ internal fun replaceRepresents(
                 newClauses.add(clause)
             }
         }
-        val result = ClauseListNode(
-                clauses = newClauses,
-                row = -1,
-                column = -1
-        )
+        val result = ClauseListNode(clauses = newClauses)
         if (newTarget == null && hasChild(node, target)) {
             newTarget = result
         }
@@ -479,11 +456,7 @@ internal fun replaceIsNodes(
                 newClauses.add(renameVars(ifThen, map) as Clause)
             }
         }
-        val result = ClauseListNode(
-                clauses = newClauses,
-                row = -1,
-                column = -1
-        )
+        val result = ClauseListNode(clauses = newClauses)
         if (newTarget == null && hasChild(node, target)) {
             newTarget = result
         }
@@ -498,19 +471,13 @@ internal fun replaceIsNodes(
 }
 
 internal fun toCanonicalForm(def: DefinesGroup) = DefinesGroup(
-        row = -1,
-        column = -1,
         signature = def.signature,
         id = def.id,
         definesSection = def.definesSection,
         assumingSection = null,
         meansSections = buildIfThens(def).map {
             MeansSection(
-                    row = -1,
-                    column = -1,
                     clauses = ClauseListNode(
-                            row = -1,
-                            column = -1,
                             clauses = listOf(it)
                     )
             )
@@ -521,21 +488,11 @@ internal fun toCanonicalForm(def: DefinesGroup) = DefinesGroup(
 
 internal fun buildIfThens(def: DefinesGroup) = def.meansSections.map {
     IfGroup(
-            row = -1,
-            column = -1,
             ifSection = IfSection(
-                    row = -1,
-                    column = -1,
                     clauses = def.assumingSection?.clauses
-                            ?: ClauseListNode(
-                                    clauses = emptyList(),
-                                    row = -1,
-                                    column = -1
-                            )
+                            ?: ClauseListNode(clauses = emptyList())
             ),
             thenSection = ThenSection(
-                    row = -1,
-                    column = -1,
                     clauses = it.clauses
             )
     )
@@ -543,20 +500,13 @@ internal fun buildIfThens(def: DefinesGroup) = def.meansSections.map {
 
 internal fun buildIfThens(rep: RepresentsGroup) = rep.thatSections.map {
     IfGroup(
-            row = -1,
-            column = -1,
             ifSection = IfSection(
-                    row = -1,
-                    column = -1,
                     clauses = rep.assumingSection?.clauses
                             ?: ClauseListNode(
-                                    clauses = emptyList(),
-                                    row = -1,
-                                    column = -1)
+                                    clauses = emptyList()
+                            )
             ),
             thenSection = ThenSection(
-                    row = -1,
-                    column = -1,
                     clauses = it.clauses
             )
     )
@@ -592,9 +542,6 @@ internal fun expandAtNode(
     defines: List<DefinesGroup>,
     represents: List<RepresentsGroup>
 ): Phase2Node {
-    resetRowColumn(root)
-    resetRowColumn(target)
-
     var transformed = root
     var realTarget = target
 
@@ -659,9 +606,7 @@ internal fun separateInfixOperatorStatements(root: Phase2Node, follow: Phase2Nod
                             for (expanded in getExpandedInfixOperators(expRoot)) {
                                 newClauses.add(Statement(
                                         text = expanded.toCode(),
-                                        texTalkRoot = ValidationSuccess(expanded),
-                                        row = -1,
-                                        column = -1
+                                        texTalkRoot = validationSuccess(expanded)
                                 ))
                             }
                         }
@@ -672,9 +617,7 @@ internal fun separateInfixOperatorStatements(root: Phase2Node, follow: Phase2Nod
                 }
             }
             val result = ClauseListNode(
-                    clauses = newClauses,
-                    row = -1,
-                    column = -1
+                    clauses = newClauses
             )
             if (newFollow == null && hasChild(it, follow)) {
                 newFollow = result

--- a/src/main/kotlin/mathlingua/common/transform/VarUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/VarUtil.kt
@@ -26,6 +26,7 @@ import mathlingua.common.textalk.ExpressionTexTalkNode
 import mathlingua.common.textalk.ParametersTexTalkNode
 import mathlingua.common.textalk.TexTalkNode
 import mathlingua.common.textalk.TextTexTalkNode
+import mathlingua.common.validationSuccess
 
 internal fun getVars(node: Phase1Node): List<String> {
     val vars = mutableListOf<String>()
@@ -61,9 +62,7 @@ internal fun renameVars(root: Phase2Node, map: Map<String, String>): Phase2Node 
         if (node is Identifier) {
             return Identifier(
                     name = map[node.name] ?: node.name,
-                    isVarArgs = node.isVarArgs,
-                    row = node.row,
-                    column = node.column
+                    isVarArgs = node.isVarArgs
             )
         }
 
@@ -72,10 +71,8 @@ internal fun renameVars(root: Phase2Node, map: Map<String, String>): Phase2Node 
                 is ValidationSuccess -> {
                     val exp = renameVars(validation.value, map) as ExpressionTexTalkNode
                     return Statement(
-                            row = -1,
-                            column = -1,
                             text = exp.toCode(),
-                            texTalkRoot = ValidationSuccess(exp)
+                            texTalkRoot = validationSuccess(exp)
                     )
                 }
                 is ValidationFailure -> node
@@ -86,11 +83,7 @@ internal fun renameVars(root: Phase2Node, map: Map<String, String>): Phase2Node 
             for (key in keysLongToShort) {
                 newText = newText.replace("$key&", map[key]!!)
             }
-            return Text(
-                    text = newText,
-                    row = -1,
-                    column = -1
-            )
+            return Text(text = newText)
         }
 
         return node

--- a/src/test/resources/goldens/chalktalk/handles a single classification in metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles a single classification in metadata/phase2-structure.txt
@@ -10,15 +10,9 @@ Document(
                     clauses = [
                                 Text(
                                   text = ""something""
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = MetaDataSection(
@@ -29,18 +23,10 @@ Document(
                                 values = [
                                            ""a""
                                          ]
-                                row = 3
-                                column = 3
                               )
-                              row = 3
-                              column = 3
                             )
                           ]
-                  row = 2
-                  column = 1
                 )
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -51,6 +37,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/handles a single tag in metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles a single tag in metadata/phase2-structure.txt
@@ -10,15 +10,9 @@ Document(
                     clauses = [
                                 Text(
                                   text = ""something""
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = MetaDataSection(
@@ -29,18 +23,10 @@ Document(
                                 values = [
                                            ""a""
                                          ]
-                                row = 3
-                                column = 3
                               )
-                              row = 3
-                              column = 3
                             )
                           ]
-                  row = 2
-                  column = 1
                 )
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -51,6 +37,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/handles multiple classifications in metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles multiple classifications in metadata/phase2-structure.txt
@@ -10,15 +10,9 @@ Document(
                     clauses = [
                                 Text(
                                   text = ""something""
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = MetaDataSection(
@@ -31,18 +25,10 @@ Document(
                                            ""b"",
                                            ""c""
                                          ]
-                                row = 3
-                                column = 3
                               )
-                              row = 3
-                              column = 3
                             )
                           ]
-                  row = 2
-                  column = 1
                 )
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -53,6 +39,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/handles multiple tags in metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles multiple tags in metadata/phase2-structure.txt
@@ -10,15 +10,9 @@ Document(
                     clauses = [
                                 Text(
                                   text = ""something""
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = MetaDataSection(
@@ -31,18 +25,10 @@ Document(
                                            ""b"",
                                            ""c""
                                          ]
-                                row = 3
-                                column = 3
                               )
-                              row = 3
-                              column = 3
                             )
                           ]
-                  row = 2
-                  column = 1
                 )
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -53,6 +39,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/handles sources with a homepage/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles sources with a homepage/phase2-structure.txt
@@ -20,11 +20,7 @@ Document(
                                 values = [
                                            ""some name""
                                          ]
-                                row = 2
-                                column = 9
                               )
-                              row = 2
-                              column = 3
                             ),
                             StringSectionGroup(
                               section = StringSection(
@@ -32,23 +28,13 @@ Document(
                                 values = [
                                            ""some.homepage.com""
                                          ]
-                                row = 3
-                                column = 13
                               )
-                              row = 3
-                              column = 3
                             )
                           ]
-                  row = 1
-                  column = 1
                 )
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/handles sources with a single author/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles sources with a single author/phase2-structure.txt
@@ -20,11 +20,7 @@ Document(
                                 values = [
                                            ""some name""
                                          ]
-                                row = 2
-                                column = 9
                               )
-                              row = 2
-                              column = 3
                             ),
                             StringSectionGroup(
                               section = StringSection(
@@ -32,23 +28,13 @@ Document(
                                 values = [
                                            ""author1""
                                          ]
-                                row = 3
-                                column = 11
                               )
-                              row = 3
-                              column = 3
                             )
                           ]
-                  row = 1
-                  column = 1
                 )
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/handles sources with a type/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles sources with a type/phase2-structure.txt
@@ -20,11 +20,7 @@ Document(
                                 values = [
                                            ""some name""
                                          ]
-                                row = 2
-                                column = 9
                               )
-                              row = 2
-                              column = 3
                             ),
                             StringSectionGroup(
                               section = StringSection(
@@ -32,23 +28,13 @@ Document(
                                 values = [
                                            ""Book""
                                          ]
-                                row = 3
-                                column = 9
                               )
-                              row = 3
-                              column = 3
                             )
                           ]
-                  row = 1
-                  column = 1
                 )
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/handles sources with multiple authors/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles sources with multiple authors/phase2-structure.txt
@@ -20,11 +20,7 @@ Document(
                                 values = [
                                            ""some name""
                                          ]
-                                row = 2
-                                column = 9
                               )
-                              row = 2
-                              column = 3
                             ),
                             StringSectionGroup(
                               section = StringSection(
@@ -34,23 +30,13 @@ Document(
                                            ""author2"",
                                            ""author3""
                                          ]
-                                row = 4
-                                column = 5
                               )
-                              row = 3
-                              column = 3
                             )
                           ]
-                  row = 1
-                  column = 1
                 )
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and empty params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and empty params/phase2-structure.txt
@@ -29,12 +29,8 @@ Document(
                                                               )
                                                             ]
                                                   )
-                                                  row = 1
-                                                  column = 8
                                                 )
                                               ]
-                                    row = 1
-                                    column = 3
                                   )
                                   whereSection = null
                                   thenSection = ThenSection(
@@ -56,30 +52,16 @@ Document(
                                                                 )
                                                               ]
                                                     )
-                                                    row = 2
-                                                    column = 9
                                                   )
                                                 ]
-                                      row = 2
-                                      column = 3
                                     )
-                                    row = 2
-                                    column = 3
                                   )
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -90,6 +72,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and non-empty params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and non-empty params/phase2-structure.txt
@@ -41,12 +41,8 @@ Document(
                                                               )
                                                             ]
                                                   )
-                                                  row = 1
-                                                  column = 8
                                                 )
                                               ]
-                                    row = 1
-                                    column = 3
                                   )
                                   whereSection = null
                                   thenSection = ThenSection(
@@ -68,30 +64,16 @@ Document(
                                                                 )
                                                               ]
                                                     )
-                                                    row = 2
-                                                    column = 9
                                                   )
                                                 ]
-                                      row = 2
-                                      column = 3
                                     )
-                                    row = 2
-                                    column = 3
                                   )
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -102,6 +84,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params and multiple params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params and multiple params/phase2-structure.txt
@@ -53,12 +53,8 @@ Document(
                                                               )
                                                             ]
                                                   )
-                                                  row = 1
-                                                  column = 8
                                                 )
                                               ]
-                                    row = 1
-                                    column = 3
                                   )
                                   whereSection = null
                                   thenSection = ThenSection(
@@ -80,30 +76,16 @@ Document(
                                                                 )
                                                               ]
                                                     )
-                                                    row = 2
-                                                    column = 9
                                                   )
                                                 ]
-                                      row = 2
-                                      column = 3
                                     )
-                                    row = 2
-                                    column = 3
                                   )
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -114,6 +96,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params/phase2-structure.txt
@@ -46,12 +46,8 @@ Document(
                                                               )
                                                             ]
                                                   )
-                                                  row = 1
-                                                  column = 8
                                                 )
                                               ]
-                                    row = 1
-                                    column = 3
                                   )
                                   whereSection = null
                                   thenSection = ThenSection(
@@ -73,30 +69,16 @@ Document(
                                                                 )
                                                               ]
                                                     )
-                                                    row = 2
-                                                    column = 9
                                                   )
                                                 ]
-                                      row = 2
-                                      column = 3
                                     )
-                                    row = 2
-                                    column = 3
                                   )
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -107,6 +89,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with non-empty sub params and empty params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with non-empty sub params and empty params/phase2-structure.txt
@@ -41,12 +41,8 @@ Document(
                                                               )
                                                             ]
                                                   )
-                                                  row = 1
-                                                  column = 8
                                                 )
                                               ]
-                                    row = 1
-                                    column = 3
                                   )
                                   whereSection = null
                                   thenSection = ThenSection(
@@ -68,30 +64,16 @@ Document(
                                                                 )
                                                               ]
                                                     )
-                                                    row = 2
-                                                    column = 9
                                                   )
                                                 ]
-                                      row = 2
-                                      column = 3
                                     )
-                                    row = 2
-                                    column = 3
                                   )
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -102,6 +84,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with one sub param and multiple params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with one sub param and multiple params/phase2-structure.txt
@@ -47,12 +47,8 @@ Document(
                                                               )
                                                             ]
                                                   )
-                                                  row = 1
-                                                  column = 8
                                                 )
                                               ]
-                                    row = 1
-                                    column = 3
                                   )
                                   whereSection = null
                                   thenSection = ThenSection(
@@ -74,30 +70,16 @@ Document(
                                                                 )
                                                               ]
                                                     )
-                                                    row = 2
-                                                    column = 9
                                                   )
                                                 ]
-                                      row = 2
-                                      column = 3
                                     )
-                                    row = 2
-                                    column = 3
                                   )
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -108,6 +90,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with one sub param/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with one sub param/phase2-structure.txt
@@ -34,12 +34,8 @@ Document(
                                                               )
                                                             ]
                                                   )
-                                                  row = 1
-                                                  column = 8
                                                 )
                                               ]
-                                    row = 1
-                                    column = 3
                                   )
                                   whereSection = null
                                   thenSection = ThenSection(
@@ -61,30 +57,16 @@ Document(
                                                                 )
                                                               ]
                                                     )
-                                                    row = 2
-                                                    column = 9
                                                   )
                                                 ]
-                                      row = 2
-                                      column = 3
                                     )
-                                    row = 2
-                                    column = 3
                                   )
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -95,6 +77,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses enclosed abstractions with sub params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed abstractions with sub params/phase2-structure.txt
@@ -34,12 +34,8 @@ Document(
                                                               )
                                                             ]
                                                   )
-                                                  row = 1
-                                                  column = 9
                                                 )
                                               ]
-                                    row = 1
-                                    column = 3
                                   )
                                   whereSection = null
                                   thenSection = ThenSection(
@@ -61,30 +57,16 @@ Document(
                                                                 )
                                                               ]
                                                     )
-                                                    row = 2
-                                                    column = 9
                                                   )
                                                 ]
-                                      row = 2
-                                      column = 3
                                     )
-                                    row = 2
-                                    column = 3
                                   )
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -95,6 +77,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses enclosed plain abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed plain abstractions/phase2-structure.txt
@@ -27,12 +27,8 @@ Document(
                                                               )
                                                             ]
                                                   )
-                                                  row = 1
-                                                  column = 9
                                                 )
                                               ]
-                                    row = 1
-                                    column = 3
                                   )
                                   whereSection = null
                                   thenSection = ThenSection(
@@ -54,30 +50,16 @@ Document(
                                                                 )
                                                               ]
                                                     )
-                                                    row = 2
-                                                    column = 9
                                                   )
                                                 ]
-                                      row = 2
-                                      column = 3
                                     )
-                                    row = 2
-                                    column = 3
                                   )
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -88,6 +70,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses enclosed regular abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed regular abstractions/phase2-structure.txt
@@ -34,12 +34,8 @@ Document(
                                                               )
                                                             ]
                                                   )
-                                                  row = 1
-                                                  column = 9
                                                 )
                                               ]
-                                    row = 1
-                                    column = 3
                                   )
                                   whereSection = null
                                   thenSection = ThenSection(
@@ -61,30 +57,16 @@ Document(
                                                                 )
                                                               ]
                                                     )
-                                                    row = 2
-                                                    column = 9
                                                   )
                                                 ]
-                                      row = 2
-                                      column = 3
                                     )
-                                    row = 2
-                                    column = 3
                                   )
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -95,6 +77,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses multi var abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multi var abstractions/phase2-structure.txt
@@ -43,20 +43,12 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 8
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -67,6 +59,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments indented/phase2-structure.txt
@@ -24,8 +24,6 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 1
-                                  column = 3
                                 ),
                                 AbstractionNode(
                                   abstraction = Abstraction(
@@ -43,8 +41,6 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 2
-                                  column = 3
                                 ),
                                 AbstractionNode(
                                   abstraction = Abstraction(
@@ -62,20 +58,12 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 3
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -86,6 +74,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments mixed indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments mixed indented/phase2-structure.txt
@@ -24,8 +24,6 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 8
                                 ),
                                 AbstractionNode(
                                   abstraction = Abstraction(
@@ -43,8 +41,6 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 11
                                 ),
                                 AbstractionNode(
                                   abstraction = Abstraction(
@@ -62,8 +58,6 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 1
-                                  column = 3
                                 ),
                                 AbstractionNode(
                                   abstraction = Abstraction(
@@ -81,8 +75,6 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 2
-                                  column = 3
                                 ),
                                 AbstractionNode(
                                   abstraction = Abstraction(
@@ -100,8 +92,6 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 2
-                                  column = 6
                                 ),
                                 AbstractionNode(
                                   abstraction = Abstraction(
@@ -119,20 +109,12 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 3
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -143,6 +125,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments single line/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments single line/phase2-structure.txt
@@ -24,8 +24,6 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 8
                                 ),
                                 AbstractionNode(
                                   abstraction = Abstraction(
@@ -43,8 +41,6 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 11
                                 ),
                                 AbstractionNode(
                                   abstraction = Abstraction(
@@ -62,20 +58,12 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 14
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -86,6 +74,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses names with .../phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses names with .../phase2-structure.txt
@@ -24,20 +24,12 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 8
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -48,6 +40,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses nested names with .../phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses nested names with .../phase2-structure.txt
@@ -31,20 +31,12 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 8
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -55,6 +47,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses operator identifiers/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses operator identifiers/phase2-structure.txt
@@ -24,20 +24,12 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 8
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -48,6 +40,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses single argument indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single argument indented/phase2-structure.txt
@@ -24,20 +24,12 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 1
-                                  column = 3
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -48,6 +40,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses single argument on same line/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single argument on same line/phase2-structure.txt
@@ -24,20 +24,12 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 8
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -48,6 +40,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses single var abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single var abstractions/phase2-structure.txt
@@ -31,20 +31,12 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 8
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -55,6 +47,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )

--- a/src/test/resources/goldens/chalktalk/parses text identifiers/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses text identifiers/phase2-structure.txt
@@ -24,20 +24,12 @@ Document(
                                               )
                                             ]
                                   )
-                                  row = 0
-                                  column = 8
                                 )
                               ]
-                    row = 0
-                    column = 0
                   )
-                  row = 0
-                  column = 0
                 )
                 aliasSection = null
                 metaDataSection = null
-                row = 0
-                column = 0
               )
             ]
   axioms = [
@@ -48,6 +40,4 @@ Document(
             ]
   protoGroups = [
                 ]
-  row = 0
-  column = 0
 )


### PR DESCRIPTION
Previously, the ast was not completely immutable because each
node had `row` and `column` properties that were mutable.  This
made it difficult to compare nodes with the same structure but
different row and/or column.

Now row and column information is stored in a separate
`LocationTracker` object and a new `MathLingua.parseWithLocations()`
method is available to get a `Document` and a `LocationTracker`.