### PR TITLE
fix: `means` sections in `Defines` in correct order

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/TopLevelGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/toplevel/TopLevelGroup.kt
@@ -242,7 +242,10 @@ fun <G : Phase2Node, S, E> validateDefinesLikeGroup(
             buildGroup(
                 id?.signature(),
                 id!!, definesLikeSection!!,
-                assumingSection, endSections,
+                assumingSection,
+                // the end sections are in reverse order so they
+                // must be reversed here to be in the correct order
+                endSections.reversed(),
                 aliasSection, metaDataSection
             )
         )

--- a/src/test/resources/goldens/chalktalk/handles defines with multi means/input.math
+++ b/src/test/resources/goldens/chalktalk/handles defines with multi means/input.math
@@ -1,0 +1,9 @@
+[\f]
+Defines: X
+means:
+. 'a'
+means:
+. "b"
+means:
+. if: x
+  then: y

--- a/src/test/resources/goldens/chalktalk/handles defines with multi means/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/handles defines with multi means/phase1-output.math
@@ -1,0 +1,12 @@
+[\f]
+Defines:
+. X
+means:
+. 'a'
+means:
+. "b"
+means:
+. if:
+  . x
+  then:
+  . y

--- a/src/test/resources/goldens/chalktalk/handles defines with multi means/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles defines with multi means/phase1-structure.txt
@@ -1,0 +1,157 @@
+Root(
+  groups = [
+             Group(
+               sections = [
+                            Section(
+                              name = Phase1Token(
+                                text = "Defines"
+                                type = ChalkTalkTokenType.Name
+                                row = 1
+                                column = 1
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Abstraction(
+                                           isEnclosed = false
+                                           isVarArgs = false
+                                           parts = [
+                                                     AbstractionPart(
+                                                       name = Phase1Token(
+                                                         text = "X"
+                                                         type = ChalkTalkTokenType.Name
+                                                         row = 1
+                                                         column = 10
+                                                       )
+                                                       subParams = null
+                                                       params = null
+                                                       tail = null
+                                                     )
+                                                   ]
+                                           subParams = null
+                                         )
+                                       )
+                                     ]
+                            ),
+                            Section(
+                              name = Phase1Token(
+                                text = "means"
+                                type = ChalkTalkTokenType.Name
+                                row = 2
+                                column = 1
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Phase1Token(
+                                           text = "'a'"
+                                           type = ChalkTalkTokenType.Statement
+                                           row = 3
+                                           column = 3
+                                         )
+                                       )
+                                     ]
+                            ),
+                            Section(
+                              name = Phase1Token(
+                                text = "means"
+                                type = ChalkTalkTokenType.Name
+                                row = 4
+                                column = 1
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Phase1Token(
+                                           text = ""b""
+                                           type = ChalkTalkTokenType.String
+                                           row = 5
+                                           column = 3
+                                         )
+                                       )
+                                     ]
+                            ),
+                            Section(
+                              name = Phase1Token(
+                                text = "means"
+                                type = ChalkTalkTokenType.Name
+                                row = 6
+                                column = 1
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Group(
+                                           sections = [
+                                                        Section(
+                                                          name = Phase1Token(
+                                                            text = "if"
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 7
+                                                            column = 3
+                                                          )
+                                                          args = [
+                                                                   Argument(
+                                                                     chalkTalkTarget = Abstraction(
+                                                                       isEnclosed = false
+                                                                       isVarArgs = false
+                                                                       parts = [
+                                                                                 AbstractionPart(
+                                                                                   name = Phase1Token(
+                                                                                     text = "x"
+                                                                                     type = ChalkTalkTokenType.Name
+                                                                                     row = 7
+                                                                                     column = 7
+                                                                                   )
+                                                                                   subParams = null
+                                                                                   params = null
+                                                                                   tail = null
+                                                                                 )
+                                                                               ]
+                                                                       subParams = null
+                                                                     )
+                                                                   )
+                                                                 ]
+                                                        ),
+                                                        Section(
+                                                          name = Phase1Token(
+                                                            text = "then"
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 8
+                                                            column = 3
+                                                          )
+                                                          args = [
+                                                                   Argument(
+                                                                     chalkTalkTarget = Abstraction(
+                                                                       isEnclosed = false
+                                                                       isVarArgs = false
+                                                                       parts = [
+                                                                                 AbstractionPart(
+                                                                                   name = Phase1Token(
+                                                                                     text = "y"
+                                                                                     type = ChalkTalkTokenType.Name
+                                                                                     row = 8
+                                                                                     column = 9
+                                                                                   )
+                                                                                   subParams = null
+                                                                                   params = null
+                                                                                   tail = null
+                                                                                 )
+                                                                               ]
+                                                                       subParams = null
+                                                                     )
+                                                                   )
+                                                                 ]
+                                                        )
+                                                      ]
+                                           id = null
+                                         )
+                                       )
+                                     ]
+                            )
+                          ]
+               id = Phase1Token(
+                 text = "[\f]"
+                 type = ChalkTalkTokenType.Id
+                 row = 0
+                 column = 0
+               )
+             )
+           ]
+)

