### PR TITLE
chore: update the printExpanded() function (#146)

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkParser.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkParser.kt
@@ -237,14 +237,25 @@ private class ChalkTalkParserImpl : ChalkTalkParser {
                 }
             }
 
+            var subParams: List<Phase1Token>? = null
             if (isEnclosed) {
                 expect(ChalkTalkTokenType.RCurly)
+                if (has(ChalkTalkTokenType.Underscore)) {
+                    expect(ChalkTalkTokenType.Underscore)
+                    if (has(ChalkTalkTokenType.LCurly)) {
+                        expect(ChalkTalkTokenType.LCurly)
+                        subParams = nameList(ChalkTalkTokenType.RCurly)
+                        expect(ChalkTalkTokenType.RCurly)
+                    } else {
+                        subParams = listOf(expect(ChalkTalkTokenType.Name))
+                    }
+                }
             }
 
             return if (!isEnclosed && parts.isEmpty()) {
                 null
             } else {
-                Abstraction(isEnclosed, parts)
+                Abstraction(isEnclosed, parts, subParams)
             }
         }
 

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ast/Phase1Target.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ast/Phase1Target.kt
@@ -157,7 +157,7 @@ data class Tuple(val items: List<TupleItem>) : AssignmentRhs() {
     ))
 }
 
