### PR TITLE
fix: address an issue matching operators

### DIFF
--- a/src/main/kotlin/mathlingua/common/MathLingua.kt
+++ b/src/main/kotlin/mathlingua/common/MathLingua.kt
@@ -164,6 +164,12 @@ object MathLingua {
                 val exp = validation.value
                 if (exp.children.size == 1 && exp.children[0] is OperatorTexTalkNode) {
                     result[exp.children[0] as OperatorTexTalkNode] = writtenAs
+                } else if (exp.children.size == 1 && exp.children[0] is Command) {
+                    result[OperatorTexTalkNode(
+                        lhs = null,
+                        command = exp.children[0] as Command,
+                        rhs = null
+                    )] = writtenAs
                 }
             }
         }
@@ -189,7 +195,9 @@ object MathLingua {
             val validation = def.id.texTalkRoot
             if (validation is ValidationSuccess) {
                 val exp = validation.value
-                if (exp.children.size == 1 && exp.children[0] is Command) {
+                if (exp.children.size == 1 && exp.children[0] is OperatorTexTalkNode) {
+                    result[exp.children[0] as OperatorTexTalkNode] = writtenAs
+                } else if (exp.children.size == 1 && exp.children[0] is Command) {
                     val cmd = exp.children[0] as Command
                     result[OperatorTexTalkNode(
                         lhs = null,
@@ -273,7 +281,7 @@ object MathLingua {
         }
         val code = node.toCode(false, 0, writer = writer).getCode()
         return if (html) {
-            getHtml(code.replace("<br/><br/><br/>", "<br/><br/>"))
+            getHtml(code)
         } else {
             code
         }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/CodeWriter.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/CodeWriter.kt
@@ -181,6 +181,7 @@ open class HtmlCodeWriter(
 
     override fun endTopLevel() {
         builder.append("</span>")
+        builder.append("<span class='end-mathlingua-top-level'/>")
     }
 
     override fun newCodeWriter(defines: List<DefinesGroup>) = HtmlCodeWriter(defines, represents)

--- a/src/test/kotlin/mathlingua/common/MathLinguaTest.kt
+++ b/src/test/kotlin/mathlingua/common/MathLinguaTest.kt
@@ -1,0 +1,92 @@
+package mathlingua.common
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import mathlingua.common.textalk.Command
+import mathlingua.common.textalk.CommandPart
+import mathlingua.common.textalk.ExpressionTexTalkNode
+import mathlingua.common.textalk.GroupTexTalkNode
+import mathlingua.common.textalk.OperatorTexTalkNode
+import mathlingua.common.textalk.ParametersTexTalkNode
+import mathlingua.common.textalk.TexTalkNodeType
+import mathlingua.common.textalk.TexTalkTokenType
+import mathlingua.common.textalk.TextTexTalkNode
+import org.junit.jupiter.api.Test
+
+internal class MathLinguaTest {
+
+    @Test
+    fun expandWrittenAs() {
+        val validation = MathLingua.parse("""
+            [\or{a}{b}]
+            Represents:
+            that: "something"
+            Metadata:
+            . written: "a? \text{ or } b?"
+        """.trimIndent())
+        assertThat(validation is ValidationSuccess)
+        val doc = (validation as ValidationSuccess).value
+        val map = MathLingua.getPatternsToWrittenAs(emptyList(), doc.represents)
+        val expectedCommand = Command(
+            parts = listOf(
+                CommandPart(
+                    name = TextTexTalkNode(
+                        type = TexTalkNodeType.Identifier,
+                        tokenType = TexTalkTokenType.Identifier,
+                        text = "or",
+                        isVarArg = false
+                    ),
+                    square = null,
+                    subSup = null,
+                    groups = listOf(
+                        GroupTexTalkNode(
+                            type = TexTalkNodeType.CurlyGroup,
+                            parameters = ParametersTexTalkNode(
+                                items = listOf(
+                                    ExpressionTexTalkNode(
+                                        children = listOf(
+                                            TextTexTalkNode(
+                                                type = TexTalkNodeType.Identifier,
+                                                tokenType = TexTalkTokenType.Identifier,
+                                                text = "a",
+                                                isVarArg = false
+                                            )
+                                        )
+                                    )
+                                )
+                            ),
+                            isVarArg = false
+                        ),
+                        GroupTexTalkNode(
+                            type = TexTalkNodeType.CurlyGroup,
+                            parameters = ParametersTexTalkNode(
+                                items = listOf(
+                                    ExpressionTexTalkNode(
+                                        children = listOf(
+                                            TextTexTalkNode(
+                                                type = TexTalkNodeType.Identifier,
+                                                tokenType = TexTalkTokenType.Identifier,
+                                                text = "b",
+                                                isVarArg = false
+                                            )
+                                        )
+                                    )
+                                )
+                            ),
+                            isVarArg = false
+                        )
+                    ),
+                    namedGroups = emptyList()
+                )
+            )
+        )
+        val expected = mapOf(
+            OperatorTexTalkNode(
+                lhs = null,
+                command = expectedCommand,
+                rhs = null
+            ) to "a? \\text{ or } b?"
+        )
+        assertThat(map).isEqualTo(expected)
+    }
+}


### PR DESCRIPTION
Previously, a `Represents:` was assumed to be an operator and a
`Defines:` to be a command.  Actually, a `Represents:` and a
`Defines:` can be an operator or a command.