--- a/src/test/resources/goldens/chalktalk/handles defines with multi means/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/handles defines with multi means/phase2-output.math
@@ -1,0 +1,11 @@
+[\f]
+Defines: X
+means:
+. 'a'
+means:
+. "b"
+means:
+. if:
+  . x
+  then:
+  . y

--- a/src/test/resources/goldens/chalktalk/handles defines with multi means/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles defines with multi means/phase2-structure.txt
@@ -1,0 +1,166 @@
+Document(
+  defines = [
+              DefinesGroup(
+                signature = "\f"
+                id = IdStatement(
+                  text = "\f"
+                  texTalkRoot = ValidationSuccessImpl(
+                    v = ExpressionTexTalkNode(
+                      children = [
+                                   Command(
+                                     parts = [
+                                               CommandPart(
+                                                 name = TextTexTalkNode(
+                                                   type = TexTalkNodeType.Identifier
+                                                   tokenType = TexTalkTokenType.Identifier
+                                                   text = "f"
+                                                   isVarArg = false
+                                                 )
+                                                 square = null
+                                                 subSup = null
+                                                 groups = [
+                                                          ]
+                                                 paren = null
+                                                 namedGroups = [
+                                                               ]
+                                               )
+                                             ]
+                                   )
+                                 ]
+                    )
+                  )
+                )
+                definesSection = DefinesSection(
+                  targets = [
+                              AbstractionNode(
+                                abstraction = Abstraction(
+                                  isEnclosed = false
+                                  isVarArgs = false
+                                  parts = [
+                                            AbstractionPart(
+                                              name = Phase1Token(
+                                                text = "X"
+                                                type = ChalkTalkTokenType.Name
+                                                row = 1
+                                                column = 10
+                                              )
+                                              subParams = null
+                                              params = null
+                                              tail = null
+                                            )
+                                          ]
+                                  subParams = null
+                                )
+                              )
+                            ]
+                )
+                assumingSection = null
+                meansSections = [
+                                  MeansSection(
+                                    clauses = ClauseListNode(
+                                      clauses = [
+                                                  Statement(
+                                                    text = "a"
+                                                    texTalkRoot = ValidationSuccessImpl(
+                                                      v = ExpressionTexTalkNode(
+                                                        children = [
+                                                                     TextTexTalkNode(
+                                                                       type = TexTalkNodeType.Identifier
+                                                                       tokenType = TexTalkTokenType.Identifier
+                                                                       text = "a"
+                                                                       isVarArg = false
+                                                                     )
+                                                                   ]
+                                                      )
+                                                    )
+                                                  )
+                                                ]
+                                    )
+                                  ),
+                                  MeansSection(
+                                    clauses = ClauseListNode(
+                                      clauses = [
+                                                  Text(
+                                                    text = ""b""
+                                                  )
+                                                ]
+                                    )
+                                  ),
+                                  MeansSection(
+                                    clauses = ClauseListNode(
+                                      clauses = [
+                                                  IfGroup(
+                                                    ifSection = IfSection(
+                                                      clauses = ClauseListNode(
+                                                        clauses = [
+                                                                    AbstractionNode(
+                                                                      abstraction = Abstraction(
+                                                                        isEnclosed = false
+                                                                        isVarArgs = false
+                                                                        parts = [
+                                                                                  AbstractionPart(
+                                                                                    name = Phase1Token(
+                                                                                      text = "x"
+                                                                                      type = ChalkTalkTokenType.Name
+                                                                                      row = 7
+                                                                                      column = 7
+                                                                                    )
+                                                                                    subParams = null
+                                                                                    params = null
+                                                                                    tail = null
+                                                                                  )
+                                                                                ]
+                                                                        subParams = null
+                                                                      )
+                                                                    )
+                                                                  ]
+                                                      )
+                                                    )
+                                                    thenSection = ThenSection(
+                                                      clauses = ClauseListNode(
+                                                        clauses = [
+                                                                    AbstractionNode(
+                                                                      abstraction = Abstraction(
+                                                                        isEnclosed = false
+                                                                        isVarArgs = false
+                                                                        parts = [
+                                                                                  AbstractionPart(
+                                                                                    name = Phase1Token(
+                                                                                      text = "y"
+                                                                                      type = ChalkTalkTokenType.Name
+                                                                                      row = 8
+                                                                                      column = 9
+                                                                                    )
+                                                                                    subParams = null
+                                                                                    params = null
+                                                                                    tail = null
+                                                                                  )
+                                                                                ]
+                                                                        subParams = null
+                                                                      )
+                                                                    )
+                                                                  ]
+                                                      )
+                                                    )
+                                                  )
+                                                ]
+                                    )
+                                  )
+                                ]
+                aliasSection = null
+                metaDataSection = null
+              )
+            ]
+  represents = [
+               ]
+  theorems = [
+             ]
+  axioms = [
+           ]
+  conjectures = [
+                ]
+  resources = [
+              ]
+  protoGroups = [
+                ]
+)


### PR DESCRIPTION
Consider the code:
```
[\f]
Defines: X
means: 'a'
means: 'b'
```
Before this change, the above code was incorrectly parsed as:
```
[\f]
Defines: X
means: 'b'
means: 'a'
```
With this change, the code is correctly parsed as:
```
[\f]
Defines: X
means: 'a'
means: 'b'
```