### PR TITLE
fix: written as works with only represents

### DIFF
--- a/src/main/kotlin/mathlingua/common/MathLingua.kt
+++ b/src/main/kotlin/mathlingua/common/MathLingua.kt
@@ -257,7 +257,11 @@ object MathLingua {
             MathLinguaCodeWriter(defines = defines, represents = represents)
         }
         val code = node.toCode(false, 0, writer = writer).getCode()
-        return getHtml(code.replace("<br/><br/><br/>", "<br/><br/>"))
+        return if (html) {
+            getHtml(code.replace("<br/><br/><br/>", "<br/><br/>"))
+        } else {
+            code
+        }
     }
 }
 
@@ -372,13 +376,10 @@ private fun getHtml(body: String) = """
             }
 
             .mathlingua-top-level {
-                box-shadow: 0px 0px 2px 0px #888888;
-                padding: 1em;
                 display: block;
                 width: fit-content;
                 overflow: scroll;
-                margin-left: auto;
-                margin-right: auto;
+                margin-left: 1em;
             }
 
             .katex {

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexer.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexer.kt
@@ -36,6 +36,12 @@ fun newChalkTalkLexer(text: String): ChalkTalkLexer {
 
 // ------------------------------------------------------------------------------------------------------------------ //
 
+// this function is needed to support transpiling to JavaScript since kotlinc-js states
+// that Character.isDigit() is an unresolved reference
+private fun isDigit(c: Char): Boolean {
+    return c in '0'..'9'
+}
+
 private class ChalkTalkLexerImpl(private var text: String) :
     ChalkTalkLexer {
 
@@ -223,10 +229,10 @@ private class ChalkTalkLexerImpl(private var text: String) :
 
                 // process the name#123 case and if matching mark the match as complete
                 if (i < text.length && text[i] == '#' &&
-                        i + 1 < text.length && text[i + 1].isDigit()) {
+                        i + 1 < text.length && isDigit(text[i + 1])) {
                     name += text[i++] // append #
                     column++
-                    while (i < text.length && text[i].isDigit()) {
+                    while (i < text.length && isDigit(text[i])) {
                         name += text[i++]
                         column++
                     }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/CodeWriter.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/CodeWriter.kt
@@ -152,7 +152,7 @@ open class HtmlCodeWriter(
                 writeDirect(lhs)
             }
         } else {
-            if (root is ValidationSuccess && defines.isNotEmpty()) {
+            if (root is ValidationSuccess && (defines.isNotEmpty() || represents.isNotEmpty())) {
                 val patternsToWrittenAs = MathLingua.getPatternsToWrittenAs(defines, represents)
                 builder.append("\\[${expandAsWritten(root.value, patternsToWrittenAs)}\\]")
             } else {
@@ -260,7 +260,7 @@ class MathLinguaCodeWriter(
     }
 
     override fun writeStatement(stmtText: String, root: Validation<ExpressionTexTalkNode>) {
-        if (root is ValidationSuccess && defines.isNotEmpty()) {
+        if (root is ValidationSuccess && (defines.isNotEmpty() || represents.isNotEmpty())) {
             val patternsToWrittenAs = MathLingua.getPatternsToWrittenAs(defines, represents)
             builder.append("'${expandAsWritten(root.value, patternsToWrittenAs)}'")
         } else {

--- a/src/main/kotlin/mathlingua/common/textalk/PostProcessing.kt
+++ b/src/main/kotlin/mathlingua/common/textalk/PostProcessing.kt
@@ -18,7 +18,6 @@ package mathlingua.common.textalk
 
 import mathlingua.common.ParseError
 import mathlingua.common.collections.newStack
-import java.lang.Exception
 
 /*
  * The following is the algorithm for parsing operators and identifying their arguments.

--- a/src/test/kotlin/mathlingua/playground/WrittenAsPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/WrittenAsPlayground.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.mathlingua.playground
+
+import mathlingua.common.MathLingua
+import mathlingua.common.ValidationFailure
+import mathlingua.common.ValidationSuccess
+import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea
+import org.fife.ui.rsyntaxtextarea.SyntaxConstants
+import org.fife.ui.rtextarea.RTextScrollPane
+import java.awt.Font
+import java.awt.event.KeyEvent
+import java.awt.event.KeyListener
+import javax.swing.JFrame
+import javax.swing.JScrollPane
+import javax.swing.JSplitPane
+import javax.swing.JTextArea
+import javax.swing.SwingUtilities
+import javax.swing.UIManager
+import javax.swing.WindowConstants
+
+fun main() {
+    // enable sub-pixel antialiasing
+    System.setProperty("awt.useSystemAAFontSettings", "on")
+    try {
+        UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel")
+    } catch (e: Exception) {
+        println("Could not set the look and feel to Nimbus: $e")
+    }
+
+    val fontSize = 18
+    val fontName = "Courier New"
+    val font = Font(fontName, Font.PLAIN, fontSize)
+    val boldFont = Font(fontName, Font.BOLD, fontSize)
+
+    val errorArea = JTextArea()
+    errorArea.font = font
+
+    val outputArea = RSyntaxTextArea(20, 60)
+    outputArea.syntaxEditingStyle = SyntaxConstants.SYNTAX_STYLE_YAML
+    outputArea.isCodeFoldingEnabled = true
+    outputArea.highlightCurrentLine = false
+    outputArea.font = font
+    outputArea.syntaxScheme
+        .getStyle(org.fife.ui.rsyntaxtextarea.Token.IDENTIFIER).font = boldFont
+
+    val inputArea = RSyntaxTextArea(20, 60)
+    inputArea.syntaxEditingStyle = SyntaxConstants.SYNTAX_STYLE_YAML
+    inputArea.isCodeFoldingEnabled = true
+    inputArea.highlightCurrentLine = false
+    inputArea.font = font
+    inputArea.syntaxScheme
+        .getStyle(org.fife.ui.rsyntaxtextarea.Token.IDENTIFIER).font = boldFont
+
+    inputArea.addKeyListener(object : KeyListener {
+        override fun keyTyped(keyEvent: KeyEvent) {}
+
+        override fun keyReleased(keyEvent: KeyEvent) {
+            if (!keyEvent.isShiftDown || keyEvent.keyCode != KeyEvent.VK_ENTER) {
+                return
+            }
+
+            SwingUtilities.invokeLater {
+                val errorBuilder = StringBuilder()
+                try {
+                    val input = inputArea.text
+                    outputArea.text = ""
+                    when (val validation = MathLingua.printExpanded(input, input, false)) {
+                        is ValidationSuccess -> outputArea.text = validation.value
+                        is ValidationFailure -> {
+                            for (err in validation.errors) {
+                                errorBuilder.append("${err.message} (${err.row}, ${err.column})")
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    System.err.println(e.message)
+                    e.printStackTrace()
+                }
+                errorArea.text = errorBuilder.toString()
+            }
+        }
+
+        override fun keyPressed(keyEvent: KeyEvent) {}
+    })
+
+    val inputSplitPane = JSplitPane(JSplitPane.HORIZONTAL_SPLIT)
+    inputSplitPane.leftComponent = RTextScrollPane(inputArea)
+    inputSplitPane.rightComponent = JScrollPane(outputArea)
+    inputSplitPane.resizeWeight = 0.5
+
+    val textPane = JSplitPane(JSplitPane.VERTICAL_SPLIT)
+    textPane.dividerLocation = 600
+    textPane.topComponent = inputSplitPane
+    textPane.bottomComponent = JScrollPane(errorArea)
+
+    val frame = JFrame()
+    frame.setSize(1300, 900)
+    frame.contentPane = textPane
+    frame.defaultCloseOperation = WindowConstants.EXIT_ON_CLOSE
+    frame.isVisible = true
+}


### PR DESCRIPTION
If a document contained only Represents and no Defines, then written
as statements would not even be processed.  Now they are.