-data class Abstraction(val isEnclosed: Boolean, val parts: List<AbstractionPart>) : AssignmentRhs() {
+data class Abstraction(val isEnclosed: Boolean, val parts: List<AbstractionPart>, val subParams: List<Phase1Token>?) : AssignmentRhs() {
 
     override fun forEach(fn: (node: Phase1Node) -> Unit) = parts.forEach(fn)
 
@@ -174,6 +174,21 @@ data class Abstraction(val isEnclosed: Boolean, val parts: List<AbstractionPart>
         }
         if (isEnclosed) {
             builder.append('}')
+            if (subParams != null) {
+                builder.append('_')
+                if (subParams.size == 1) {
+                    builder.append(subParams[0].toCode())
+                } else {
+                    builder.append('{')
+                    for (i in subParams.indices) {
+                        builder.append(subParams[i].toCode())
+                        if (i != subParams.size - 1) {
+                            builder.append(", ")
+                        }
+                    }
+                    builder.append('}')
+                }
+            }
         }
 
         return builder.toString()
@@ -183,7 +198,8 @@ data class Abstraction(val isEnclosed: Boolean, val parts: List<AbstractionPart>
 
     override fun transform(transformer: (node: Phase1Node) -> Phase1Node) = transformer(Abstraction(
         isEnclosed = isEnclosed,
-        parts = parts.map { it.transform(transformer) as AbstractionPart }
+        parts = parts.map { it.transform(transformer) as AbstractionPart },
+        subParams = subParams?.map { it.transform(transformer) as Phase1Token }
     ))
 }
 

--- a/src/test/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkParserTest.kt
+++ b/src/test/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkParserTest.kt
@@ -20,6 +20,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import mathlingua.GoldenType
+import mathlingua.common.ParseError
 import mathlingua.loadTestCases
 import mathlingua.serialize
 import org.junit.jupiter.api.DynamicTest
@@ -42,7 +43,7 @@ internal class ChalkTalkParserTest {
                         println("ERROR: $err")
                     }
                 }
-                assertThat(result.errors.size).isEqualTo(0)
+                assertThat(result.errors).isEqualTo(emptyList<ParseError>())
                 assertThat(result.root).isNotNull()
 
                 assertThat(result.root!!.toCode()).isEqualTo(it.phase1Output)

--- a/src/test/kotlin/mathlingua/common/chalktalk/phase2/ChalkTalkParserTest.kt
+++ b/src/test/kotlin/mathlingua/common/chalktalk/phase2/ChalkTalkParserTest.kt
@@ -23,6 +23,7 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import mathlingua.GoldenType
 import mathlingua.common.LocationTracker
+import mathlingua.common.ParseError
 import mathlingua.common.ValidationSuccess
 import mathlingua.common.chalktalk.phase1.newChalkTalkLexer
 import mathlingua.common.chalktalk.phase1.newChalkTalkParser
@@ -46,7 +47,7 @@ internal class ChalkTalkParserTest {
 
                 val parser = newChalkTalkParser()
                 val result = parser.parse(lexer)
-                assertThat(result.errors.size).isEqualTo(0)
+                assertThat(result.errors).isEqualTo(emptyList<ParseError>())
                 assertThat(result.root).isNotNull()
 
                 val tracker = newLocationTracker()

--- a/src/test/resources/goldens/chalktalk/handles sequence abstractions/input.math
+++ b/src/test/resources/goldens/chalktalk/handles sequence abstractions/input.math
@@ -1,0 +1,3 @@
+Theorem:
+. for: {a_k}_k
+  then: "something"

--- a/src/test/resources/goldens/chalktalk/handles sequence abstractions/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/handles sequence abstractions/phase1-output.math
@@ -1,0 +1,5 @@
+Theorem:
+. for:
+  . {a_k}_k
+  then:
+  . "something"

--- a/src/test/resources/goldens/chalktalk/handles sequence abstractions/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles sequence abstractions/phase1-structure.txt
@@ -23,22 +23,34 @@ Root(
                                                           args = [
                                                                    Argument(
                                                                      chalkTalkTarget = Abstraction(
-                                                                       isEnclosed = false
+                                                                       isEnclosed = true
                                                                        parts = [
                                                                                  AbstractionPart(
                                                                                    name = Phase1Token(
                                                                                      text = "a"
                                                                                      type = ChalkTalkTokenType.Name
                                                                                      row = 1
-                                                                                     column = 8
+                                                                                     column = 9
                                                                                    )
                                                                                    subParams = [
+                                                                                                 Phase1Token(
+                                                                                                   text = "k"
+                                                                                                   type = ChalkTalkTokenType.Name
+                                                                                                   row = 1
+                                                                                                   column = 11
+                                                                                                 )
                                                                                                ]
-                                                                                   params = [
-                                                                                            ]
+                                                                                   params = null
                                                                                  )
                                                                                ]
-                                                                       subParams = null
+                                                                       subParams = [
+                                                                                     Phase1Token(
+                                                                                       text = "k"
+                                                                                       type = ChalkTalkTokenType.Name
+                                                                                       row = 1
+                                                                                       column = 14
+                                                                                     )
+                                                                                   ]
                                                                      )
                                                                    )
                                                                  ]
@@ -52,21 +64,11 @@ Root(
                                                           )
                                                           args = [
                                                                    Argument(
-                                                                     chalkTalkTarget = Abstraction(
-                                                                       isEnclosed = false
-                                                                       parts = [
-                                                                                 AbstractionPart(
-                                                                                   name = Phase1Token(
-                                                                                     text = "b"
-                                                                                     type = ChalkTalkTokenType.Name
-                                                                                     row = 2
-                                                                                     column = 9
-                                                                                   )
-                                                                                   subParams = null
-                                                                                   params = null
-                                                                                 )
-                                                                               ]
-                                                                       subParams = null
+                                                                     chalkTalkTarget = Phase1Token(
+                                                                       text = ""something""
+                                                                       type = ChalkTalkTokenType.String
+                                                                       row = 2
+                                                                       column = 9
                                                                      )
                                                                    )
                                                                  ]

--- a/src/test/resources/goldens/chalktalk/handles sequence abstractions/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/handles sequence abstractions/phase2-output.math
@@ -1,0 +1,4 @@
+Theorem:
+. for: {a_k}_k
+  then:
+  . "something"

--- a/src/test/resources/goldens/chalktalk/handles sequence abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles sequence abstractions/phase2-structure.txt
@@ -13,39 +13,34 @@ Document(
                                      targets = [
                                                  AbstractionNode(
                                                    abstraction = Abstraction(
-                                                     isEnclosed = false
+                                                     isEnclosed = true
                                                      parts = [
                                                                AbstractionPart(
                                                                  name = Phase1Token(
                                                                    text = "a"
                                                                    type = ChalkTalkTokenType.Name
                                                                    row = 1
-                                                                   column = 8
+                                                                   column = 9
                                                                  )
                                                                  subParams = [
                                                                                Phase1Token(
-                                                                                 text = "x"
+                                                                                 text = "k"
                                                                                  type = ChalkTalkTokenType.Name
                                                                                  row = 1
                                                                                  column = 11
-                                                                               ),
-                                                                               Phase1Token(
-                                                                                 text = "y"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 14
-                                                                               ),
-                                                                               Phase1Token(
-                                                                                 text = "z"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 17
                                                                                )
                                                                              ]
                                                                  params = null
                                                                )
                                                              ]
-                                                     subParams = null
+                                                     subParams = [
+                                                                   Phase1Token(
+                                                                     text = "k"
+                                                                     type = ChalkTalkTokenType.Name
+                                                                     row = 1
+                                                                     column = 14
+                                                                   )
+                                                                 ]
                                                    )
                                                  )
                                                ]
@@ -54,23 +49,8 @@ Document(
                                    thenSection = ThenSection(
                                      clauses = ClauseListNode(
                                        clauses = [
-                                                   AbstractionNode(
-                                                     abstraction = Abstraction(
-                                                       isEnclosed = false
-                                                       parts = [
-                                                                 AbstractionPart(
-                                                                   name = Phase1Token(
-                                                                     text = "b"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 2
-                                                                     column = 9
-                                                                   )
-                                                                   subParams = null
-                                                                   params = null
-                                                                 )
-                                                               ]
-                                                       subParams = null
-                                                     )
+                                                   Text(
+                                                     text = ""something""
                                                    )
                                                  ]
                                      )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and empty params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and empty params/phase2-structure.txt
@@ -28,6 +28,7 @@ Document(
                                                                           ]
                                                                )
                                                              ]
+                                                     subParams = null
                                                    )
                                                  )
                                                ]
@@ -51,6 +52,7 @@ Document(
                                                                    params = null
                                                                  )
                                                                ]
+                                                       subParams = null
                                                      )
                                                    )
                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and non-empty params/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and non-empty params/phase1-structure.txt
