### PR TITLE
chore: Document has a single `groups` field

### DIFF
--- a/src/main/kotlin/mathlingua/Main.kt
+++ b/src/main/kotlin/mathlingua/Main.kt
@@ -162,13 +162,13 @@ private suspend fun runMlg(
                 is ValidationSuccess -> {
                     val doc = validation.value
                     val defines = if (expand) {
-                        doc.defines
+                        doc.defines()
                     } else {
                         emptyList()
                     }
 
                     val represents = if (expand) {
-                        doc.represents
+                        doc.represents()
                     } else {
                         emptyList()
                     }
@@ -315,13 +315,13 @@ private fun processFile(file: File, allSignatures: MutableSet<String>, defSignat
             val tracker = parse.tracker
             allSignatures.addAll(MathLingua.findAllSignatures(document, tracker).map { it.form })
 
-            for (def in document.defines) {
+            for (def in document.defines()) {
                 if (def.signature != null) {
                     defSignatures.add(def.signature)
                 }
             }
 
-            for (rep in document.represents) {
+            for (rep in document.represents()) {
                 if (rep.signature != null) {
                     defSignatures.add(rep.signature)
                 }
@@ -421,8 +421,8 @@ private class Render : CliktCommand() {
                             async {
                                 val result = MathLingua.parse(it.readText())
                                 if (result is ValidationSuccess) {
-                                    defines.addAll(result.value.defines)
-                                    represents.addAll(result.value.represents)
+                                    defines.addAll(result.value.defines())
+                                    represents.addAll(result.value.represents())
                                 }
                             }
                         }.toTypedArray())

--- a/src/main/kotlin/mathlingua/common/MathLingua.kt
+++ b/src/main/kotlin/mathlingua/common/MathLingua.kt
@@ -164,7 +164,7 @@ object MathLingua {
             if (validation is ValidationSuccess) {
                 val doc = validation.value.document
                 val tracker = validation.value.tracker
-                for (group in doc.all()) {
+                for (group in doc.groups) {
                     val groupContent = getContent(group)
                     if (!result.containsKey(groupContent)) {
                         result[groupContent] = mutableSetOf()
@@ -189,7 +189,7 @@ object MathLingua {
             if (validation is ValidationSuccess) {
                 val doc = validation.value.document
                 val tracker = validation.value.tracker
-                for (group in doc.all()) {
+                for (group in doc.groups) {
                     val signature = when (group) {
                         is DefinesGroup -> {
                             group.signature
@@ -224,7 +224,7 @@ object MathLingua {
         val suppContent = when (val validation = parse(supplemental.joinToString("\n\n\n"))) {
             is ValidationFailure -> emptySet()
             is ValidationSuccess -> {
-                validation.value.all().map {
+                validation.value.groups.map {
                     getContent(it)
                 }.toSet()
             }
@@ -239,7 +239,7 @@ object MathLingua {
                 val result = mutableListOf<Location>()
 
                 val inputContentSet = mutableSetOf<String>()
-                for (group in doc.all()) {
+                for (group in doc.groups) {
                     val content = getContent(group)
                     val location = tracker.getLocationOf(group)
                     if (location != null &&
@@ -309,7 +309,7 @@ object MathLingua {
                 val result = mutableListOf<Signature>()
                 val document = validation.value.document
                 val tracker = validation.value.tracker
-                result.addAll(document.defines.mapNotNull {
+                result.addAll(document.defines().mapNotNull {
                     if (it.signature == null) {
                         null
                     } else {
@@ -322,7 +322,7 @@ object MathLingua {
                         )
                     }
                 })
-                result.addAll(document.represents.mapNotNull {
+                result.addAll(document.represents().mapNotNull {
                     if (it.signature == null) {
                         null
                     } else {
@@ -465,11 +465,11 @@ object MathLingua {
         val totalTextValidation = parse(totalText)
         val defines = when (totalTextValidation) {
             is ValidationFailure -> emptyList()
-            is ValidationSuccess -> totalTextValidation.value.defines
+            is ValidationSuccess -> totalTextValidation.value.defines()
         }
         val represents = when (totalTextValidation) {
             is ValidationFailure -> emptyList()
-            is ValidationSuccess -> totalTextValidation.value.represents
+            is ValidationSuccess -> totalTextValidation.value.represents()
         }
 
         val result = StringBuilder()

--- a/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
@@ -573,7 +573,7 @@ internal fun expandAtNode(
     return transformed
 }
 
-internal fun fullExpandOnce(doc: Document) = expandAtNode(doc, doc, doc.defines, doc.represents) as Document
+internal fun fullExpandOnce(doc: Document) = expandAtNode(doc, doc, doc.defines(), doc.represents()) as Document
 
 internal fun fullExpandComplete(doc: Document, maxSteps: Int = 10): Document {
     val snapshots = mutableSetOf<String>()

--- a/src/test/kotlin/mathlingua/common/MathLinguaTest.kt
+++ b/src/test/kotlin/mathlingua/common/MathLinguaTest.kt
@@ -257,7 +257,7 @@ internal class MathLinguaTest {
         """.trimIndent())
         assertThat(validation is ValidationSuccess)
         val doc = (validation as ValidationSuccess).value
-        val map = MathLingua.getPatternsToWrittenAs(emptyList(), doc.represents)
+        val map = MathLingua.getPatternsToWrittenAs(emptyList(), doc.represents())
         val expectedCommand = Command(
             parts = listOf(
                 CommandPart(

--- a/src/test/kotlin/mathlingua/common/transform/SignatureUtilKtTest.kt
+++ b/src/test/kotlin/mathlingua/common/transform/SignatureUtilKtTest.kt
@@ -32,8 +32,9 @@ internal class SignatureUtilKtTest {
     fun findAllStatementSignaturesNonGluedTest() {
         val validation = MathLingua.parse("[\\xyz{x}]\nDefines: y\nmeans: 'something'")
         val doc = (validation as ValidationSuccess).value
-        assertThat(doc.defines.size).isEqualTo(1)
-        val def = doc.defines[0]
+        val defines = doc.defines()
+        assertThat(defines.size).isEqualTo(1)
+        val def = defines[0]
         val stmt = def.id.toStatement()
         val signatures = findAllStatementSignatures(stmt, newLocationTracker())
         assertThat(signatures).isEqualTo(setOf(Signature(
@@ -49,8 +50,9 @@ internal class SignatureUtilKtTest {
     fun statementSignaturesNotAllowedToBeGluedTest() {
         val validation = MathLingua.parse("[\\abc \\xyz{x}]\nDefines: y\nmeans: 'something'")
         val doc = (validation as ValidationSuccess).value
-        assertThat(doc.defines.size).isEqualTo(1)
-        val def = doc.defines[0]
+        val defines = doc.defines()
+        assertThat(defines.size).isEqualTo(1)
+        val def = defines[0]
         val texTalkValidation = def.id.texTalkRoot
         assertThat(texTalkValidation is ValidationFailure)
         val failure = texTalkValidation as ValidationFailure
@@ -67,8 +69,9 @@ internal class SignatureUtilKtTest {
     fun findAllStatementSignaturesInfixTest() {
         val validation = MathLingua.parse("[x \\abc y]\nDefines: y\nmeans: 'something'")
         val doc = (validation as ValidationSuccess).value
-        assertThat(doc.defines.size).isEqualTo(1)
-        val def = doc.defines[0]
+        val defines = doc.defines()
+        assertThat(defines.size).isEqualTo(1)
+        val def = defines[0]
         val stmt = def.id.toStatement()
         val signatures = findAllStatementSignatures(stmt, newLocationTracker())
         assertThat(signatures).isEqualTo(setOf(Signature(

--- a/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
@@ -142,7 +142,7 @@ fun main() {
             phase2Tree.expandPath(path)
             phase2Tree.selectionPath = path
 
-            val newDoc = expandAtNode(doc, nearestNode, doc.defines, doc.represents)
+            val newDoc = expandAtNode(doc, nearestNode, doc.defines(), doc.represents())
 
             outputArea.text = newDoc.toCode(false, 0).getCode()
             outputTree.model = DefaultTreeModel(
@@ -263,15 +263,15 @@ fun main() {
                     }
 
                     if (moveInLineIs.isSelected) {
-                        transformed = moveInlineCommandsToIsNode(transformed.defines, transformed, transformed).root as Document
+                        transformed = moveInlineCommandsToIsNode(transformed.defines(), transformed, transformed).root as Document
                     }
 
                     if (replaceReps.isSelected) {
-                        transformed = replaceRepresents(transformed, transformed.represents, transformed).root as Document
+                        transformed = replaceRepresents(transformed, transformed.represents(), transformed).root as Document
                     }
 
                     if (replaceIsNodes.isSelected) {
-                        transformed = replaceIsNodes(transformed, transformed.defines, transformed).root as Document
+                        transformed = replaceIsNodes(transformed, transformed.defines(), transformed).root as Document
                     }
 
                     if (completeExpand.isSelected) {

--- a/src/test/resources/goldens/chalktalk/handle varargs with defined length/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handle varargs with defined length/phase2-structure.txt
@@ -1,103 +1,91 @@
 Document(
-  defines = [
-              DefinesGroup(
-                signature = "\f"
-                id = IdStatement(
-                  text = "\f{x...}"
-                  texTalkRoot = ValidationSuccessImpl(
-                    v = ExpressionTexTalkNode(
-                      children = [
-                                   Command(
-                                     parts = [
-                                               CommandPart(
-                                                 name = TextTexTalkNode(
-                                                   type = TexTalkNodeType.Identifier
-                                                   tokenType = TexTalkTokenType.Identifier
-                                                   text = "f"
-                                                   isVarArg = false
-                                                 )
-                                                 square = null
-                                                 subSup = null
-                                                 groups = [
-                                                            GroupTexTalkNode(
-                                                              type = TexTalkNodeType.CurlyGroup
-                                                              parameters = ParametersTexTalkNode(
-                                                                items = [
-                                                                          ExpressionTexTalkNode(
-                                                                            children = [
-                                                                                         TextTexTalkNode(
-                                                                                           type = TexTalkNodeType.Identifier
-                                                                                           tokenType = TexTalkTokenType.Identifier
-                                                                                           text = "x"
-                                                                                           isVarArg = true
-                                                                                         )
-                                                                                       ]
-                                                                          )
-                                                                        ]
-                                                              )
-                                                              isVarArg = false
-                                                            )
-                                                          ]
-                                                 paren = null
-                                                 namedGroups = [
-                                                               ]
-                                               )
-                                             ]
-                                   )
-                                 ]
-                    )
-                  )
-                )
-                definesSection = DefinesSection(
-                  targets = [
-                              AbstractionNode(
-                                abstraction = Abstraction(
-                                  isEnclosed = false
-                                  isVarArgs = false
-                                  parts = [
-                                            AbstractionPart(
-                                              name = Phase1Token(
-                                                text = "X...#x..."
-                                                type = ChalkTalkTokenType.Name
-                                                row = 1
-                                                column = 10
+  groups = [
+             DefinesGroup(
+               signature = "\f"
+               id = IdStatement(
+                 text = "\f{x...}"
+                 texTalkRoot = ValidationSuccessImpl(
+                   v = ExpressionTexTalkNode(
+                     children = [
+                                  Command(
+                                    parts = [
+                                              CommandPart(
+                                                name = TextTexTalkNode(
+                                                  type = TexTalkNodeType.Identifier
+                                                  tokenType = TexTalkTokenType.Identifier
+                                                  text = "f"
+                                                  isVarArg = false
+                                                )
+                                                square = null
+                                                subSup = null
+                                                groups = [
+                                                           GroupTexTalkNode(
+                                                             type = TexTalkNodeType.CurlyGroup
+                                                             parameters = ParametersTexTalkNode(
+                                                               items = [
+                                                                         ExpressionTexTalkNode(
+                                                                           children = [
+                                                                                        TextTexTalkNode(
+                                                                                          type = TexTalkNodeType.Identifier
+                                                                                          tokenType = TexTalkTokenType.Identifier
+                                                                                          text = "x"
+                                                                                          isVarArg = true
+                                                                                        )
+                                                                                      ]
+                                                                         )
+                                                                       ]
+                                                             )
+                                                             isVarArg = false
+                                                           )
+                                                         ]
+                                                paren = null
+                                                namedGroups = [
+                                                              ]
                                               )
-                                              subParams = null
-                                              params = null
-                                              tail = null
-                                            )
-                                          ]
-                                  subParams = null
-                                )
-                              )
-                            ]
-                )
-                assumingSection = null
-                meansSections = [
-                                  MeansSection(
-                                    clauses = ClauseListNode(
-                                      clauses = [
-                                                  Text(
-                                                    text = ""something for X...#x...""
-                                                  )
-                                                ]
-                                    )
+                                            ]
                                   )
                                 ]
-                aliasSection = null
-                metaDataSection = null
-              )
-            ]
-  represents = [
-               ]
-  theorems = [
-             ]
-  axioms = [
+                   )
+                 )
+               )
+               definesSection = DefinesSection(
+                 targets = [
+                             AbstractionNode(
+                               abstraction = Abstraction(
+                                 isEnclosed = false
+                                 isVarArgs = false
+                                 parts = [
+                                           AbstractionPart(
+                                             name = Phase1Token(
+                                               text = "X...#x..."
+                                               type = ChalkTalkTokenType.Name
+                                               row = 1
+                                               column = 10
+                                             )
+                                             subParams = null
+                                             params = null
+                                             tail = null
+                                           )
+                                         ]
+                                 subParams = null
+                               )
+                             )
+                           ]
+               )
+               assumingSection = null
+               meansSections = [
+                                 MeansSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
+                                                 Text(
+                                                   text = ""something for X...#x...""
+                                                 )
+                                               ]
+                                   )
+                                 )
+                               ]
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/handles a single classification in metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles a single classification in metadata/phase2-structure.txt
@@ -1,40 +1,28 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 Text(
-                                   text = ""something""
-                                 )
-                               ]
-                   )
-                 )
-                 aliasSection = null
-                 metaDataSection = MetaDataSection(
-                   items = [
-                             StringSectionGroup(
-                               section = StringSection(
-                                 name = "classification"
-                                 values = [
-                                            ""a""
-                                          ]
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               Text(
+                                 text = ""something""
                                )
-                             )
-                           ]
+                             ]
                  )
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = MetaDataSection(
+                 items = [
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "classification"
+                               values = [
+                                          ""a""
+                                        ]
+                             )
+                           )
+                         ]
+               )
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/handles a single tag in metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles a single tag in metadata/phase2-structure.txt
@@ -1,40 +1,28 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 Text(
-                                   text = ""something""
-                                 )
-                               ]
-                   )
-                 )
-                 aliasSection = null
-                 metaDataSection = MetaDataSection(
-                   items = [
-                             StringSectionGroup(
-                               section = StringSection(
-                                 name = "tag"
-                                 values = [
-                                            ""a""
-                                          ]
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               Text(
+                                 text = ""something""
                                )
-                             )
-                           ]
+                             ]
                  )
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = MetaDataSection(
+                 items = [
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "tag"
+                               values = [
+                                          ""a""
+                                        ]
+                             )
+                           )
+                         ]
+               )
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/handles defines with multi means/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles defines with multi means/phase2-structure.txt
@@ -1,166 +1,154 @@
 Document(
-  defines = [
-              DefinesGroup(
-                signature = "\f"
-                id = IdStatement(
-                  text = "\f"
-                  texTalkRoot = ValidationSuccessImpl(
-                    v = ExpressionTexTalkNode(
-                      children = [
-                                   Command(
-                                     parts = [
-                                               CommandPart(
-                                                 name = TextTexTalkNode(
-                                                   type = TexTalkNodeType.Identifier
-                                                   tokenType = TexTalkTokenType.Identifier
-                                                   text = "f"
-                                                   isVarArg = false
-                                                 )
-                                                 square = null
-                                                 subSup = null
-                                                 groups = [
-                                                          ]
-                                                 paren = null
-                                                 namedGroups = [
-                                                               ]
-                                               )
-                                             ]
-                                   )
-                                 ]
-                    )
-                  )
-                )
-                definesSection = DefinesSection(
-                  targets = [
-                              AbstractionNode(
-                                abstraction = Abstraction(
-                                  isEnclosed = false
-                                  isVarArgs = false
-                                  parts = [
-                                            AbstractionPart(
-                                              name = Phase1Token(
-                                                text = "X"
-                                                type = ChalkTalkTokenType.Name
-                                                row = 1
-                                                column = 10
+  groups = [
+             DefinesGroup(
+               signature = "\f"
+               id = IdStatement(
+                 text = "\f"
+                 texTalkRoot = ValidationSuccessImpl(
+                   v = ExpressionTexTalkNode(
+                     children = [
+                                  Command(
+                                    parts = [
+                                              CommandPart(
+                                                name = TextTexTalkNode(
+                                                  type = TexTalkNodeType.Identifier
+                                                  tokenType = TexTalkTokenType.Identifier
+                                                  text = "f"
+                                                  isVarArg = false
+                                                )
+                                                square = null
+                                                subSup = null
+                                                groups = [
+                                                         ]
+                                                paren = null
+                                                namedGroups = [
+                                                              ]
                                               )
-                                              subParams = null
-                                              params = null
-                                              tail = null
-                                            )
-                                          ]
-                                  subParams = null
-                                )
-                              )
-                            ]
-                )
-                assumingSection = null
-                meansSections = [
-                                  MeansSection(
-                                    clauses = ClauseListNode(
-                                      clauses = [
-                                                  Statement(
-                                                    text = "a"
-                                                    texTalkRoot = ValidationSuccessImpl(
-                                                      v = ExpressionTexTalkNode(
-                                                        children = [
-                                                                     TextTexTalkNode(
-                                                                       type = TexTalkNodeType.Identifier
-                                                                       tokenType = TexTalkTokenType.Identifier
-                                                                       text = "a"
-                                                                       isVarArg = false
-                                                                     )
-                                                                   ]
-                                                      )
-                                                    )
-                                                  )
-                                                ]
-                                    )
-                                  ),
-                                  MeansSection(
-                                    clauses = ClauseListNode(
-                                      clauses = [
-                                                  Text(
-                                                    text = ""b""
-                                                  )
-                                                ]
-                                    )
-                                  ),
-                                  MeansSection(
-                                    clauses = ClauseListNode(
-                                      clauses = [
-                                                  IfGroup(
-                                                    ifSection = IfSection(
-                                                      clauses = ClauseListNode(
-                                                        clauses = [
-                                                                    AbstractionNode(
-                                                                      abstraction = Abstraction(
-                                                                        isEnclosed = false
-                                                                        isVarArgs = false
-                                                                        parts = [
-                                                                                  AbstractionPart(
-                                                                                    name = Phase1Token(
-                                                                                      text = "x"
-                                                                                      type = ChalkTalkTokenType.Name
-                                                                                      row = 7
-                                                                                      column = 7
-                                                                                    )
-                                                                                    subParams = null
-                                                                                    params = null
-                                                                                    tail = null
-                                                                                  )
-                                                                                ]
-                                                                        subParams = null
-                                                                      )
-                                                                    )
-                                                                  ]
-                                                      )
-                                                    )
-                                                    thenSection = ThenSection(
-                                                      clauses = ClauseListNode(
-                                                        clauses = [
-                                                                    AbstractionNode(
-                                                                      abstraction = Abstraction(
-                                                                        isEnclosed = false
-                                                                        isVarArgs = false
-                                                                        parts = [
-                                                                                  AbstractionPart(
-                                                                                    name = Phase1Token(
-                                                                                      text = "y"
-                                                                                      type = ChalkTalkTokenType.Name
-                                                                                      row = 8
-                                                                                      column = 9
-                                                                                    )
-                                                                                    subParams = null
-                                                                                    params = null
-                                                                                    tail = null
-                                                                                  )
-                                                                                ]
-                                                                        subParams = null
-                                                                      )
-                                                                    )
-                                                                  ]
-                                                      )
-                                                    )
-                                                  )
-                                                ]
-                                    )
+                                            ]
                                   )
                                 ]
-                aliasSection = null
-                metaDataSection = null
-              )
-            ]
-  represents = [
-               ]
-  theorems = [
-             ]
-  axioms = [
+                   )
+                 )
+               )
+               definesSection = DefinesSection(
+                 targets = [
+                             AbstractionNode(
+                               abstraction = Abstraction(
+                                 isEnclosed = false
+                                 isVarArgs = false
+                                 parts = [
+                                           AbstractionPart(
+                                             name = Phase1Token(
+                                               text = "X"
+                                               type = ChalkTalkTokenType.Name
+                                               row = 1
+                                               column = 10
+                                             )
+                                             subParams = null
+                                             params = null
+                                             tail = null
+                                           )
+                                         ]
+                                 subParams = null
+                               )
+                             )
+                           ]
+               )
+               assumingSection = null
+               meansSections = [
+                                 MeansSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
+                                                 Statement(
+                                                   text = "a"
+                                                   texTalkRoot = ValidationSuccessImpl(
+                                                     v = ExpressionTexTalkNode(
+                                                       children = [
+                                                                    TextTexTalkNode(
+                                                                      type = TexTalkNodeType.Identifier
+                                                                      tokenType = TexTalkTokenType.Identifier
+                                                                      text = "a"
+                                                                      isVarArg = false
+                                                                    )
+                                                                  ]
+                                                     )
+                                                   )
+                                                 )
+                                               ]
+                                   )
+                                 ),
+                                 MeansSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
+                                                 Text(
+                                                   text = ""b""
+                                                 )
+                                               ]
+                                   )
+                                 ),
+                                 MeansSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
+                                                 IfGroup(
+                                                   ifSection = IfSection(
+                                                     clauses = ClauseListNode(
+                                                       clauses = [
+                                                                   AbstractionNode(
+                                                                     abstraction = Abstraction(
+                                                                       isEnclosed = false
+                                                                       isVarArgs = false
+                                                                       parts = [
+                                                                                 AbstractionPart(
+                                                                                   name = Phase1Token(
+                                                                                     text = "x"
+                                                                                     type = ChalkTalkTokenType.Name
+                                                                                     row = 7
+                                                                                     column = 7
+                                                                                   )
+                                                                                   subParams = null
+                                                                                   params = null
+                                                                                   tail = null
+                                                                                 )
+                                                                               ]
+                                                                       subParams = null
+                                                                     )
+                                                                   )
+                                                                 ]
+                                                     )
+                                                   )
+                                                   thenSection = ThenSection(
+                                                     clauses = ClauseListNode(
+                                                       clauses = [
+                                                                   AbstractionNode(
+                                                                     abstraction = Abstraction(
+                                                                       isEnclosed = false
+                                                                       isVarArgs = false
+                                                                       parts = [
+                                                                                 AbstractionPart(
+                                                                                   name = Phase1Token(
+                                                                                     text = "y"
+                                                                                     type = ChalkTalkTokenType.Name
+                                                                                     row = 8
+                                                                                     column = 9
+                                                                                   )
+                                                                                   subParams = null
+                                                                                   params = null
+                                                                                   tail = null
+                                                                                 )
+                                                                               ]
+                                                                       subParams = null
+                                                                     )
+                                                                   )
+                                                                 ]
+                                                     )
+                                                   )
+                                                 )
+                                               ]
+                                   )
+                                 )
+                               ]
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/handles multiple classifications in metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles multiple classifications in metadata/phase2-structure.txt
@@ -1,42 +1,30 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 Text(
-                                   text = ""something""
-                                 )
-                               ]
-                   )
-                 )
-                 aliasSection = null
-                 metaDataSection = MetaDataSection(
-                   items = [
-                             StringSectionGroup(
-                               section = StringSection(
-                                 name = "classification"
-                                 values = [
-                                            ""a"",
-                                            ""b"",
-                                            ""c""
-                                          ]
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               Text(
+                                 text = ""something""
                                )
-                             )
-                           ]
+                             ]
                  )
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = MetaDataSection(
+                 items = [
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "classification"
+                               values = [
+                                          ""a"",
+                                          ""b"",
+                                          ""c""
+                                        ]
+                             )
+                           )
+                         ]
+               )
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/handles multiple tags in metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles multiple tags in metadata/phase2-structure.txt
@@ -1,42 +1,30 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 Text(
-                                   text = ""something""
-                                 )
-                               ]
-                   )
-                 )
-                 aliasSection = null
-                 metaDataSection = MetaDataSection(
-                   items = [
-                             StringSectionGroup(
-                               section = StringSection(
-                                 name = "tag"
-                                 values = [
-                                            ""a"",
-                                            ""b"",
-                                            ""c""
-                                          ]
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               Text(
+                                 text = ""something""
                                )
-                             )
-                           ]
+                             ]
                  )
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = MetaDataSection(
+                 items = [
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "tag"
+                               values = [
+                                          ""a"",
+                                          ""b"",
+                                          ""c""
+                                        ]
+                             )
+                           )
+                         ]
+               )
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/handles sequence abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles sequence abstractions/phase2-structure.txt
@@ -1,76 +1,64 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 ForGroup(
-                                   forSection = ForSection(
-                                     targets = [
-                                                 AbstractionNode(
-                                                   abstraction = Abstraction(
-                                                     isEnclosed = true
-                                                     isVarArgs = false
-                                                     parts = [
-                                                               AbstractionPart(
-                                                                 name = Phase1Token(
-                                                                   text = "a"
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               ForGroup(
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = true
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "a"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 1
+                                                                 column = 9
+                                                               )
+                                                               subParams = [
+                                                                             Phase1Token(
+                                                                               text = "k"
+                                                                               type = ChalkTalkTokenType.Name
+                                                                               row = 1
+                                                                               column = 11
+                                                                             )
+                                                                           ]
+                                                               params = null
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = [
+                                                                 Phase1Token(
+                                                                   text = "k"
                                                                    type = ChalkTalkTokenType.Name
                                                                    row = 1
-                                                                   column = 9
+                                                                   column = 14
                                                                  )
-                                                                 subParams = [
-                                                                               Phase1Token(
-                                                                                 text = "k"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 11
-                                                                               )
-                                                                             ]
-                                                                 params = null
-                                                                 tail = null
-                                                               )
-                                                             ]
-                                                     subParams = [
-                                                                   Phase1Token(
-                                                                     text = "k"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 1
-                                                                     column = 14
-                                                                   )
-                                                                 ]
-                                                   )
+                                                               ]
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = null
+                                 thenSection = ThenSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
+                                                 Text(
+                                                   text = ""something""
                                                  )
                                                ]
                                    )
-                                   whereSection = null
-                                   thenSection = ThenSection(
-                                     clauses = ClauseListNode(
-                                       clauses = [
-                                                   Text(
-                                                     text = ""something""
-                                                   )
-                                                 ]
-                                     )
-                                   )
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/handles sources with a homepage/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles sources with a homepage/phase2-structure.txt
@@ -1,40 +1,28 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-             ]
-  axioms = [
+  groups = [
+             ResourceGroup(
+               id = "id"
+               sourceSection = ResourceSection(
+                 items = [
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "name"
+                               values = [
+                                          ""some name""
+                                        ]
+                             )
+                           ),
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "homepage"
+                               values = [
+                                          ""some.homepage.com""
+                                        ]
+                             )
+                           )
+                         ]
+               )
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-                ResourceGroup(
-                  id = "id"
-                  sourceSection = ResourceSection(
-                    items = [
-                              StringSectionGroup(
-                                section = StringSection(
-                                  name = "name"
-                                  values = [
-                                             ""some name""
-                                           ]
-                                )
-                              ),
-                              StringSectionGroup(
-                                section = StringSection(
-                                  name = "homepage"
-                                  values = [
-                                             ""some.homepage.com""
-                                           ]
-                                )
-                              )
-                            ]
-                  )
-                  metaDataSection = null
-                )
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/handles sources with a single author/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles sources with a single author/phase2-structure.txt
@@ -1,40 +1,28 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-             ]
-  axioms = [
+  groups = [
+             ResourceGroup(
+               id = "id"
+               sourceSection = ResourceSection(
+                 items = [
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "name"
+                               values = [
+                                          ""some name""
+                                        ]
+                             )
+                           ),
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "author"
+                               values = [
+                                          ""author1""
+                                        ]
+                             )
+                           )
+                         ]
+               )
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-                ResourceGroup(
-                  id = "id"
-                  sourceSection = ResourceSection(
-                    items = [
-                              StringSectionGroup(
-                                section = StringSection(
-                                  name = "name"
-                                  values = [
-                                             ""some name""
-                                           ]
-                                )
-                              ),
-                              StringSectionGroup(
-                                section = StringSection(
-                                  name = "author"
-                                  values = [
-                                             ""author1""
-                                           ]
-                                )
-                              )
-                            ]
-                  )
-                  metaDataSection = null
-                )
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/handles sources with a type/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles sources with a type/phase2-structure.txt
@@ -1,40 +1,28 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-             ]
-  axioms = [
+  groups = [
+             ResourceGroup(
+               id = "id"
+               sourceSection = ResourceSection(
+                 items = [
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "name"
+                               values = [
+                                          ""some name""
+                                        ]
+                             )
+                           ),
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "type"
+                               values = [
+                                          ""Book""
+                                        ]
+                             )
+                           )
+                         ]
+               )
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-                ResourceGroup(
-                  id = "id"
-                  sourceSection = ResourceSection(
-                    items = [
-                              StringSectionGroup(
-                                section = StringSection(
-                                  name = "name"
-                                  values = [
-                                             ""some name""
-                                           ]
-                                )
-                              ),
-                              StringSectionGroup(
-                                section = StringSection(
-                                  name = "type"
-                                  values = [
-                                             ""Book""
-                                           ]
-                                )
-                              )
-                            ]
-                  )
-                  metaDataSection = null
-                )
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/handles sources with multiple authors/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles sources with multiple authors/phase2-structure.txt
@@ -1,42 +1,30 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-             ]
-  axioms = [
+  groups = [
+             ResourceGroup(
+               id = "id"
+               sourceSection = ResourceSection(
+                 items = [
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "name"
+                               values = [
+                                          ""some name""
+                                        ]
+                             )
+                           ),
+                           StringSectionGroup(
+                             section = StringSection(
+                               name = "author"
+                               values = [
+                                          ""author1"",
+                                          ""author2"",
+                                          ""author3""
+                                        ]
+                             )
+                           )
+                         ]
+               )
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-                ResourceGroup(
-                  id = "id"
-                  sourceSection = ResourceSection(
-                    items = [
-                              StringSectionGroup(
-                                section = StringSection(
-                                  name = "name"
-                                  values = [
-                                             ""some name""
-                                           ]
-                                )
-                              ),
-                              StringSectionGroup(
-                                section = StringSection(
-                                  name = "author"
-                                  values = [
-                                             ""author1"",
-                                             ""author2"",
-                                             ""author3""
-                                           ]
-                                )
-                              )
-                            ]
-                  )
-                  metaDataSection = null
-                )
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and empty params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and empty params/phase2-structure.txt
@@ -1,16 +1,40 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 ForGroup(
-                                   forSection = ForSection(
-                                     targets = [
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               ForGroup(
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = false
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "a"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 1
+                                                                 column = 8
+                                                               )
+                                                               subParams = [
+                                                                           ]
+                                                               params = [
+                                                                        ]
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = null
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = null
+                                 thenSection = ThenSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
                                                  AbstractionNode(
                                                    abstraction = Abstraction(
                                                      isEnclosed = false
@@ -18,15 +42,13 @@ Document(
                                                      parts = [
                                                                AbstractionPart(
                                                                  name = Phase1Token(
-                                                                   text = "a"
+                                                                   text = "b"
                                                                    type = ChalkTalkTokenType.Name
-                                                                   row = 1
-                                                                   column = 8
+                                                                   row = 2
+                                                                   column = 9
                                                                  )
-                                                                 subParams = [
-                                                                             ]
-                                                                 params = [
-                                                                          ]
+                                                                 subParams = null
+                                                                 params = null
                                                                  tail = null
                                                                )
                                                              ]
@@ -35,47 +57,13 @@ Document(
                                                  )
                                                ]
                                    )
-                                   whereSection = null
-                                   thenSection = ThenSection(
-                                     clauses = ClauseListNode(
-                                       clauses = [
-                                                   AbstractionNode(
-                                                     abstraction = Abstraction(
-                                                       isEnclosed = false
-                                                       isVarArgs = false
-                                                       parts = [
-                                                                 AbstractionPart(
-                                                                   name = Phase1Token(
-                                                                     text = "b"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 2
-                                                                     column = 9
-                                                                   )
-                                                                   subParams = null
-                                                                   params = null
-                                                                   tail = null
-                                                                 )
-                                                               ]
-                                                       subParams = null
-                                                     )
-                                                   )
-                                                 ]
-                                     )
-                                   )
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and non-empty params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with empty sub params and non-empty params/phase2-structure.txt
@@ -1,16 +1,52 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 ForGroup(
-                                   forSection = ForSection(
-                                     targets = [
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               ForGroup(
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = false
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "a"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 1
+                                                                 column = 8
+                                                               )
+                                                               subParams = [
+                                                                           ]
+                                                               params = [
+                                                                          Phase1Token(
+                                                                            text = "x"
+                                                                            type = ChalkTalkTokenType.Name
+                                                                            row = 1
+                                                                            column = 13
+                                                                          ),
+                                                                          Phase1Token(
+                                                                            text = "y"
+                                                                            type = ChalkTalkTokenType.Name
+                                                                            row = 1
+                                                                            column = 16
+                                                                          )
+                                                                        ]
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = null
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = null
+                                 thenSection = ThenSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
                                                  AbstractionNode(
                                                    abstraction = Abstraction(
                                                      isEnclosed = false
@@ -18,27 +54,13 @@ Document(
                                                      parts = [
                                                                AbstractionPart(
                                                                  name = Phase1Token(
-                                                                   text = "a"
+                                                                   text = "b"
                                                                    type = ChalkTalkTokenType.Name
-                                                                   row = 1
-                                                                   column = 8
+                                                                   row = 2
+                                                                   column = 9
                                                                  )
-                                                                 subParams = [
-                                                                             ]
-                                                                 params = [
-                                                                            Phase1Token(
-                                                                              text = "x"
-                                                                              type = ChalkTalkTokenType.Name
-                                                                              row = 1
-                                                                              column = 13
-                                                                            ),
-                                                                            Phase1Token(
-                                                                              text = "y"
-                                                                              type = ChalkTalkTokenType.Name
-                                                                              row = 1
-                                                                              column = 16
-                                                                            )
-                                                                          ]
+                                                                 subParams = null
+                                                                 params = null
                                                                  tail = null
                                                                )
                                                              ]
@@ -47,47 +69,13 @@ Document(
                                                  )
                                                ]
                                    )
-                                   whereSection = null
-                                   thenSection = ThenSection(
-                                     clauses = ClauseListNode(
-                                       clauses = [
-                                                   AbstractionNode(
-                                                     abstraction = Abstraction(
-                                                       isEnclosed = false
-                                                       isVarArgs = false
-                                                       parts = [
-                                                                 AbstractionPart(
-                                                                   name = Phase1Token(
-                                                                     text = "b"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 2
-                                                                     column = 9
-                                                                   )
-                                                                   subParams = null
-                                                                   params = null
-                                                                   tail = null
-                                                                 )
-                                                               ]
-                                                       subParams = null
-                                                     )
-                                                   )
-                                                 ]
-                                     )
-                                   )
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params and multiple params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params and multiple params/phase2-structure.txt
@@ -1,16 +1,64 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 ForGroup(
-                                   forSection = ForSection(
-                                     targets = [
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               ForGroup(
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = false
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "a"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 1
+                                                                 column = 8
+                                                               )
+                                                               subParams = [
+                                                                             Phase1Token(
+                                                                               text = "n"
+                                                                               type = ChalkTalkTokenType.Name
+                                                                               row = 1
+                                                                               column = 11
+                                                                             ),
+                                                                             Phase1Token(
+                                                                               text = "m"
+                                                                               type = ChalkTalkTokenType.Name
+                                                                               row = 1
+                                                                               column = 14
+                                                                             )
+                                                                           ]
+                                                               params = [
+                                                                          Phase1Token(
+                                                                            text = "x"
+                                                                            type = ChalkTalkTokenType.Name
+                                                                            row = 1
+                                                                            column = 17
+                                                                          ),
+                                                                          Phase1Token(
+                                                                            text = "y"
+                                                                            type = ChalkTalkTokenType.Name
+                                                                            row = 1
+                                                                            column = 20
+                                                                          )
+                                                                        ]
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = null
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = null
+                                 thenSection = ThenSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
                                                  AbstractionNode(
                                                    abstraction = Abstraction(
                                                      isEnclosed = false
@@ -18,39 +66,13 @@ Document(
                                                      parts = [
                                                                AbstractionPart(
                                                                  name = Phase1Token(
-                                                                   text = "a"
+                                                                   text = "b"
                                                                    type = ChalkTalkTokenType.Name
-                                                                   row = 1
-                                                                   column = 8
+                                                                   row = 2
+                                                                   column = 9
                                                                  )
-                                                                 subParams = [
-                                                                               Phase1Token(
-                                                                                 text = "n"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 11
-                                                                               ),
-                                                                               Phase1Token(
-                                                                                 text = "m"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 14
-                                                                               )
-                                                                             ]
-                                                                 params = [
-                                                                            Phase1Token(
-                                                                              text = "x"
-                                                                              type = ChalkTalkTokenType.Name
-                                                                              row = 1
-                                                                              column = 17
-                                                                            ),
-                                                                            Phase1Token(
-                                                                              text = "y"
-                                                                              type = ChalkTalkTokenType.Name
-                                                                              row = 1
-                                                                              column = 20
-                                                                            )
-                                                                          ]
+                                                                 subParams = null
+                                                                 params = null
                                                                  tail = null
                                                                )
                                                              ]
@@ -59,47 +81,13 @@ Document(
                                                  )
                                                ]
                                    )
-                                   whereSection = null
-                                   thenSection = ThenSection(
-                                     clauses = ClauseListNode(
-                                       clauses = [
-                                                   AbstractionNode(
-                                                     abstraction = Abstraction(
-                                                       isEnclosed = false
-                                                       isVarArgs = false
-                                                       parts = [
-                                                                 AbstractionPart(
-                                                                   name = Phase1Token(
-                                                                     text = "b"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 2
-                                                                     column = 9
-                                                                   )
-                                                                   subParams = null
-                                                                   params = null
-                                                                   tail = null
-                                                                 )
-                                                               ]
-                                                       subParams = null
-                                                     )
-                                                   )
-                                                 ]
-                                     )
-                                   )
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with multiple sub params/phase2-structure.txt
@@ -1,16 +1,57 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 ForGroup(
-                                   forSection = ForSection(
-                                     targets = [
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               ForGroup(
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = false
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "a"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 1
+                                                                 column = 8
+                                                               )
+                                                               subParams = [
+                                                                             Phase1Token(
+                                                                               text = "x"
+                                                                               type = ChalkTalkTokenType.Name
+                                                                               row = 1
+                                                                               column = 11
+                                                                             ),
+                                                                             Phase1Token(
+                                                                               text = "y"
+                                                                               type = ChalkTalkTokenType.Name
+                                                                               row = 1
+                                                                               column = 14
+                                                                             ),
+                                                                             Phase1Token(
+                                                                               text = "z"
+                                                                               type = ChalkTalkTokenType.Name
+                                                                               row = 1
+                                                                               column = 17
+                                                                             )
+                                                                           ]
+                                                               params = null
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = null
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = null
+                                 thenSection = ThenSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
                                                  AbstractionNode(
                                                    abstraction = Abstraction(
                                                      isEnclosed = false
@@ -18,31 +59,12 @@ Document(
                                                      parts = [
                                                                AbstractionPart(
                                                                  name = Phase1Token(
-                                                                   text = "a"
+                                                                   text = "b"
                                                                    type = ChalkTalkTokenType.Name
-                                                                   row = 1
-                                                                   column = 8
+                                                                   row = 2
+                                                                   column = 9
                                                                  )
-                                                                 subParams = [
-                                                                               Phase1Token(
-                                                                                 text = "x"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 11
-                                                                               ),
-                                                                               Phase1Token(
-                                                                                 text = "y"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 14
-                                                                               ),
-                                                                               Phase1Token(
-                                                                                 text = "z"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 17
-                                                                               )
-                                                                             ]
+                                                                 subParams = null
                                                                  params = null
                                                                  tail = null
                                                                )
@@ -52,47 +74,13 @@ Document(
                                                  )
                                                ]
                                    )
-                                   whereSection = null
-                                   thenSection = ThenSection(
-                                     clauses = ClauseListNode(
-                                       clauses = [
-                                                   AbstractionNode(
-                                                     abstraction = Abstraction(
-                                                       isEnclosed = false
-                                                       isVarArgs = false
-                                                       parts = [
-                                                                 AbstractionPart(
-                                                                   name = Phase1Token(
-                                                                     text = "b"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 2
-                                                                     column = 9
-                                                                   )
-                                                                   subParams = null
-                                                                   params = null
-                                                                   tail = null
-                                                                 )
-                                                               ]
-                                                       subParams = null
-                                                     )
-                                                   )
-                                                 ]
-                                     )
-                                   )
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with non-empty sub params and empty params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with non-empty sub params and empty params/phase2-structure.txt
@@ -1,16 +1,52 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 ForGroup(
-                                   forSection = ForSection(
-                                     targets = [
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               ForGroup(
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = false
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "a"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 1
+                                                                 column = 8
+                                                               )
+                                                               subParams = [
+                                                                             Phase1Token(
+                                                                               text = "n"
+                                                                               type = ChalkTalkTokenType.Name
+                                                                               row = 1
+                                                                               column = 11
+                                                                             ),
+                                                                             Phase1Token(
+                                                                               text = "m"
+                                                                               type = ChalkTalkTokenType.Name
+                                                                               row = 1
+                                                                               column = 14
+                                                                             )
+                                                                           ]
+                                                               params = [
+                                                                        ]
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = null
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = null
+                                 thenSection = ThenSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
                                                  AbstractionNode(
                                                    abstraction = Abstraction(
                                                      isEnclosed = false
@@ -18,27 +54,13 @@ Document(
                                                      parts = [
                                                                AbstractionPart(
                                                                  name = Phase1Token(
-                                                                   text = "a"
+                                                                   text = "b"
                                                                    type = ChalkTalkTokenType.Name
-                                                                   row = 1
-                                                                   column = 8
+                                                                   row = 2
+                                                                   column = 9
                                                                  )
-                                                                 subParams = [
-                                                                               Phase1Token(
-                                                                                 text = "n"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 11
-                                                                               ),
-                                                                               Phase1Token(
-                                                                                 text = "m"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 14
-                                                                               )
-                                                                             ]
-                                                                 params = [
-                                                                          ]
+                                                                 subParams = null
+                                                                 params = null
                                                                  tail = null
                                                                )
                                                              ]
@@ -47,47 +69,13 @@ Document(
                                                  )
                                                ]
                                    )
-                                   whereSection = null
-                                   thenSection = ThenSection(
-                                     clauses = ClauseListNode(
-                                       clauses = [
-                                                   AbstractionNode(
-                                                     abstraction = Abstraction(
-                                                       isEnclosed = false
-                                                       isVarArgs = false
-                                                       parts = [
-                                                                 AbstractionPart(
-                                                                   name = Phase1Token(
-                                                                     text = "b"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 2
-                                                                     column = 9
-                                                                   )
-                                                                   subParams = null
-                                                                   params = null
-                                                                   tail = null
-                                                                 )
-                                                               ]
-                                                       subParams = null
-                                                     )
-                                                   )
-                                                 ]
-                                     )
-                                   )
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with one sub param and multiple params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with one sub param and multiple params/phase2-structure.txt
@@ -1,16 +1,58 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 ForGroup(
-                                   forSection = ForSection(
-                                     targets = [
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               ForGroup(
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = false
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "a"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 1
+                                                                 column = 8
+                                                               )
+                                                               subParams = [
+                                                                             Phase1Token(
+                                                                               text = "n"
+                                                                               type = ChalkTalkTokenType.Name
+                                                                               row = 1
+                                                                               column = 10
+                                                                             )
+                                                                           ]
+                                                               params = [
+                                                                          Phase1Token(
+                                                                            text = "x"
+                                                                            type = ChalkTalkTokenType.Name
+                                                                            row = 1
+                                                                            column = 12
+                                                                          ),
+                                                                          Phase1Token(
+                                                                            text = "y"
+                                                                            type = ChalkTalkTokenType.Name
+                                                                            row = 1
+                                                                            column = 15
+                                                                          )
+                                                                        ]
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = null
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = null
+                                 thenSection = ThenSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
                                                  AbstractionNode(
                                                    abstraction = Abstraction(
                                                      isEnclosed = false
@@ -18,33 +60,13 @@ Document(
                                                      parts = [
                                                                AbstractionPart(
                                                                  name = Phase1Token(
-                                                                   text = "a"
+                                                                   text = "b"
                                                                    type = ChalkTalkTokenType.Name
-                                                                   row = 1
-                                                                   column = 8
+                                                                   row = 2
+                                                                   column = 9
                                                                  )
-                                                                 subParams = [
-                                                                               Phase1Token(
-                                                                                 text = "n"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 10
-                                                                               )
-                                                                             ]
-                                                                 params = [
-                                                                            Phase1Token(
-                                                                              text = "x"
-                                                                              type = ChalkTalkTokenType.Name
-                                                                              row = 1
-                                                                              column = 12
-                                                                            ),
-                                                                            Phase1Token(
-                                                                              text = "y"
-                                                                              type = ChalkTalkTokenType.Name
-                                                                              row = 1
-                                                                              column = 15
-                                                                            )
-                                                                          ]
+                                                                 subParams = null
+                                                                 params = null
                                                                  tail = null
                                                                )
                                                              ]
@@ -53,47 +75,13 @@ Document(
                                                  )
                                                ]
                                    )
-                                   whereSection = null
-                                   thenSection = ThenSection(
-                                     clauses = ClauseListNode(
-                                       clauses = [
-                                                   AbstractionNode(
-                                                     abstraction = Abstraction(
-                                                       isEnclosed = false
-                                                       isVarArgs = false
-                                                       parts = [
-                                                                 AbstractionPart(
-                                                                   name = Phase1Token(
-                                                                     text = "b"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 2
-                                                                     column = 9
-                                                                   )
-                                                                   subParams = null
-                                                                   params = null
-                                                                   tail = null
-                                                                 )
-                                                               ]
-                                                       subParams = null
-                                                     )
-                                                   )
-                                                 ]
-                                     )
-                                   )
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses abstractions with one sub param/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses abstractions with one sub param/phase2-structure.txt
@@ -1,16 +1,45 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 ForGroup(
-                                   forSection = ForSection(
-                                     targets = [
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               ForGroup(
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = false
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "a"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 1
+                                                                 column = 8
+                                                               )
+                                                               subParams = [
+                                                                             Phase1Token(
+                                                                               text = "n"
+                                                                               type = ChalkTalkTokenType.Name
+                                                                               row = 1
+                                                                               column = 10
+                                                                             )
+                                                                           ]
+                                                               params = null
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = null
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = null
+                                 thenSection = ThenSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
                                                  AbstractionNode(
                                                    abstraction = Abstraction(
                                                      isEnclosed = false
@@ -18,19 +47,12 @@ Document(
                                                      parts = [
                                                                AbstractionPart(
                                                                  name = Phase1Token(
-                                                                   text = "a"
+                                                                   text = "b"
                                                                    type = ChalkTalkTokenType.Name
-                                                                   row = 1
-                                                                   column = 8
+                                                                   row = 2
+                                                                   column = 9
                                                                  )
-                                                                 subParams = [
-                                                                               Phase1Token(
-                                                                                 text = "n"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 10
-                                                                               )
-                                                                             ]
+                                                                 subParams = null
                                                                  params = null
                                                                  tail = null
                                                                )
@@ -40,47 +62,13 @@ Document(
                                                  )
                                                ]
                                    )
-                                   whereSection = null
-                                   thenSection = ThenSection(
-                                     clauses = ClauseListNode(
-                                       clauses = [
-                                                   AbstractionNode(
-                                                     abstraction = Abstraction(
-                                                       isEnclosed = false
-                                                       isVarArgs = false
-                                                       parts = [
-                                                                 AbstractionPart(
-                                                                   name = Phase1Token(
-                                                                     text = "b"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 2
-                                                                     column = 9
-                                                                   )
-                                                                   subParams = null
-                                                                   params = null
-                                                                   tail = null
-                                                                 )
-                                                               ]
-                                                       subParams = null
-                                                     )
-                                                   )
-                                                 ]
-                                     )
-                                   )
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses enclosed abstractions with sub params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed abstractions with sub params/phase2-structure.txt
@@ -1,36 +1,58 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 ForGroup(
-                                   forSection = ForSection(
-                                     targets = [
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               ForGroup(
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = true
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "a"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 1
+                                                                 column = 9
+                                                               )
+                                                               subParams = [
+                                                                             Phase1Token(
+                                                                               text = "i"
+                                                                               type = ChalkTalkTokenType.Name
+                                                                               row = 1
+                                                                               column = 11
+                                                                             )
+                                                                           ]
+                                                               params = null
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = null
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = null
+                                 thenSection = ThenSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
                                                  AbstractionNode(
                                                    abstraction = Abstraction(
-                                                     isEnclosed = true
+                                                     isEnclosed = false
                                                      isVarArgs = false
                                                      parts = [
                                                                AbstractionPart(
                                                                  name = Phase1Token(
-                                                                   text = "a"
+                                                                   text = "x"
                                                                    type = ChalkTalkTokenType.Name
-                                                                   row = 1
+                                                                   row = 2
                                                                    column = 9
                                                                  )
-                                                                 subParams = [
-                                                                               Phase1Token(
-                                                                                 text = "i"
-                                                                                 type = ChalkTalkTokenType.Name
-                                                                                 row = 1
-                                                                                 column = 11
-                                                                               )
-                                                                             ]
+                                                                 subParams = null
                                                                  params = null
                                                                  tail = null
                                                                )
@@ -40,47 +62,13 @@ Document(
                                                  )
                                                ]
                                    )
-                                   whereSection = null
-                                   thenSection = ThenSection(
-                                     clauses = ClauseListNode(
-                                       clauses = [
-                                                   AbstractionNode(
-                                                     abstraction = Abstraction(
-                                                       isEnclosed = false
-                                                       isVarArgs = false
-                                                       parts = [
-                                                                 AbstractionPart(
-                                                                   name = Phase1Token(
-                                                                     text = "x"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 2
-                                                                     column = 9
-                                                                   )
-                                                                   subParams = null
-                                                                   params = null
-                                                                   tail = null
-                                                                 )
-                                                               ]
-                                                       subParams = null
-                                                     )
-                                                   )
-                                                 ]
-                                     )
-                                   )
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses enclosed plain abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed plain abstractions/phase2-structure.txt
@@ -1,26 +1,48 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 ForGroup(
-                                   forSection = ForSection(
-                                     targets = [
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               ForGroup(
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = true
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "f"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 1
+                                                                 column = 9
+                                                               )
+                                                               subParams = null
+                                                               params = null
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = null
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = null
+                                 thenSection = ThenSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
                                                  AbstractionNode(
                                                    abstraction = Abstraction(
-                                                     isEnclosed = true
+                                                     isEnclosed = false
                                                      isVarArgs = false
                                                      parts = [
                                                                AbstractionPart(
                                                                  name = Phase1Token(
-                                                                   text = "f"
+                                                                   text = "x"
                                                                    type = ChalkTalkTokenType.Name
-                                                                   row = 1
+                                                                   row = 2
                                                                    column = 9
                                                                  )
                                                                  subParams = null
@@ -33,47 +55,13 @@ Document(
                                                  )
                                                ]
                                    )
-                                   whereSection = null
-                                   thenSection = ThenSection(
-                                     clauses = ClauseListNode(
-                                       clauses = [
-                                                   AbstractionNode(
-                                                     abstraction = Abstraction(
-                                                       isEnclosed = false
-                                                       isVarArgs = false
-                                                       parts = [
-                                                                 AbstractionPart(
-                                                                   name = Phase1Token(
-                                                                     text = "x"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 2
-                                                                     column = 9
-                                                                   )
-                                                                   subParams = null
-                                                                   params = null
-                                                                   tail = null
-                                                                 )
-                                                               ]
-                                                       subParams = null
-                                                     )
-                                                   )
-                                                 ]
-                                     )
-                                   )
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses enclosed regular abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses enclosed regular abstractions/phase2-structure.txt
@@ -1,37 +1,59 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 ForGroup(
-                                   forSection = ForSection(
-                                     targets = [
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               ForGroup(
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = true
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "f"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 1
+                                                                 column = 9
+                                                               )
+                                                               subParams = null
+                                                               params = [
+                                                                          Phase1Token(
+                                                                            text = "x"
+                                                                            type = ChalkTalkTokenType.Name
+                                                                            row = 1
+                                                                            column = 11
+                                                                          )
+                                                                        ]
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = null
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = null
+                                 thenSection = ThenSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
                                                  AbstractionNode(
                                                    abstraction = Abstraction(
-                                                     isEnclosed = true
+                                                     isEnclosed = false
                                                      isVarArgs = false
                                                      parts = [
                                                                AbstractionPart(
                                                                  name = Phase1Token(
-                                                                   text = "f"
+                                                                   text = "x"
                                                                    type = ChalkTalkTokenType.Name
-                                                                   row = 1
+                                                                   row = 2
                                                                    column = 9
                                                                  )
                                                                  subParams = null
-                                                                 params = [
-                                                                            Phase1Token(
-                                                                              text = "x"
-                                                                              type = ChalkTalkTokenType.Name
-                                                                              row = 1
-                                                                              column = 11
-                                                                            )
-                                                                          ]
+                                                                 params = null
                                                                  tail = null
                                                                )
                                                              ]
@@ -40,47 +62,13 @@ Document(
                                                  )
                                                ]
                                    )
-                                   whereSection = null
-                                   thenSection = ThenSection(
-                                     clauses = ClauseListNode(
-                                       clauses = [
-                                                   AbstractionNode(
-                                                     abstraction = Abstraction(
-                                                       isEnclosed = false
-                                                       isVarArgs = false
-                                                       parts = [
-                                                                 AbstractionPart(
-                                                                   name = Phase1Token(
-                                                                     text = "x"
-                                                                     type = ChalkTalkTokenType.Name
-                                                                     row = 2
-                                                                     column = 9
-                                                                   )
-                                                                   subParams = null
-                                                                   params = null
-                                                                   tail = null
-                                                                 )
-                                                               ]
-                                                       subParams = null
-                                                     )
-                                                   )
-                                                 ]
-                                     )
-                                   )
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses multi var abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multi var abstractions/phase2-structure.txt
@@ -1,65 +1,53 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "f"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 9
-                                                 )
-                                                 subParams = null
-                                                 params = [
-                                                            Phase1Token(
-                                                              text = "x"
-                                                              type = ChalkTalkTokenType.Name
-                                                              row = 0
-                                                              column = 11
-                                                            ),
-                                                            Phase1Token(
-                                                              text = "y"
-                                                              type = ChalkTalkTokenType.Name
-                                                              row = 0
-                                                              column = 14
-                                                            ),
-                                                            Phase1Token(
-                                                              text = "z"
-                                                              type = ChalkTalkTokenType.Name
-                                                              row = 0
-                                                              column = 17
-                                                            )
-                                                          ]
-                                                 tail = null
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "f"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 9
                                                )
-                                             ]
-                                     subParams = null
-                                   )
+                                               subParams = null
+                                               params = [
+                                                          Phase1Token(
+                                                            text = "x"
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 0
+                                                            column = 11
+                                                          ),
+                                                          Phase1Token(
+                                                            text = "y"
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 0
+                                                            column = 14
+                                                          ),
+                                                          Phase1Token(
+                                                            text = "z"
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 0
+                                                            column = 17
+                                                          )
+                                                        ]
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments indented/phase2-structure.txt
@@ -1,86 +1,74 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "a"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 1
-                                                   column = 3
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "a"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 1
+                                                 column = 3
                                                )
-                                             ]
-                                     subParams = null
-                                   )
-                                 ),
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "b"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 2
-                                                   column = 3
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
-                                               )
-                                             ]
-                                     subParams = null
-                                   )
-                                 ),
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "c"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 3
-                                                   column = 3
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
-                                               )
-                                             ]
-                                     subParams = null
-                                   )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
                                  )
-                               ]
-                   )
+                               ),
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "b"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 2
+                                                 column = 3
+                                               )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
+                                 )
+                               ),
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "c"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 3
+                                                 column = 3
+                                               )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
+                                 )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments mixed indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments mixed indented/phase2-structure.txt
@@ -1,146 +1,134 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "a"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 9
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "a"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 9
                                                )
-                                             ]
-                                     subParams = null
-                                   )
-                                 ),
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "b"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 12
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
-                                               )
-                                             ]
-                                     subParams = null
-                                   )
-                                 ),
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "c"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 1
-                                                   column = 3
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
-                                               )
-                                             ]
-                                     subParams = null
-                                   )
-                                 ),
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "d"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 2
-                                                   column = 3
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
-                                               )
-                                             ]
-                                     subParams = null
-                                   )
-                                 ),
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "e"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 2
-                                                   column = 6
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
-                                               )
-                                             ]
-                                     subParams = null
-                                   )
-                                 ),
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "f"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 3
-                                                   column = 3
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
-                                               )
-                                             ]
-                                     subParams = null
-                                   )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
                                  )
-                               ]
-                   )
+                               ),
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "b"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 12
+                                               )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
+                                 )
+                               ),
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "c"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 1
+                                                 column = 3
+                                               )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
+                                 )
+                               ),
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "d"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 2
+                                                 column = 3
+                                               )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
+                                 )
+                               ),
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "e"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 2
+                                                 column = 6
+                                               )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
+                                 )
+                               ),
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "f"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 3
+                                                 column = 3
+                                               )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
+                                 )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses multiple arguments single line/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses multiple arguments single line/phase2-structure.txt
@@ -1,86 +1,74 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "a"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 9
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "a"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 9
                                                )
-                                             ]
-                                     subParams = null
-                                   )
-                                 ),
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "b"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 12
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
-                                               )
-                                             ]
-                                     subParams = null
-                                   )
-                                 ),
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "c"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 15
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
-                                               )
-                                             ]
-                                     subParams = null
-                                   )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
                                  )
-                               ]
-                   )
+                               ),
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "b"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 12
+                                               )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
+                                 )
+                               ),
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "c"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 15
+                                               )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
+                                 )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses names with .../phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses names with .../phase2-structure.txt
@@ -1,46 +1,34 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "abc..."
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 9
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "abc..."
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 9
                                                )
-                                             ]
-                                     subParams = null
-                                   )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses nested names with .../phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses nested names with .../phase2-structure.txt
@@ -1,53 +1,41 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "f"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 9
-                                                 )
-                                                 subParams = null
-                                                 params = [
-                                                            Phase1Token(
-                                                              text = "abc..."
-                                                              type = ChalkTalkTokenType.Name
-                                                              row = 0
-                                                              column = 11
-                                                            )
-                                                          ]
-                                                 tail = null
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "f"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 9
                                                )
-                                             ]
-                                     subParams = null
-                                   )
+                                               subParams = null
+                                               params = [
+                                                          Phase1Token(
+                                                            text = "abc..."
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 0
+                                                            column = 11
+                                                          )
+                                                        ]
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses operator identifiers/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses operator identifiers/phase2-structure.txt
@@ -1,46 +1,34 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "*"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 9
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "*"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 9
                                                )
-                                             ]
-                                     subParams = null
-                                   )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses single argument indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single argument indented/phase2-structure.txt
@@ -1,46 +1,34 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "x"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 1
-                                                   column = 3
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "x"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 1
+                                                 column = 3
                                                )
-                                             ]
-                                     subParams = null
-                                   )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses single argument on same line/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single argument on same line/phase2-structure.txt
@@ -1,46 +1,34 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "x"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 9
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "x"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 9
                                                )
-                                             ]
-                                     subParams = null
-                                   )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses single var abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses single var abstractions/phase2-structure.txt
@@ -1,53 +1,41 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "f"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 9
-                                                 )
-                                                 subParams = null
-                                                 params = [
-                                                            Phase1Token(
-                                                              text = "x"
-                                                              type = ChalkTalkTokenType.Name
-                                                              row = 0
-                                                              column = 11
-                                                            )
-                                                          ]
-                                                 tail = null
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "f"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 9
                                                )
-                                             ]
-                                     subParams = null
-                                   )
+                                               subParams = null
+                                               params = [
+                                                          Phase1Token(
+                                                            text = "x"
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 0
+                                                            column = 11
+                                                          )
+                                                        ]
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses text elements/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses text elements/phase2-structure.txt
@@ -1,72 +1,60 @@
 Document(
-  defines = [
-              DefinesGroup(
-                signature = null
-                id = IdStatement(
-                  text = "A"
-                  texTalkRoot = ValidationSuccessImpl(
-                    v = ExpressionTexTalkNode(
-                      children = [
-                                   TextTexTalkNode(
-                                     type = TexTalkNodeType.Identifier
-                                     tokenType = TexTalkTokenType.Identifier
-                                     text = "A"
-                                     isVarArg = false
-                                   )
-                                 ]
-                    )
-                  )
-                )
-                definesSection = DefinesSection(
-                  targets = [
-                              AbstractionNode(
-                                abstraction = Abstraction(
-                                  isEnclosed = false
-                                  isVarArgs = false
-                                  parts = [
-                                            AbstractionPart(
-                                              name = Phase1Token(
-                                                text = "B"
-                                                type = ChalkTalkTokenType.Name
-                                                row = 1
-                                                column = 10
-                                              )
-                                              subParams = null
-                                              params = null
-                                              tail = null
-                                            )
-                                          ]
-                                  subParams = null
-                                )
-                              )
-                            ]
-                )
-                assumingSection = null
-                meansSections = [
-                                  MeansSection(
-                                    clauses = ClauseListNode(
-                                      clauses = [
-                                                  Text(
-                                                    text = ""C""
-                                                  )
-                                                ]
-                                    )
+  groups = [
+             DefinesGroup(
+               signature = null
+               id = IdStatement(
+                 text = "A"
+                 texTalkRoot = ValidationSuccessImpl(
+                   v = ExpressionTexTalkNode(
+                     children = [
+                                  TextTexTalkNode(
+                                    type = TexTalkNodeType.Identifier
+                                    tokenType = TexTalkTokenType.Identifier
+                                    text = "A"
+                                    isVarArg = false
                                   )
                                 ]
-                aliasSection = null
-                metaDataSection = null
-              )
-            ]
-  represents = [
-               ]
-  theorems = [
-             ]
-  axioms = [
+                   )
+                 )
+               )
+               definesSection = DefinesSection(
+                 targets = [
+                             AbstractionNode(
+                               abstraction = Abstraction(
+                                 isEnclosed = false
+                                 isVarArgs = false
+                                 parts = [
+                                           AbstractionPart(
+                                             name = Phase1Token(
+                                               text = "B"
+                                               type = ChalkTalkTokenType.Name
+                                               row = 1
+                                               column = 10
+                                             )
+                                             subParams = null
+                                             params = null
+                                             tail = null
+                                           )
+                                         ]
+                                 subParams = null
+                               )
+                             )
+                           ]
+               )
+               assumingSection = null
+               meansSections = [
+                                 MeansSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
+                                                 Text(
+                                                   text = ""C""
+                                                 )
+                                               ]
+                                   )
+                                 )
+                               ]
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )

--- a/src/test/resources/goldens/chalktalk/parses text identifiers/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses text identifiers/phase2-structure.txt
@@ -1,46 +1,34 @@
 Document(
-  defines = [
-            ]
-  represents = [
-               ]
-  theorems = [
-               TheoremGroup(
-                 theoremSection = TheoremSection(
-                   clauses = ClauseListNode(
-                     clauses = [
-                                 AbstractionNode(
-                                   abstraction = Abstraction(
-                                     isEnclosed = false
-                                     isVarArgs = false
-                                     parts = [
-                                               AbstractionPart(
-                                                 name = Phase1Token(
-                                                   text = "x"
-                                                   type = ChalkTalkTokenType.Name
-                                                   row = 0
-                                                   column = 9
-                                                 )
-                                                 subParams = null
-                                                 params = null
-                                                 tail = null
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               AbstractionNode(
+                                 abstraction = Abstraction(
+                                   isEnclosed = false
+                                   isVarArgs = false
+                                   parts = [
+                                             AbstractionPart(
+                                               name = Phase1Token(
+                                                 text = "x"
+                                                 type = ChalkTalkTokenType.Name
+                                                 row = 0
+                                                 column = 9
                                                )
-                                             ]
-                                     subParams = null
-                                   )
+                                               subParams = null
+                                               params = null
+                                               tail = null
+                                             )
+                                           ]
+                                   subParams = null
                                  )
-                               ]
-                   )
+                               )
+                             ]
                  )
-                 aliasSection = null
-                 metaDataSection = null
                )
-             ]
-  axioms = [
+               aliasSection = null
+               metaDataSection = null
+             )
            ]
-  conjectures = [
-                ]
-  resources = [
-              ]
-  protoGroups = [
-                ]
 )


### PR DESCRIPTION
This allows a Document to record the order of `TopLevelGroup`s in
the document.  Methods exist (for example `defines()`) for
getting a list of a particular type of group in the document.