### PR TITLE
feat: text now supports both latex and mathlingua

### DIFF
--- a/src/main/kotlin/mathlingua/Main.kt
+++ b/src/main/kotlin/mathlingua/Main.kt
@@ -404,7 +404,6 @@ private class Render : CliktCommand() {
                         .filter { it.isFile && it.name.endsWith(".math") }
                         .filter {
                             if (filterItems.isEmpty()) {
-                                log("returning true")
                                 return@filter true
                             }
 


### PR DESCRIPTION
In a text value, mathlingua code can be entered in single quotes,
and, when the "written as" form of the mathlingua is expanded, it
will expanded in the text value.

If a text value needs to have a single quote but that quote
shouldn't be interpreted as the start of mathlingua code, the
single quote can be escaped as `\'`.

For example, consider
```
[\f{x}]
Defines: X
means: 'something'
Metadata:
. written: "g(x?)"

Theorem:
. "Some text: $'\f{y} + 1 = 0'$ and $'\f{y}' \in A$"

```

Then the Theorem will be expanded as:
```
Theorem:
. "Some text: $'g(y) + 1 = 0'$ and $'g(y)' \in A$"
```

Note that in the first math mode text, the entire expression
`\f{y} + 1 = 0` is viewed as Mathlingua code, while in the second
only `\f{y}` is viewed as Mathlingua code.