### PR TITLE
feat: formalize the use of () vs {}

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/DefinesGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/DefinesGroup.kt
@@ -17,14 +17,22 @@
 package mathlingua.common.chalktalk.phase2.ast.toplevel
 
 import mathlingua.common.MutableLocationTracker
+import mathlingua.common.ParseError
+import mathlingua.common.Validation
+import mathlingua.common.ValidationFailure
+import mathlingua.common.ValidationSuccess
 import mathlingua.common.chalktalk.phase1.ast.Group
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.clause.AbstractionNode
 import mathlingua.common.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.common.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.common.chalktalk.phase2.ast.section.*
 import mathlingua.common.chalktalk.phase2.ast.metadata.section.MetaDataSection
+import mathlingua.common.textalk.Command
+import mathlingua.common.validationFailure
+import mathlingua.common.validationSuccess
 
 data class DefinesGroup(
     val signature: String?,
@@ -74,7 +82,8 @@ data class DefinesGroup(
 
 fun isDefinesGroup(node: Phase1Node) = firstSectionMatchesName(node, "Defines")
 
-fun validateDefinesGroup(groupNode: Group, tracker: MutableLocationTracker) = validateDefinesLikeGroup(
+fun validateDefinesGroup(groupNode: Group, tracker: MutableLocationTracker): Validation<DefinesGroup> {
+    val validation = validateDefinesLikeGroup(
         tracker,
         groupNode,
         "Defines",
@@ -82,4 +91,100 @@ fun validateDefinesGroup(groupNode: Group, tracker: MutableLocationTracker) = va
         "means",
         ::validateMeansSection,
         ::DefinesGroup
-)
+    )
+
+    if (validation is ValidationFailure) {
+        return validation
+    }
+
+    val errors = mutableListOf<ParseError>()
+    val defines = (validation as ValidationSuccess).value
+    val idParen = if (defines.id.texTalkRoot is ValidationSuccess) {
+        val commandParts = (defines.id.texTalkRoot.value.children.find {
+            it is Command
+        } as Command?)?.parts ?: emptyList()
+
+        val partsWithParens = commandParts.filter { it.paren != null }
+        if (partsWithParens.isNotEmpty() && partsWithParens.size != 1) {
+            val location = tracker.getLocationOf(defines.id)
+            errors.add(
+                ParseError(
+                    message = "A signature can only contain zero or one set of parens",
+                    row = location?.row ?: -1,
+                    column = location?.column ?: -1
+                )
+            )
+        }
+
+        if (partsWithParens.isEmpty()) {
+            null
+        } else {
+            partsWithParens[0].paren
+        }
+    } else {
+        null
+    }
+
+    if (errors.isNotEmpty()) {
+        return validationFailure(errors)
+    } else if (idParen == null) {
+        return validationSuccess(defines)
+    }
+
+    // it is ok for the id to not have a () but the definition to
+    // contain one such as
+    //
+    //   [\function]
+    //   Defines: f(x)
+    //   means: ...
+
+    // if the targets is empty then `validation` above would have been
+    // a ValidationFailure and the code would not have reached this point
+    val target = defines.definesSection.targets[0]
+    val location = tracker.getLocationOf(target)
+
+    if (target !is AbstractionNode) {
+        errors.add(
+            ParseError(
+                message = "If the signature of a Defines contains a parens then it must define " +
+                    "a function type with a matching signature in parens",
+                row = location?.row ?: -1,
+                column = location?.column ?: -1
+            ))
+    } else {
+        if (target.abstraction.isVarArgs ||
+            target.abstraction.isEnclosed ||
+            !target.abstraction.subParams.isNullOrEmpty() ||
+            target.abstraction.parts.size != 1) {
+            errors.add(
+                ParseError(
+                    message = "If the signature of a Defines contains a parens then " +
+                        "the function type it defines cannot describe a sequence like, set like, or variadic form.",
+                    row = location?.row ?: -1,
+                    column = location?.column ?: -1
+                )
+            )
+        } else {
+            val func = target.abstraction.parts[0]
+            val idForm = idParen.toCode().replace(" ", "")
+            val defForm = func.toCode().replace(func.name.text, "").replace(" ", "")
+            if (idForm != defForm) {
+                errors.add(
+                    ParseError(
+                        message = "If the signature of a Defines contains a parens then " +
+                            "then the defines must define a function like that has the exact same " +
+                            "signature as the parens in the signature of the Defines.",
+                        row = location?.row ?: -1,
+                        column = location?.column ?: -1
+                    )
+                )
+            }
+        }
+    }
+
+    return if (errors.isEmpty()) {
+        validationSuccess(defines)
+    } else {
+        validationFailure(errors)
+    }
+}

--- a/src/main/kotlin/mathlingua/common/textalk/Ast.kt
+++ b/src/main/kotlin/mathlingua/common/textalk/Ast.kt
@@ -110,6 +110,7 @@ data class CommandPart(
     val square: GroupTexTalkNode?,
     val subSup: SubSupTexTalkNode?,
     val groups: List<GroupTexTalkNode>,
+    val paren: GroupTexTalkNode?,
     val namedGroups: List<NamedGroupTexTalkNode>
 ) : TexTalkNode {
 
@@ -138,6 +139,10 @@ data class CommandPart(
             buffer.append(grp.toCode(interceptor))
         }
 
+        if (paren != null) {
+            buffer.append(paren.toCode(interceptor))
+        }
+
         if (namedGroups.isNotEmpty()) {
             buffer.append(":")
         }
@@ -159,6 +164,11 @@ data class CommandPart(
         }
 
         groups.forEach(fn)
+
+        if (paren != null) {
+            fn(paren)
+        }
+
         namedGroups.forEach(fn)
     }
 
@@ -168,6 +178,7 @@ data class CommandPart(
             square = square?.transform(transformer) as GroupTexTalkNode?,
             subSup = subSup?.transform(transformer) as SubSupTexTalkNode?,
             groups = groups.map { it.transform(transformer) as GroupTexTalkNode },
+            paren = paren?.transform(transformer) as GroupTexTalkNode?,
             namedGroups = namedGroups.map { it.transform(transformer) as NamedGroupTexTalkNode }
         ))
 }

