### PR TITLE
fix: `MeansSection.forEach()` not implemented correctly

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/MeansSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/MeansSection.kt
@@ -24,7 +24,7 @@ import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.validateClauseList
 
 data class MeansSection(val clauses: ClauseListNode) : Phase2Node {
-    override fun forEach(fn: (node: Phase2Node) -> Unit) = fn(clauses)
+    override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
@@ -36,9 +36,10 @@ data class MeansSection(val clauses: ClauseListNode) : Phase2Node {
         return writer
     }
 
-    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(MeansSection(
-            clauses = clauses.transform(chalkTransformer) as ClauseListNode
-    ))
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
+            chalkTransformer(MeansSection(
+                    clauses = clauses.transform(chalkTransformer) as ClauseListNode
+            ))
 }
 
 fun validateMeansSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(

--- a/src/test/resources/goldens/chalktalk/parses text elements/input.math
+++ b/src/test/resources/goldens/chalktalk/parses text elements/input.math
@@ -1,0 +1,3 @@
+[A]
+Defines: B
+means: "C"

--- a/src/test/resources/goldens/chalktalk/parses text elements/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/parses text elements/phase1-output.math
@@ -1,0 +1,5 @@
+[A]
+Defines:
+. B
+means:
+. "C"

--- a/src/test/resources/goldens/chalktalk/parses text elements/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses text elements/phase1-structure.txt
@@ -1,0 +1,60 @@
+Root(
+  groups = [
+             Group(
+               sections = [
+                            Section(
+                              name = Phase1Token(
+                                text = "Defines"
+                                type = ChalkTalkTokenType.Name
+                                row = 1
+                                column = 1
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Abstraction(
+                                           isEnclosed = false
+                                           parts = [
+                                                     AbstractionPart(
+                                                       name = Phase1Token(
+                                                         text = "B"
+                                                         type = ChalkTalkTokenType.Name
+                                                         row = 1
+                                                         column = 10
+                                                       )
+                                                       subParams = null
+                                                       params = null
+                                                     )
+                                                   ]
+                                           subParams = null
+                                         )
+                                       )
+                                     ]
+                            ),
+                            Section(
+                              name = Phase1Token(
+                                text = "means"
+                                type = ChalkTalkTokenType.Name
+                                row = 2
+                                column = 1
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Phase1Token(
+                                           text = ""C""
+                                           type = ChalkTalkTokenType.String
+                                           row = 2
+                                           column = 8
+                                         )
+                                       )
+                                     ]
+                            )
+                          ]
+               id = Phase1Token(
+                 text = "[A]"
+                 type = ChalkTalkTokenType.Id
+                 row = 0
+                 column = 0
+               )
+             )
+           ]
+)

--- a/src/test/resources/goldens/chalktalk/parses text elements/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/parses text elements/phase2-output.math
@@ -1,0 +1,4 @@
+[A]
+Defines: B
+means:
+. "C"

--- a/src/test/resources/goldens/chalktalk/parses text elements/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses text elements/phase2-structure.txt
@@ -1,0 +1,69 @@
+Document(
+  defines = [
+              DefinesGroup(
+                signature = null
+                id = IdStatement(
+                  text = "A"
+                  texTalkRoot = ValidationSuccessImpl(
+                    v = ExpressionTexTalkNode(
+                      children = [
+                                   TextTexTalkNode(
+                                     type = TexTalkNodeType.Identifier
+                                     text = "A"
+                                     isVarArg = false
+                                   )
+                                 ]
+                    )
+                  )
+                )
+                definesSection = DefinesSection(
+                  targets = [
+                              AbstractionNode(
+                                abstraction = Abstraction(
+                                  isEnclosed = false
+                                  parts = [
+                                            AbstractionPart(
+                                              name = Phase1Token(
+                                                text = "B"
+                                                type = ChalkTalkTokenType.Name
+                                                row = 1
+                                                column = 10
+                                              )
+                                              subParams = null
+                                              params = null
+                                            )
+                                          ]
+                                  subParams = null
+                                )
+                              )
+                            ]
+                )
+                assumingSection = null
+                meansSections = [
+                                  MeansSection(
+                                    clauses = ClauseListNode(
+                                      clauses = [
+                                                  Text(
+                                                    text = ""C""
+                                                  )
+                                                ]
+                                    )
+                                  )
+                                ]
+                aliasSection = null
+                metaDataSection = null
+              )
+            ]
+  represents = [
+               ]
+  theorems = [
+             ]
+  axioms = [
+           ]
+  conjectures = [
+                ]
+  resources = [
+              ]
+  protoGroups = [
+                ]
+)


### PR DESCRIPTION
The `MeansSection.forEach()` method was not implemented correctly.
As a result, any child of MeansSection didn't have its location
recorded for the parseWithLocations() function.