@@ -50,6 +50,7 @@ Root(
                                                                                             ]
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]
@@ -77,6 +78,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and non-empty params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and non-empty params/phase2-structure.txt
@@ -40,6 +40,7 @@ Document(
                                                                           ]
                                                                )
                                                              ]
+                                                     subParams = null
                                                    )
                                                  )
                                                ]
@@ -63,6 +64,7 @@ Document(
                                                                    params = null
                                                                  )
                                                                ]
+                                                       subParams = null
                                                      )
                                                    )
                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params and multiple params/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params and multiple params/phase1-structure.txt
@@ -62,6 +62,7 @@ Root(
                                                                                             ]
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]
@@ -89,6 +90,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params and multiple params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params and multiple params/phase2-structure.txt
@@ -52,6 +52,7 @@ Document(
                                                                           ]
                                                                )
                                                              ]
+                                                     subParams = null
                                                    )
                                                  )
                                                ]
@@ -75,6 +76,7 @@ Document(
                                                                    params = null
                                                                  )
                                                                ]
+                                                       subParams = null
                                                      )
                                                    )
                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params/phase1-structure.txt
@@ -55,6 +55,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]
@@ -82,6 +83,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses abstractions with non-empty sub params and empty params/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with non-empty sub params and empty params/phase1-structure.txt
@@ -50,6 +50,7 @@ Root(
                                                                                             ]
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]
@@ -77,6 +78,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses abstractions with non-empty sub params and empty params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with non-empty sub params and empty params/phase2-structure.txt
@@ -40,6 +40,7 @@ Document(
                                                                           ]
                                                                )
                                                              ]
+                                                     subParams = null
                                                    )
                                                  )
                                                ]
