### PR TITLE
feat: support literals

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexer.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkLexer.kt
@@ -309,6 +309,25 @@ private class ChalkTalkLexerImpl(private var text: String) :
                 }
 
                 this.chalkTalkTokens!!.add(Phase1Token(name, ChalkTalkTokenType.Name, startLine, startColumn))
+            } else if (c == '`') {
+                val startLine = line
+                val startColumn = column
+                var str = "" + c
+                while (i < text.length && text[i] != '`') {
+                    str += text[i++]
+                    column++
+                }
+                if (i == text.length) {
+                    errors.add(
+                        ParseError("Expected a terminating `", line, column)
+                    )
+                    str += "`"
+                } else {
+                    // include the terminating `
+                    str += text[i++]
+                    column++
+                }
+                this.chalkTalkTokens!!.add(Phase1Token(str, ChalkTalkTokenType.Literal, startLine, startColumn))
             } else if (c == '"') {
                 val startLine = line
                 val startColumn = column

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkParser.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ChalkTalkParser.kt
@@ -154,10 +154,11 @@ private class ChalkTalkParserImpl : ChalkTalkParser {
         }
 
         private fun argument(): Argument? {
-            val literal = token(ChalkTalkTokenType.Statement)
+            val text = token(ChalkTalkTokenType.Statement)
                 ?: token(ChalkTalkTokenType.String)
-            if (literal != null) {
-                return Argument(literal)
+                ?: token(ChalkTalkTokenType.Literal)
+            if (text != null) {
+                return Argument(text)
             }
 
             val mapping = mapping()

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase1/ast/Phase1Target.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase1/ast/Phase1Target.kt
@@ -35,7 +35,8 @@ enum class ChalkTalkTokenType {
     LCurly,
     RCurly,
     Underscore,
-    DotDotDot
+    DotDotDot,
+    Literal
 }
 
 sealed class Phase1Target : Phase1Node

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/CodeWriter.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/CodeWriter.kt
@@ -23,6 +23,7 @@ import mathlingua.common.ValidationSuccess
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.clause.IdStatement
+import mathlingua.common.chalktalk.phase2.ast.clause.Literal
 import mathlingua.common.chalktalk.phase2.ast.toplevel.DefinesGroup
 import mathlingua.common.chalktalk.phase2.ast.toplevel.RepresentsGroup
 import mathlingua.common.textalk.ExpressionTexTalkNode
@@ -42,9 +43,11 @@ interface CodeWriter {
     fun writeIndent(hasDot: Boolean, indent: Int)
     fun writePhase1Node(phase1Node: Phase1Node)
     fun writeId(id: IdStatement)
+    fun writeId(id: Literal)
     fun writeStatement(stmtText: String, root: Validation<ExpressionTexTalkNode>)
     fun writeIdentifier(name: String, isVarArgs: Boolean)
     fun writeText(text: String)
+    fun writeLiteral(text: String)
     fun writeDirect(text: String)
     fun beginTopLevel()
     fun endTopLevel()
@@ -136,6 +139,20 @@ open class HtmlCodeWriter(
         val stmt = id.toStatement().toCode(false, 0, MathLinguaCodeWriter(emptyList(), emptyList())).getCode()
         builder.append(stmt.removeSurrounding("'", "'"))
         builder.append(']')
+        builder.append("</span>")
+    }
+
+    override fun writeId(id: Literal) {
+        builder.append("<span class='mathlingua-id'>")
+        builder.append('[')
+        builder.append(id.literal)
+        builder.append(']')
+        builder.append("</span>")
+    }
+
+    override fun writeLiteral(text: String) {
+        builder.append("<span class='mathlingua-literal'>")
+        builder.append("`$text`")
         builder.append("</span>")
     }
 
@@ -310,6 +327,18 @@ class MathLinguaCodeWriter(
         val stmt = id.toStatement().toCode(false, 0, newCodeWriter(emptyList(), emptyList())).getCode()
         builder.append(stmt.removeSurrounding("'", "'"))
         builder.append(']')
+    }
+
+    override fun writeId(id: Literal) {
+        builder.append('[')
+        builder.append(id.literal)
+        builder.append(']')
+    }
+
+    override fun writeLiteral(text: String) {
+        builder.append('`')
+        builder.append(text)
+        builder.append('`')
     }
 
     override fun writeText(text: String) {

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Clause.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Clause.kt
@@ -60,6 +60,10 @@ private val CLAUSE_VALIDATORS = listOf(
                 ::validateText
         ),
         ValidationPair(
+                ::isLiteral,
+                ::validateLiteral
+        ),
+        ValidationPair(
                 ::isForGroup,
                 ::validateForGroup
         ),

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Literal.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Literal.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.common.chalktalk.phase2.ast.clause
+
+import mathlingua.common.*
+import mathlingua.common.chalktalk.phase1.ast.*
+import mathlingua.common.chalktalk.phase2.CodeWriter
+import mathlingua.common.chalktalk.phase2.ast.Phase2Node
+
+data class Literal(val literal: String) : Clause {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) {}
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeLiteral(literal.removeSurrounding("`", "`"))
+        return writer
+    }
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
+}
+
+fun isLiteral(node: Phase1Node) = node is Phase1Token && node.type === ChalkTalkTokenType.Literal
+
+fun validateLiteral(rawNode: Phase1Node, tracker: MutableLocationTracker): Validation<Literal> {
+    val node = rawNode.resolve()
+
+    val errors = ArrayList<ParseError>()
+    if (node !is Phase1Token) {
+        errors.add(
+            ParseError(
+                "Cannot convert a to a ChalkTalkToken",
+                getRow(node), getColumn(node)
+            )
+        )
+    }
+
+    val (text, type, row, column) = node as Phase1Token
+    if (type !== ChalkTalkTokenType.Literal) {
+        errors.add(
+            ParseError(
+                "Cannot convert a " + node.toCode() + " to a Literal",
+                row, column
+            )
+        )
+        return validationFailure(errors)
+    }
+
+    return validationSuccess(tracker, rawNode, Literal(text))
+}

--- a/src/test/resources/goldens/chalktalk/handles_literals/input.math
+++ b/src/test/resources/goldens/chalktalk/handles_literals/input.math
@@ -1,0 +1,3 @@
+Theorem:
+. `some literal
+      text`

--- a/src/test/resources/goldens/chalktalk/handles_literals/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/handles_literals/phase1-output.math
@@ -1,0 +1,3 @@
+Theorem:
+. `some literal
+      text`

--- a/src/test/resources/goldens/chalktalk/handles_literals/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles_literals/phase1-structure.txt
@@ -1,0 +1,28 @@
+Root(
+  groups = [
+             Group(
+               sections = [
+                            Section(
+                              name = Phase1Token(
+                                text = "Theorem"
+                                type = ChalkTalkTokenType.Name
+                                row = 0
+                                column = 0
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Phase1Token(
+                                           text = "`some literal
+      text`"
+                                           type = ChalkTalkTokenType.Literal
+                                           row = 1
+                                           column = 3
+                                         )
+                                       )
+                                     ]
+                            )
+                          ]
+               id = null
+             )
+           ]
+)

--- a/src/test/resources/goldens/chalktalk/handles_literals/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/handles_literals/phase2-output.math
@@ -1,0 +1,3 @@
+Theorem:
+. `some literal
+      text`

--- a/src/test/resources/goldens/chalktalk/handles_literals/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles_literals/phase2-structure.txt
@@ -1,0 +1,18 @@
+Document(
+  groups = [
+             TheoremGroup(
+               theoremSection = TheoremSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               Literal(
+                                 literal = "`some literal
+      text`"
+                               )
+                             ]
+                 )
+               )
+               aliasSection = null
+               metaDataSection = null
+             )
+           ]
+)


### PR DESCRIPTION
Backticks are now supported that enclose literal text.  This can
be used to specify the content in an underlying formal language.