--- a/src/main/kotlin/mathlingua/common/textalk/TexTalkParser.kt
+++ b/src/main/kotlin/mathlingua/common/textalk/TexTalkParser.kt
@@ -178,29 +178,13 @@ private class TexTalkParserImpl : TexTalkParser {
             val subSup = subSup()
             val groups = mutableListOf<GroupTexTalkNode>()
 
-            var startGroup: GroupTexTalkNode? = null
+            while (texTalkLexer.hasNext()) {
+                val grp = group(TexTalkNodeType.CurlyGroup)
+                grp ?: break
+                groups.add(grp)
+            }
+
             val paren = group(TexTalkNodeType.ParenGroup)
-            if (paren != null) {
-                startGroup = paren
-            }
-
-            if (startGroup == null) {
-                val curly = group(TexTalkNodeType.CurlyGroup)
-                if (curly != null) {
-                    startGroup = curly
-                }
-            }
-
-            if (startGroup != null) {
-                groups.add(startGroup)
-
-                while (hasNext()) {
-                    val grp = group(startGroup.type)
-                    grp ?: break
-                    groups.add(grp)
-                }
-            }
-
             val namedGroups = mutableListOf<NamedGroupTexTalkNode>()
             if (has(TexTalkTokenType.Colon)) {
                 expect(TexTalkTokenType.Colon) // absorb the colon
@@ -216,6 +200,7 @@ private class TexTalkParserImpl : TexTalkParser {
                 square,
                 subSup,
                 groups,
+                paren,
                 namedGroups
             )
         }

--- a/src/main/kotlin/mathlingua/common/transform/Matcher.kt
+++ b/src/main/kotlin/mathlingua/common/transform/Matcher.kt
@@ -312,6 +312,23 @@ private fun findSubstitutions(pattern: CommandPart, value: CommandPart, subs: Mu
 
     handleVariadicGroupSubstitutions(pattern.groups, value.groups, subs)
 
+    if (pattern.paren == null && value.paren != null) {
+        // if the pattern doesn't accept a paren but the value has one,
+        // then it isn't a match
+        subs.doesMatch = false
+    } else if (pattern.paren != null && value.paren != null) {
+        // if the value and pattern both have parens, they have to match
+        // in the number of parameters
+        findSubstitutions(pattern.paren, value.paren, subs)
+    }
+
+    // it is fine if the pattern has a paren but the value does not
+    // because then the value is assumed to have (?,?) with the number
+    // of ? matching the number of parameters that are expected
+
+    // it is also fine if neither the pattern or the value have parens
+    // in that case it is a match but there are no substitutions needed
+
     if (pattern.namedGroups.size == value.namedGroups.size) {
         for (i in pattern.namedGroups.indices) {
             val patternGrp = pattern.namedGroups[i]
@@ -373,6 +390,8 @@ private fun validatePatternImpl(part: CommandPart, errors: MutableList<String>) 
     validatePatternGroupImpl(part.square, false, "A square group", errors)
     validatePatternGroupImpl(part.subSup?.sub, false, "A ^ group", errors)
     validatePatternGroupImpl(part.subSup?.sup, false, "A _ group", errors)
+    validatePatternGroupImpl(part.paren, true, "A paren group", errors)
+
     for (i in part.groups.indices) {
         val canBeVarArg = i == part.groups.size - 1
         val description = if (i == part.groups.size - 1) {

--- a/src/test/kotlin/mathlingua/common/MathLinguaTest.kt
+++ b/src/test/kotlin/mathlingua/common/MathLinguaTest.kt
@@ -307,6 +307,7 @@ internal class MathLinguaTest {
                             isVarArg = false
                         )
                     ),
+                    paren = null,
                     namedGroups = emptyList()
                 )
             )

--- a/src/test/kotlin/mathlingua/common/transform/MatcherKtTest.kt
+++ b/src/test/kotlin/mathlingua/common/transform/MatcherKtTest.kt
@@ -82,6 +82,66 @@ class MatcherKtTest {
     }
 
     @Test
+    fun testParenCommandValueWithParenExpandAsWritten() {
+        val patternToExpression = mapOf(
+            buildOperator(buildCommand("\\function(x)")) to "f(x?)"
+        )
+        val node = buildNode("\\function(y)")
+        val expanded = expandAsWritten(node, patternToExpression)
+        assertThat(expanded).isEqualTo("f(y)")
+    }
+
+    @Test
+    fun testParenCommandValueWithoutParenExpandAsWritten() {
+        val patternToExpression = mapOf(
+            buildOperator(buildCommand("\\function(x)")) to "f(x?)"
+        )
+        val node = buildNode("\\function")
+        val expanded = expandAsWritten(node, patternToExpression)
+        assertThat(expanded).isEqualTo("f(x?)")
+    }
+
+    @Test
+    fun testParenCommandValueWithParenVarargExpandAsWritten() {
+        val patternToExpression = mapOf(
+            buildOperator(buildCommand("\\function(x...)")) to "f(x{...;...}?)"
+        )
+        val node = buildNode("\\function(a, b, c)")
+        val expanded = expandAsWritten(node, patternToExpression)
+        assertThat(expanded).isEqualTo("f(a;b;c)")
+    }
+
+    @Test
+    fun testParenCommandValueWithParenAndCurlyExpandAsWritten() {
+        val patternToExpression = mapOf(
+            buildOperator(buildCommand("\\function{a}(x)")) to "f_{a?}(x?)"
+        )
+        val node = buildNode("\\function{b}(y)")
+        val expanded = expandAsWritten(node, patternToExpression)
+        assertThat(expanded).isEqualTo("f_{b}(y)")
+    }
+
+    @Test
+    fun testParenCommandValueWithParenAndNamedGroupExpandAsWritten() {
+        val patternToExpression = mapOf(
+            buildOperator(buildCommand("\\function(x):given{a}")) to "f_{a?}(x?)"
+        )
+        val node = buildNode("\\function(y):given{b}")
+        val expanded = expandAsWritten(node, patternToExpression)
+        assertThat(expanded).isEqualTo("f_{b}(y)")
+    }
+
+    @Test
+    fun testParenCommandNoMatchExpandAsWritten() {
+        val patternToExpression = mapOf(
+            buildOperator(buildCommand("\\function(x)")) to "f(x?)"
+        )
+        val node = buildNode("\\function(a,b)")
+        val expanded = expandAsWritten(node, patternToExpression)
+        assertThat(expanded).isEqualTo("\\function(a, b)")
+    }
+
+    @Test
     fun testSimpleCommandExpandAsWritten() {
         val patternToExpansion = mapOf(
                 buildOperator(buildCommand("\\function:on{A}to{B}")) to "\\cdot : A? \\rightarrow B?"

--- a/src/test/resources/goldens/chalktalk/handle varargs with defined length/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handle varargs with defined length/phase2-structure.txt
@@ -38,6 +38,7 @@ Document(
                                                               isVarArg = false
                                                             )
                                                           ]
+                                                 paren = null
                                                  namedGroups = [
                                                                ]
                                                )

--- a/src/test/resources/goldens/messages/Defines id paren must match target/input.math
+++ b/src/test/resources/goldens/messages/Defines id paren must match target/input.math
@@ -1,0 +1,23 @@
+[\f(x, y)]
+Defines: f(x)
+means: 'something'
+
+[\g(x)]
+Defines: f
+means: 'something'
+
+[\h(x)]
+Defines: {h}
+means: 'something'
+
+[\j(x)]
+Defines: j_x
+means: 'something'
+
+[\k(x, y)]
+Defines: k(  x,    y  )
+means: 'something'
+
+[\n]
+Defines: n(x)
+means: 'something'

--- a/src/test/resources/goldens/messages/Defines id paren must match target/messages.txt
+++ b/src/test/resources/goldens/messages/Defines id paren must match target/messages.txt
@@ -1,0 +1,24 @@
+Row: 1
+Column: 10
+Message:
+If the signature of a Defines contains a parens then then the defines must define a function like that has the exact same signature as the parens in the signature of the Defines.
+EndMessage:
+
+Row: 5
+Column: 10
+Message:
+If the signature of a Defines contains a parens then then the defines must define a function like that has the exact same signature as the parens in the signature of the Defines.
+EndMessage:
+
+Row: 9
+Column: 11
+Message:
+If the signature of a Defines contains a parens then the function type it defines cannot describe a sequence like, set like, or variadic form.
+EndMessage:
+
+Row: 13
+Column: 10
+Message:
+If the signature of a Defines contains a parens then then the defines must define a function like that has the exact same signature as the parens in the signature of the Defines.
+EndMessage:
+

--- a/src/test/resources/goldens/textalk/handles varargs in groups/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/handles varargs in groups/phase1-structure.txt
@@ -49,6 +49,7 @@ ExpressionTexTalkNode(
                                           isVarArg = true
                                         )
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses commands with a single bare sub param and a single bare sup param/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses commands with a single bare sub param and a single bare sup param/phase1-structure.txt
@@ -67,6 +67,7 @@ ExpressionTexTalkNode(
                              )
                              groups = [
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses commands with a single bare sub param/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses commands with a single bare sub param/phase1-structure.txt
@@ -50,6 +50,7 @@ ExpressionTexTalkNode(
                              )
                              groups = [
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses commands with a single bare sup param/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses commands with a single bare sup param/phase1-structure.txt
@@ -50,6 +50,7 @@ ExpressionTexTalkNode(
                              )
                              groups = [
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses complex compound name/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses complex compound name/phase1-structure.txt
@@ -85,6 +85,7 @@ ExpressionTexTalkNode(
                                           isVarArg = false
                                         )
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            ),
@@ -99,6 +100,7 @@ ExpressionTexTalkNode(
                              subSup = null
                              groups = [
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            ),
@@ -112,25 +114,25 @@ ExpressionTexTalkNode(
                              square = null
                              subSup = null
                              groups = [
-                                        GroupTexTalkNode(
-                                          type = TexTalkNodeType.ParenGroup
-                                          parameters = ParametersTexTalkNode(
-                                            items = [
-                                                      ExpressionTexTalkNode(
-                                                        children = [
-                                                                     TextTexTalkNode(
-                                                                       type = TexTalkNodeType.Identifier
-                                                                       tokenType = TexTalkTokenType.Identifier
-                                                                       text = "x"
-                                                                       isVarArg = false
-                                                                     )
-                                                                   ]
-                                                      )
-                                                    ]
-                                          )
-                                          isVarArg = false
-                                        )
                                       ]
+                             paren = GroupTexTalkNode(
+                               type = TexTalkNodeType.ParenGroup
+                               parameters = ParametersTexTalkNode(
+                                 items = [
+                                           ExpressionTexTalkNode(
+                                             children = [
+                                                          TextTexTalkNode(
+                                                            type = TexTalkNodeType.Identifier
+                                                            tokenType = TexTalkTokenType.Identifier
+                                                            text = "x"
+                                                            isVarArg = false
+                                                          )
+                                                        ]
+                                           )
+                                         ]
+                               )
+                               isVarArg = false
+                             )
                              namedGroups = [
                                            ]
                            ),
@@ -190,6 +192,7 @@ ExpressionTexTalkNode(
                                           isVarArg = false
                                         )
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses compound name command/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses compound name command/phase1-structure.txt
@@ -13,6 +13,7 @@ ExpressionTexTalkNode(
                              subSup = null
                              groups = [
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            ),
@@ -27,6 +28,7 @@ ExpressionTexTalkNode(
                              subSup = null
                              groups = [
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            ),
@@ -41,6 +43,7 @@ ExpressionTexTalkNode(
                              subSup = null
                              groups = [
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses expressions/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses expressions/phase1-structure.txt
@@ -53,25 +53,25 @@ ExpressionTexTalkNode(
                                    square = null
                                    subSup = null
                                    groups = [
-                                              GroupTexTalkNode(
-                                                type = TexTalkNodeType.ParenGroup
-                                                parameters = ParametersTexTalkNode(
-                                                  items = [
-                                                            ExpressionTexTalkNode(
-                                                              children = [
-                                                                           TextTexTalkNode(
-                                                                             type = TexTalkNodeType.Identifier
-                                                                             tokenType = TexTalkTokenType.Identifier
-                                                                             text = "x"
-                                                                             isVarArg = false
-                                                                           )
-                                                                         ]
-                                                            )
-                                                          ]
-                                                )
-                                                isVarArg = false
-                                              )
                                             ]
+                                   paren = GroupTexTalkNode(
+                                     type = TexTalkNodeType.ParenGroup
+                                     parameters = ParametersTexTalkNode(
+                                       items = [
+                                                 ExpressionTexTalkNode(
+                                                   children = [
+                                                                TextTexTalkNode(
+                                                                  type = TexTalkNodeType.Identifier
+                                                                  tokenType = TexTalkTokenType.Identifier
+                                                                  text = "x"
+                                                                  isVarArg = false
+                                                                )
+                                                              ]
+                                                 )
+                                               ]
+                                     )
+                                     isVarArg = false
+                                   )
                                    namedGroups = [
                                                  ]
                                  )
@@ -133,6 +133,7 @@ ExpressionTexTalkNode(
                                               isVarArg = false
                                             )
                                           ]
+                                 paren = null
                                  namedGroups = [
                                                ]
                                )

--- a/src/test/resources/goldens/textalk/parses is statements with commands/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses is statements with commands/phase1-structure.txt
@@ -32,6 +32,7 @@ ExpressionTexTalkNode(
                                                           subSup = null
                                                           groups = [
                                                                    ]
+                                                          paren = null
                                                           namedGroups = [
                                                                         ]
                                                         )

--- a/src/test/resources/goldens/textalk/parses is statements with multi commands/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses is statements with multi commands/phase1-structure.txt
@@ -32,6 +32,7 @@ ExpressionTexTalkNode(
                                                           subSup = null
                                                           groups = [
                                                                    ]
+                                                          paren = null
                                                           namedGroups = [
                                                                         ]
                                                         )
@@ -50,6 +51,7 @@ ExpressionTexTalkNode(
                                                           subSup = null
                                                           groups = [
                                                                    ]
+                                                          paren = null
                                                           namedGroups = [
                                                                         ]
                                                         )
@@ -68,6 +70,7 @@ ExpressionTexTalkNode(
                                                           subSup = null
                                                           groups = [
                                                                    ]
+                                                          paren = null
                                                           namedGroups = [
                                                                         ]
                                                         )

--- a/src/test/resources/goldens/textalk/parses single name command with ()/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command with ()/phase1-structure.txt
@@ -12,25 +12,25 @@ ExpressionTexTalkNode(
                              square = null
                              subSup = null
                              groups = [
-                                        GroupTexTalkNode(
-                                          type = TexTalkNodeType.ParenGroup
-                                          parameters = ParametersTexTalkNode(
-                                            items = [
-                                                      ExpressionTexTalkNode(
-                                                        children = [
-                                                                     TextTexTalkNode(
-                                                                       type = TexTalkNodeType.Identifier
-                                                                       tokenType = TexTalkTokenType.Identifier
-                                                                       text = "x"
-                                                                       isVarArg = false
-                                                                     )
-                                                                   ]
-                                                      )
-                                                    ]
-                                          )
-                                          isVarArg = false
-                                        )
                                       ]
+                             paren = GroupTexTalkNode(
+                               type = TexTalkNodeType.ParenGroup
+                               parameters = ParametersTexTalkNode(
+                                 items = [
+                                           ExpressionTexTalkNode(
+                                             children = [
+                                                          TextTexTalkNode(
+                                                            type = TexTalkNodeType.Identifier
+                                                            tokenType = TexTalkTokenType.Identifier
+                                                            text = "x"
+                                                            isVarArg = false
+                                                          )
+                                                        ]
+                                           )
+                                         ]
+                               )
+                               isVarArg = false
+                             )
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses single name command with [] and multi args and sub-sup and () and multi args/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command with [] and multi args and sub-sup and () and multi args/phase1-structure.txt
@@ -86,45 +86,45 @@ ExpressionTexTalkNode(
                                )
                              )
                              groups = [
-                                        GroupTexTalkNode(
-                                          type = TexTalkNodeType.ParenGroup
-                                          parameters = ParametersTexTalkNode(
-                                            items = [
-                                                      ExpressionTexTalkNode(
-                                                        children = [
-                                                                     TextTexTalkNode(
-                                                                       type = TexTalkNodeType.Identifier
-                                                                       tokenType = TexTalkTokenType.Identifier
-                                                                       text = "x"
-                                                                       isVarArg = false
-                                                                     )
-                                                                   ]
-                                                      ),
-                                                      ExpressionTexTalkNode(
-                                                        children = [
-                                                                     TextTexTalkNode(
-                                                                       type = TexTalkNodeType.Identifier
-                                                                       tokenType = TexTalkTokenType.Identifier
-                                                                       text = "y"
-                                                                       isVarArg = false
-                                                                     )
-                                                                   ]
-                                                      ),
-                                                      ExpressionTexTalkNode(
-                                                        children = [
-                                                                     TextTexTalkNode(
-                                                                       type = TexTalkNodeType.Identifier
-                                                                       tokenType = TexTalkTokenType.Identifier
-                                                                       text = "z"
-                                                                       isVarArg = false
-                                                                     )
-                                                                   ]
-                                                      )
-                                                    ]
-                                          )
-                                          isVarArg = false
-                                        )
                                       ]
+                             paren = GroupTexTalkNode(
+                               type = TexTalkNodeType.ParenGroup
+                               parameters = ParametersTexTalkNode(
+                                 items = [
+                                           ExpressionTexTalkNode(
+                                             children = [
+                                                          TextTexTalkNode(
+                                                            type = TexTalkNodeType.Identifier
+                                                            tokenType = TexTalkTokenType.Identifier
+                                                            text = "x"
+                                                            isVarArg = false
+                                                          )
+                                                        ]
+                                           ),
+                                           ExpressionTexTalkNode(
+                                             children = [
+                                                          TextTexTalkNode(
+                                                            type = TexTalkNodeType.Identifier
+                                                            tokenType = TexTalkTokenType.Identifier
+                                                            text = "y"
+                                                            isVarArg = false
+                                                          )
+                                                        ]
+                                           ),
+                                           ExpressionTexTalkNode(
+                                             children = [
+                                                          TextTexTalkNode(
+                                                            type = TexTalkNodeType.Identifier
+                                                            tokenType = TexTalkTokenType.Identifier
+                                                            text = "z"
+                                                            isVarArg = false
+                                                          )
+                                                        ]
+                                           )
+                                         ]
+                               )
+                               isVarArg = false
+                             )
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses single name command with [] and multi args and sub-sup and ()/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command with [] and multi args and sub-sup and ()/phase1-structure.txt
@@ -86,25 +86,25 @@ ExpressionTexTalkNode(
                                )
                              )
                              groups = [
-                                        GroupTexTalkNode(
-                                          type = TexTalkNodeType.ParenGroup
-                                          parameters = ParametersTexTalkNode(
-                                            items = [
-                                                      ExpressionTexTalkNode(
-                                                        children = [
-                                                                     TextTexTalkNode(
-                                                                       type = TexTalkNodeType.Identifier
-                                                                       tokenType = TexTalkTokenType.Identifier
-                                                                       text = "x"
-                                                                       isVarArg = false
-                                                                     )
-                                                                   ]
-                                                      )
-                                                    ]
-                                          )
-                                          isVarArg = false
-                                        )
                                       ]
+                             paren = GroupTexTalkNode(
+                               type = TexTalkNodeType.ParenGroup
+                               parameters = ParametersTexTalkNode(
+                                 items = [
+                                           ExpressionTexTalkNode(
+                                             children = [
+                                                          TextTexTalkNode(
+                                                            type = TexTalkNodeType.Identifier
+                                                            tokenType = TexTalkTokenType.Identifier
+                                                            text = "x"
+                                                            isVarArg = false
+                                                          )
+                                                        ]
+                                           )
+                                         ]
+                               )
+                               isVarArg = false
+                             )
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses single name command with [] and multi args and sub-sup and {}/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command with [] and multi args and sub-sup and {}/phase1-structure.txt
@@ -105,6 +105,7 @@ ExpressionTexTalkNode(
                                           isVarArg = false
                                         )
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses single name command with [] and multi args and sub-sup/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command with [] and multi args and sub-sup/phase1-structure.txt
@@ -87,6 +87,7 @@ ExpressionTexTalkNode(
                              )
                              groups = [
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses single name command with [] and multi args/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command with [] and multi args/phase1-structure.txt
@@ -50,6 +50,7 @@ ExpressionTexTalkNode(
                              subSup = null
                              groups = [
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses single name command with [] and {} and multi args/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command with [] and {} and multi args/phase1-structure.txt
@@ -88,6 +88,7 @@ ExpressionTexTalkNode(
                                           isVarArg = false
                                         )
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses single name command with [] and {}/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command with [] and {}/phase1-structure.txt
@@ -48,6 +48,7 @@ ExpressionTexTalkNode(
                                           isVarArg = false
                                         )
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses single name command with []/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command with []/phase1-structure.txt
@@ -30,6 +30,7 @@ ExpressionTexTalkNode(
                              subSup = null
                              groups = [
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses single name command with {} and multi args/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command with {} and multi args/phase1-structure.txt
@@ -51,6 +51,7 @@ ExpressionTexTalkNode(
                                           isVarArg = false
                                         )
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses single name command with {}/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command with {}/phase1-structure.txt
@@ -31,6 +31,7 @@ ExpressionTexTalkNode(
                                           isVarArg = false
                                         )
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )

--- a/src/test/resources/goldens/textalk/parses single name command/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses single name command/phase1-structure.txt
@@ -13,6 +13,7 @@ ExpressionTexTalkNode(
                              subSup = null
                              groups = [
                                       ]
+                             paren = null
                              namedGroups = [
                                            ]
                            )


### PR DESCRIPTION
A command signature of a Defines can contain at most one paren
group, and if provided, the Defines must define a function like
object whose parameters exactly match those of the signature.

For example, the following is valid:
```
[\f(x, y)]
Defines: f(x, y)
means: 'something'
```
while the following is invalid since the signature has one
parameter `x` while the target of the Defines has two parameters
`x` and `y`:
```
[\f(x)]
Defines: f(x, y)
means: 'something'
```

Note that the above two examples are when a Defines contains a
paren group.  If it doesn't, then the target of the Defines can
be a function of any form.  Thus the following are both valid:
```
[\function]
Defines: f(x)
means: 'something'

[\another.function]
Defines: f(x, y)
means: 'something'
```

With respect to matching, parens can be omitted and a match will
still occur.  That is, given the Defines:
```
[\Sin(x)]
Defines: f(x)
means: '...'
Metadata:
. written: "\sin(x?)"
```

Then `\Sin(y)` would be expanded as `\sin(y)` while `\Sin` would be
expanded as `\sin(x?)` to signify that the `x` parameter was not
specified.

This `\sin(x?)` form specifies that the expression should be
interpreted as a function `\sin` of one variable as compared to
`\sin(x)` which is the value of the `\sin` function at `x`.