@@ -63,6 +64,7 @@ Document(
                                                                    params = null
                                                                  )
                                                                ]
+                                                       subParams = null
                                                      )
                                                    )
                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses abstractions with one sub param and multiple params/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with one sub param and multiple params/phase1-structure.txt
@@ -56,6 +56,7 @@ Root(
                                                                                             ]
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]
@@ -83,6 +84,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses abstractions with one sub param and multiple params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with one sub param and multiple params/phase2-structure.txt
@@ -46,6 +46,7 @@ Document(
                                                                           ]
                                                                )
                                                              ]
+                                                     subParams = null
                                                    )
                                                  )
                                                ]
@@ -69,6 +70,7 @@ Document(
                                                                    params = null
                                                                  )
                                                                ]
+                                                       subParams = null
                                                      )
                                                    )
                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses abstractions with one sub param/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with one sub param/phase1-structure.txt
@@ -43,6 +43,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]
@@ -70,6 +71,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses abstractions with one sub param/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with one sub param/phase2-structure.txt
@@ -33,6 +33,7 @@ Document(
                                                                  params = null
                                                                )
                                                              ]
+                                                     subParams = null
                                                    )
                                                  )
                                                ]
@@ -56,6 +57,7 @@ Document(
                                                                    params = null
                                                                  )
                                                                ]
+                                                       subParams = null
                                                      )
                                                    )
                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses enclosed abstractions with sub params/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed abstractions with sub params/phase1-structure.txt
@@ -43,6 +43,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]
@@ -70,6 +71,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses enclosed abstractions with sub params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed abstractions with sub params/phase2-structure.txt
@@ -33,6 +33,7 @@ Document(
                                                                  params = null
                                                                )
                                                              ]
+                                                     subParams = null
                                                    )
                                                  )
                                                ]
@@ -56,6 +57,7 @@ Document(
                                                                    params = null
                                                                  )
                                                                ]
+                                                       subParams = null
                                                      )
                                                    )
                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses enclosed plain abstractions/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed plain abstractions/phase1-structure.txt
@@ -36,6 +36,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]
@@ -63,6 +64,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses enclosed plain abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed plain abstractions/phase2-structure.txt
@@ -26,6 +26,7 @@ Document(
                                                                  params = null
                                                                )
                                                              ]
+                                                     subParams = null
                                                    )
                                                  )
                                                ]
@@ -49,6 +50,7 @@ Document(
                                                                    params = null
                                                                  )
                                                                ]
+                                                       subParams = null
                                                      )
                                                    )
                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses enclosed regular abstractions/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed regular abstractions/phase1-structure.txt
@@ -43,6 +43,7 @@ Root(
                                                                                             ]
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]
@@ -70,6 +71,7 @@ Root(
                                                                                    params = null
                                                                                  )
                                                                                ]
+                                                                       subParams = null
                                                                      )
                                                                    )
                                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses enclosed regular abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed regular abstractions/phase2-structure.txt
@@ -33,6 +33,7 @@ Document(
                                                                           ]
                                                                )
                                                              ]
+                                                     subParams = null
                                                    )
                                                  )
                                                ]
@@ -56,6 +57,7 @@ Document(
                                                                    params = null
                                                                  )
                                                                ]
+                                                       subParams = null
                                                      )
                                                    )
                                                  ]

