### PR TITLE
feat: support `X??` and `X{...}??`

### DIFF
--- a/src/main/kotlin/mathlingua/common/MathLingua.kt
+++ b/src/main/kotlin/mathlingua/common/MathLingua.kt
@@ -310,7 +310,7 @@ private fun getHtml(body: String) = """
                 if (text[text.length - 1] === '"') {
                     text = text.substring(0, text.length - 1);
                 }
-                text = text.replace(/([a-zA-Z0-9])\?/g, '${'$'}1');
+                text = text.replace(/([a-zA-Z0-9])\?\??/g, '${'$'}1');
                 const fragment = document.createDocumentFragment();
                 var buffer = '';
                 var i = 0;


### PR DESCRIPTION
Using a `??` indicates that a variable should be replaced by
an expression surrounded by parentheses if the expression isn't
a single identifier or command.

For example, if the 'written as' form `\set.complement:of{X}` is
defined as `X?^C` then `\set.complement:of{A + B}` would be
expanded as `A + B^C` which is not what is wanted.

If, instead, the 'written as' form is defined as `X??^C` then
`\set.complement:of{A + B}` would be `(A + B)^C`, which is what
is desired.

Note, in this case, `\set.complement:of{A}` is still rendered
`A^C` (whithout the parentheses) because `A` is just an identifier
and not a complex expression like `A + B`.