### PR TITLE
feat: CLI supports outputing expanded MathLingua

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/Phase2Node.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/Phase2Node.kt
@@ -21,6 +21,6 @@ import mathlingua.common.chalktalk.phase2.MathLinguaCodeWriter
 
 interface Phase2Node {
     fun forEach(fn: (node: Phase2Node) -> Unit)
-    fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter = MathLinguaCodeWriter()): CodeWriter
+    fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter = MathLinguaCodeWriter(defines = emptyList())): CodeWriter
     fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node): Phase2Node
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/IdStatement.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/IdStatement.kt
@@ -30,7 +30,7 @@ data class IdStatement(
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
-        writer.writeStatement(text, texTalkRoot)
+        writer.writeId(this)
         return writer
     }
 


### PR DESCRIPTION
The CLI has a new --output option that, when specified, outputs
the contents of the supplied files.  The option can have values
'mathlingua', 'html', or 'none' (default).

In addition, the --expand flag has been added.  If that flag is
provided with the --output option, the statements in the output
will have their form fully expanded into their equivalent LaTeX
representations.

Also note that when the html output option is provided, the
generated html code uses KaTeX to render the math in the
document but references the KaTeX from its cdn.  Thus the html
is fully self contained.