--- a/src/test/resources/goldens/chalktalk/parses multi var abstractions/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multi var abstractions/phase1-structure.txt
@@ -44,6 +44,7 @@ Root(
                                                                 ]
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/parses multi var abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multi var abstractions/phase2-structure.txt
@@ -42,6 +42,7 @@ Document(
                                                           ]
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  )
                                ]

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments indented/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments indented/phase1-structure.txt
@@ -25,6 +25,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        ),
                                        Argument(
@@ -42,6 +43,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        ),
                                        Argument(
@@ -59,6 +61,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments indented/phase2-structure.txt
@@ -23,6 +23,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  ),
                                  AbstractionNode(
@@ -40,6 +41,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  ),
                                  AbstractionNode(
@@ -57,6 +59,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  )
                                ]

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments mixed indented/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments mixed indented/phase1-structure.txt
@@ -25,6 +25,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        ),
                                        Argument(
@@ -42,6 +43,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        ),
                                        Argument(
@@ -59,6 +61,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        ),
                                        Argument(
@@ -76,6 +79,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        ),
                                        Argument(
@@ -93,6 +97,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        ),
                                        Argument(
@@ -110,6 +115,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments mixed indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments mixed indented/phase2-structure.txt
@@ -23,6 +23,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  ),
                                  AbstractionNode(
@@ -40,6 +41,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  ),
                                  AbstractionNode(
@@ -57,6 +59,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  ),
                                  AbstractionNode(
@@ -74,6 +77,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  ),
                                  AbstractionNode(
@@ -91,6 +95,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  ),
                                  AbstractionNode(
@@ -108,6 +113,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  )
                                ]

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments single line/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments single line/phase1-structure.txt
@@ -25,6 +25,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        ),
                                        Argument(
@@ -42,6 +43,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        ),
                                        Argument(
@@ -59,6 +61,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments single line/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments single line/phase2-structure.txt
@@ -23,6 +23,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  ),
                                  AbstractionNode(
@@ -40,6 +41,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  ),
                                  AbstractionNode(
@@ -57,6 +59,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  )
                                ]

--- a/src/test/resources/goldens/chalktalk/parses names with .../phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses names with .../phase1-structure.txt
@@ -25,6 +25,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/parses names with .../phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses names with .../phase2-structure.txt
@@ -23,6 +23,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  )
                                ]

--- a/src/test/resources/goldens/chalktalk/parses nested names with .../phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses nested names with .../phase1-structure.txt
@@ -32,6 +32,7 @@ Root(
                                                                 ]
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/parses nested names with .../phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses nested names with .../phase2-structure.txt
@@ -30,6 +30,7 @@ Document(
                                                           ]
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  )
                                ]

--- a/src/test/resources/goldens/chalktalk/parses operator identifiers/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses operator identifiers/phase1-structure.txt
@@ -25,6 +25,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/parses operator identifiers/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses operator identifiers/phase2-structure.txt
@@ -23,6 +23,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  )
                                ]

--- a/src/test/resources/goldens/chalktalk/parses single argument indented/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single argument indented/phase1-structure.txt
@@ -25,6 +25,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/parses single argument indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single argument indented/phase2-structure.txt
@@ -23,6 +23,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  )
                                ]

--- a/src/test/resources/goldens/chalktalk/parses single argument on same line/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single argument on same line/phase1-structure.txt
@@ -25,6 +25,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/parses single argument on same line/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single argument on same line/phase2-structure.txt
@@ -23,6 +23,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  )
                                ]

--- a/src/test/resources/goldens/chalktalk/parses single var abstractions/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single var abstractions/phase1-structure.txt
@@ -32,6 +32,7 @@ Root(
                                                                 ]
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/parses single var abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single var abstractions/phase2-structure.txt
@@ -30,6 +30,7 @@ Document(
                                                           ]
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  )
                                ]

--- a/src/test/resources/goldens/chalktalk/parses text identifiers/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses text identifiers/phase1-structure.txt
@@ -25,6 +25,7 @@ Root(
                                                        params = null
                                                      )
                                                    ]
+                                           subParams = null
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/parses text identifiers/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses text identifiers/phase2-structure.txt
@@ -23,6 +23,7 @@ Document(
                                                  params = null
                                                )
                                              ]
+                                     subParams = null
                                    )
                                  )
                                ]


### PR DESCRIPTION
The printExpanded() function now takes an `input` paramenter and
a `supplemental` parameter.  The `input` parameter specifies the
text to render and the `supplemental` parameter specifies text
that contains additional definitions.