### PR TITLE
feat: support multiple sections with the same name

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/SectionIdentification.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/SectionIdentification.kt
@@ -42,6 +42,7 @@ fun identifySections(sections: List<Section>, vararg expected: String): Map<Stri
         expectedQueue.offer(e)
     }
 
+    val usedSectionNames = mutableMapOf<String, Int>()
     val result = mutableMapOf<String, MutableList<Section>>()
 
     while (!sectionQueue.isEmpty() && !expectedQueue.isEmpty()) {
@@ -51,16 +52,22 @@ fun identifySections(sections: List<Section>, vararg expected: String): Map<Stri
         val isOptional = maybeName.endsWith("?")
         val trueName =
             if (isOptional) maybeName.substring(0, maybeName.length - 1) else maybeName
+        val key = if (usedSectionNames.containsKey(trueName)) {
+            "$trueName${usedSectionNames[trueName]}"
+        } else {
+            trueName
+        }
+        usedSectionNames[trueName] = usedSectionNames.getOrDefault(trueName, 0) + 1
         if (nextSection.name.text == trueName) {
-            if (!result.containsKey(trueName)) {
-                result[trueName] = mutableListOf()
+            if (!result.containsKey(key)) {
+                result[key] = mutableListOf()
             }
-            result[trueName]!!.add(nextSection)
+            result[key]!!.add(nextSection)
             // the expected name and Section have both been used so move past them
             sectionQueue.poll()
             expectedQueue.poll()
             while (!sectionQueue.isEmpty() && sectionQueue.peek().name.text == trueName) {
-                result[trueName]!!.add(sectionQueue.poll())
+                result[key]!!.add(sectionQueue.poll())
             }
         } else if (isOptional) {
             // The Section found doesn't match the expected name

--- a/src/test/kotlin/mathlingua/common/chalktalk/phase2/ast/section/SectionIdentificationTest.kt
+++ b/src/test/kotlin/mathlingua/common/chalktalk/phase2/ast/section/SectionIdentificationTest.kt
@@ -1,0 +1,89 @@
+package mathlingua.common.chalktalk.phase2.ast.section
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import mathlingua.common.chalktalk.phase1.ast.ChalkTalkTokenType
+import mathlingua.common.chalktalk.phase1.ast.Phase1Token
+import mathlingua.common.chalktalk.phase1.ast.Section
+import org.junit.jupiter.api.Test
+
+internal class SectionIdentificationTest {
+    @Test
+    fun identifiesUniqueRequiredSectionNames() {
+        val sections = listOf(
+            Section(Phase1Token("Theorem", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("given", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("where", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("then", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("using", ChalkTalkTokenType.Name, -1, -1), emptyList())
+        )
+        val ids = identifySections(sections, "Theorem", "given", "where", "then", "using")
+        assertThat(ids.keys).isEqualTo(setOf("Theorem", "given", "where", "then", "using"))
+    }
+
+    @Test
+    fun identifiesUniqueOptionalAllSuppliedSectionNames() {
+        val sections = listOf(
+            Section(Phase1Token("Theorem", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("given", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("where", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("then", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("using", ChalkTalkTokenType.Name, -1, -1), emptyList())
+        )
+        val ids = identifySections(sections, "Theorem", "given?", "where?", "then", "using?")
+        assertThat(ids.keys).isEqualTo(setOf("Theorem", "given", "where", "then", "using"))
+    }
+
+    @Test
+    fun identifiesUniqueOptionalSomeOmittedSectionNames() {
+        val sections = listOf(
+            Section(Phase1Token("Theorem", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("then", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("using", ChalkTalkTokenType.Name, -1, -1), emptyList())
+        )
+        val ids = identifySections(sections, "Theorem", "given?", "where?", "then", "using?")
+        assertThat(ids.keys).isEqualTo(setOf("Theorem", "then", "using"))
+    }
+
+    @Test
+    fun identifiesDuplicateOptionalAllSuppliedSectionNames() {
+        val sections = listOf(
+            Section(Phase1Token("Theorem", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("given", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("where", ChalkTalkTokenType.Name, 1, 1), emptyList()),
+            Section(Phase1Token("then", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("using", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("where", ChalkTalkTokenType.Name, 2, 2), emptyList())
+        )
+        val ids = identifySections(sections, "Theorem", "given?", "where?", "then", "using?", "where?")
+        assertThat(ids.keys).isEqualTo(setOf("Theorem", "given", "where", "then", "using", "where1"))
+        assertThat(ids["where"]!![0].name.row).isEqualTo(1)
+        assertThat(ids["where1"]!![0].name.row).isEqualTo(2)
+    }
+
+    @Test
+    fun identifiesDuplicateOptionalFirstOmittedSectionNames() {
+        val sections = listOf(
+            Section(Phase1Token("Theorem", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("then", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("using", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("where", ChalkTalkTokenType.Name, 2, 2), emptyList())
+        )
+        val ids = identifySections(sections, "Theorem", "given?", "where?", "then", "using?", "where?")
+        assertThat(ids.keys).isEqualTo(setOf("Theorem", "then", "using", "where1"))
+        assertThat(ids["where1"]!![0].name.row).isEqualTo(2)
+    }
+
+    @Test
+    fun identifiesDuplicateOptionalSecondOmittedSectionNames() {
+        val sections = listOf(
+            Section(Phase1Token("Theorem", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("where", ChalkTalkTokenType.Name, 1, 1), emptyList()),
+            Section(Phase1Token("then", ChalkTalkTokenType.Name, -1, -1), emptyList()),
+            Section(Phase1Token("using", ChalkTalkTokenType.Name, -1, -1), emptyList())
+        )
+        val ids = identifySections(sections, "Theorem", "given?", "where?", "then", "using?", "where?")
+        assertThat(ids.keys).isEqualTo(setOf("Theorem", "where", "then", "using"))
+        assertThat(ids["where"]!![0].name.row).isEqualTo(1)
+    }
+}


### PR DESCRIPTION
In particular, the sections with the same name do not need
to be continuous.  That is, the following is supported:
```
Theorem:
given:
where:
then:
using:
where:
```
Notice that there are two `where:` sections.  The first is
accessed by `where` and the second by `where1`.

The use of `where` instead of `where0` for the first `where:`
section is used since most of the time sections are not duplicated.