### PR TITLE
fix: address issue html rendering commands with is

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/CodeWriter.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/CodeWriter.kt
@@ -50,6 +50,8 @@ interface CodeWriter {
     fun getCode(): String
 }
 
+const val IS = " is "
+
 open class HtmlCodeWriter(
     val defines: List<DefinesGroup>,
     val represents: List<RepresentsGroup>
@@ -137,7 +139,6 @@ open class HtmlCodeWriter(
 
     override fun writeStatement(stmtText: String, root: Validation<ExpressionTexTalkNode>) {
         builder.append("<span class='mathlingua-statement' title='${stmtText.removeSurrounding("'", "'")}'>")
-        val IS = "is"
         if (stmtText.contains(IS)) {
             val index = stmtText.indexOf(IS)
             builder.append("\\[${stmtText.substring(0, index)}\\]")


### PR DESCRIPTION
If a custom command contained the text `is` (such as `\exists`)
then previously it wasn't rendered correctly by the html
renderer.  In the example, it was rendered as `\ex is ts`.