### PR TITLE
fix: CLI now reports warnings that were missed

### DIFF
--- a/src/main/kotlin/mathlingua/jvm/Main.kt
+++ b/src/main/kotlin/mathlingua/jvm/Main.kt
@@ -176,11 +176,15 @@ private fun processFile(file: File, allSignatures: MutableSet<String>, defSignat
             allSignatures.addAll(MathLingua.findAllSignatures(document))
 
             for (def in document.defines) {
-                defSignatures.addAll(MathLingua.findAllSignatures(def))
+                if (def.signature != null) {
+                    defSignatures.add(def.signature)
+                }
             }
 
             for (rep in document.represents) {
-                defSignatures.addAll(MathLingua.findAllSignatures(rep))
+                if (rep.signature != null) {
+                    defSignatures.add(rep.signature)
+                }
             }
             emptyList()
         }


### PR DESCRIPTION
The CLI was recording all signatures in a Defines or Represents
as defined signatures instead of only recording the signature of
the item defined by the Defines or Represents.

As a result, the CLI wouldn't give warnings for used signatures
that didn't have an associated definition.