### PR TITLE
feat: `mlg render --noexpand` doesn't render content

### DIFF
--- a/src/main/kotlin/mathlingua/common/MathLingua.kt
+++ b/src/main/kotlin/mathlingua/common/MathLingua.kt
@@ -653,6 +653,10 @@ private fun getHtml(body: String) = """
             }
 
             function render(node) {
+                if (node.className && node.className.indexOf('no-render') >= 0) {
+                    return;
+                }
+
                 /*
                  * The layout for nodes corresponding to text in a "written:" section
                  * looks like the following.  Determine if any child nodes of 'node'
@@ -745,6 +749,14 @@ private fun getHtml(body: String) = """
 
             .mathlingua-text {
                 color: #007700;
+            }
+
+            .mathlingua-text-no-render {
+                color: #007700;
+            }
+
+            .mathlingua-statement-no-render {
+                color: #007377;
             }
 
             .katex {

--- a/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
@@ -144,7 +144,7 @@ fun main() {
 
             val newDoc = expandAtNode(doc, nearestNode, doc.defines(), doc.represents())
 
-            outputArea.text = newDoc.toCode(false, 0).getCode()
+            outputArea.text = newDoc.toCode(false, 0, HtmlCodeWriter(emptyList(), emptyList())).getCode()
             outputTree.model = DefaultTreeModel(
                 toTreeNode(
                     tracker,


### PR DESCRIPTION
That is, `mlg render --noexpand --format=html` generates html
code, but it is written so the content looks like the input
MathLingua code instead of being rendered by KaTeX.