### PR TITLE
feat: support `collection:of:over:for:where:`

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Clause.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Clause.kt
@@ -98,6 +98,10 @@ private val CLAUSE_VALIDATORS = listOf(
         ValidationPair(
             ::isMappingGroup,
             ::validateMappingGroup
+        ),
+        ValidationPair(
+            ::isCollectionGroup,
+            ::validateCollectionGroup
         )
 )
 

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/CollectionGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/CollectionGroup.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.common.chalktalk.phase2.ast.clause
+
+import mathlingua.common.*
+import mathlingua.common.chalktalk.phase1.ast.*
+import mathlingua.common.chalktalk.phase2.CodeWriter
+import mathlingua.common.chalktalk.phase2.ast.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.section.identifySections
+import mathlingua.common.chalktalk.phase2.ast.section.*
+
+data class CollectionGroup(
+    val collectionSection: CollectionSection,
+    val ofSection: OfSection,
+    val overSection: OverSection?,
+    val forSection: ForSection,
+    val whereSection: WhereSection
+) : Clause {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) {
+        fn(collectionSection)
+        fn(ofSection)
+        if (overSection != null) {
+            fn(overSection)
+        }
+        fn(forSection)
+        fn(whereSection)
+    }
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+        toCode(writer, isArg, indent, collectionSection, ofSection, overSection, forSection, whereSection)
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(CollectionGroup(
+        collectionSection = collectionSection.transform(chalkTransformer) as CollectionSection,
+        ofSection = ofSection.transform(chalkTransformer) as OfSection,
+        overSection = overSection?.transform(chalkTransformer) as OverSection?,
+        forSection = forSection.transform(chalkTransformer) as ForSection,
+        whereSection = whereSection.transform(chalkTransformer) as WhereSection
+    ))
+}
+
+fun isCollectionGroup(node: Phase1Node) = firstSectionMatchesName(node, "collection")
+
+fun validateCollectionGroup(rawNode: Phase1Node, tracker: MutableLocationTracker): Validation<CollectionGroup> {
+    val node = rawNode.resolve()
+
+    val errors = ArrayList<ParseError>()
+    if (node !is Group) {
+        errors.add(
+            ParseError(
+                "Expected a Group",
+                getRow(node), getColumn(node)
+            )
+        )
+        return validationFailure(errors)
+    }
+
+    val (sections) = node
+
+    val sectionMap: Map<String, List<Section>>
+    try {
+        sectionMap = identifySections(
+            sections,
+            "collection", "of", "over?", "for", "where"
+        )
+    } catch (e: ParseError) {
+        errors.add(ParseError(e.message, e.row, e.column))
+        return validationFailure(errors)
+    }
+
+    val collectionNode = sectionMap["collection"]!!
+    val ofNode = sectionMap["of"]!!
+    val overNode = sectionMap["over"]
+    val forNode = sectionMap["for"]!!
+    val whereNode = sectionMap["where"]!!
+
+    var collectionSection: CollectionSection? = null
+    when (val validation = validateCollectionSection(collectionNode[0], tracker)) {
+        is ValidationSuccess -> collectionSection = validation.value
+        is ValidationFailure -> errors.addAll(validation.errors)
+    }
+
+    var ofSection: OfSection? = null
+    when (val validation = validateOfSection(ofNode[0], tracker)) {
+        is ValidationSuccess -> ofSection = validation.value
+        is ValidationFailure -> errors.addAll(validation.errors)
+    }
+
+    var overSection: OverSection? = null
+    if (overNode != null) {
+        when (val validation = validateOverSection(overNode[0], tracker)) {
+            is ValidationSuccess -> overSection = validation.value
+            is ValidationFailure -> errors.addAll(validation.errors)
+        }
+    }
+
+    var forSection: ForSection? = null
+    when (val validation = validateForSection(forNode[0], tracker)) {
+        is ValidationSuccess -> forSection = validation.value
+        is ValidationFailure -> errors.addAll(validation.errors)
+    }
+
+    var whereSection: WhereSection? = null
+    when (val validation = validateWhereSection(whereNode[0], tracker)) {
+        is ValidationSuccess -> whereSection = validation.value
+        is ValidationFailure -> errors.addAll(validation.errors)
+    }
+
+    return if (errors.isNotEmpty()) {
+        validationFailure(errors)
+    } else validationSuccess(
+        tracker,
+        rawNode,
+        CollectionGroup(
+            collectionSection!!,
+            ofSection!!,
+            overSection,
+            forSection!!,
+            whereSection!!
+        )
+    )
+}

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/CollectionSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/CollectionSection.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.common.chalktalk.phase2.ast.section
+
+import mathlingua.common.MutableLocationTracker
+import mathlingua.common.chalktalk.phase1.ast.Phase1Node
+import mathlingua.common.chalktalk.phase2.CodeWriter
+import mathlingua.common.chalktalk.phase2.ast.Phase2Node
+
+class CollectionSection : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) {
+    }
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("collection")
+        return writer
+    }
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
+        chalkTransformer(this)
+}
+
+fun validateCollectionSection(node: Phase1Node, tracker: MutableLocationTracker) = validateEmptySection(
+    node,
+    tracker,
+    "collection",
+    ::CollectionSection
+)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/OfSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/OfSection.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.common.chalktalk.phase2.ast.section
+
+import mathlingua.common.MutableLocationTracker
+import mathlingua.common.chalktalk.phase1.ast.Phase1Node
+import mathlingua.common.chalktalk.phase2.CodeWriter
+import mathlingua.common.chalktalk.phase2.ast.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.clause.Statement
+
+data class OfSection(val statement: Statement) : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) {
+        fn(statement)
+    }
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("of")
+        writer.append(statement, false, 1)
+        return writer
+    }
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
+        chalkTransformer(OfSection(
+            statement = statement.transform(chalkTransformer) as Statement
+        ))
+}
+
+fun validateOfSection(node: Phase1Node, tracker: MutableLocationTracker) = validateStatementSection(
+    node,
+    tracker,
+    "of",
+    ::OfSection
+)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/OverSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/section/OverSection.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.common.chalktalk.phase2.ast.section
+
+import mathlingua.common.MutableLocationTracker
+import mathlingua.common.chalktalk.phase1.ast.Phase1Node
+import mathlingua.common.chalktalk.phase2.CodeWriter
+import mathlingua.common.chalktalk.phase2.ast.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.clause.Statement
+
+data class OverSection(val statement: Statement) : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) {
+        fn(statement)
+    }
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("over")
+        writer.append(statement, false, 1)
+        return writer
+    }
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
+        chalkTransformer(OverSection(
+            statement = statement.transform(chalkTransformer) as Statement
+        ))
+}
+
+fun validateOverSection(node: Phase1Node, tracker: MutableLocationTracker) = validateStatementSection(
+    node,
+    tracker,
+    "over",
+    ::OverSection
+)

--- a/src/test/resources/goldens/chalktalk/parses_collection_groups/input.math
+++ b/src/test/resources/goldens/chalktalk/parses_collection_groups/input.math
@@ -1,0 +1,8 @@
+[\evens]
+Defines: X
+computes:
+. collection:
+  of: '2*k'
+  over: '\integer'
+  for: k
+  where: 'k is \integer'

--- a/src/test/resources/goldens/chalktalk/parses_collection_groups/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/parses_collection_groups/phase1-output.math
@@ -1,0 +1,13 @@
+[\evens]
+Defines:
+. X
+computes:
+. collection:
+  of:
+  . '2*k'
+  over:
+  . '\integer'
+  for:
+  . k
+  where:
+  . 'k is \integer'

--- a/src/test/resources/goldens/chalktalk/parses_collection_groups/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_collection_groups/phase1-structure.txt
@@ -1,0 +1,155 @@
+Root(
+  groups = [
+             Group(
+               sections = [
+                            Section(
+                              name = Phase1Token(
+                                text = "Defines"
+                                type = ChalkTalkTokenType.Name
+                                row = 1
+                                column = 1
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Abstraction(
+                                           isEnclosed = false
+                                           isVarArgs = false
+                                           parts = [
+                                                     AbstractionPart(
+                                                       name = Phase1Token(
+                                                         text = "X"
+                                                         type = ChalkTalkTokenType.Name
+                                                         row = 1
+                                                         column = 10
+                                                       )
+                                                       subParams = null
+                                                       params = null
+                                                       tail = null
+                                                     )
+                                                   ]
+                                           subParams = null
+                                         )
+                                       )
+                                     ]
+                            ),
+                            Section(
+                              name = Phase1Token(
+                                text = "computes"
+                                type = ChalkTalkTokenType.Name
+                                row = 2
+                                column = 1
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Group(
+                                           sections = [
+                                                        Section(
+                                                          name = Phase1Token(
+                                                            text = "collection"
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 3
+                                                            column = 3
+                                                          )
+                                                          args = [
+                                                                 ]
+                                                        ),
+                                                        Section(
+                                                          name = Phase1Token(
+                                                            text = "of"
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 4
+                                                            column = 3
+                                                          )
+                                                          args = [
+                                                                   Argument(
+                                                                     chalkTalkTarget = Phase1Token(
+                                                                       text = "'2*k'"
+                                                                       type = ChalkTalkTokenType.Statement
+                                                                       row = 4
+                                                                       column = 7
+                                                                     )
+                                                                   )
+                                                                 ]
+                                                        ),
+                                                        Section(
+                                                          name = Phase1Token(
+                                                            text = "over"
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 5
+                                                            column = 3
+                                                          )
+                                                          args = [
+                                                                   Argument(
+                                                                     chalkTalkTarget = Phase1Token(
+                                                                       text = "'\integer'"
+                                                                       type = ChalkTalkTokenType.Statement
+                                                                       row = 5
+                                                                       column = 9
+                                                                     )
+                                                                   )
+                                                                 ]
+                                                        ),
+                                                        Section(
+                                                          name = Phase1Token(
+                                                            text = "for"
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 6
+                                                            column = 3
+                                                          )
+                                                          args = [
+                                                                   Argument(
+                                                                     chalkTalkTarget = Abstraction(
+                                                                       isEnclosed = false
+                                                                       isVarArgs = false
+                                                                       parts = [
+                                                                                 AbstractionPart(
+                                                                                   name = Phase1Token(
+                                                                                     text = "k"
+                                                                                     type = ChalkTalkTokenType.Name
+                                                                                     row = 6
+                                                                                     column = 8
+                                                                                   )
+                                                                                   subParams = null
+                                                                                   params = null
+                                                                                   tail = null
+                                                                                 )
+                                                                               ]
+                                                                       subParams = null
+                                                                     )
+                                                                   )
+                                                                 ]
+                                                        ),
+                                                        Section(
+                                                          name = Phase1Token(
+                                                            text = "where"
+                                                            type = ChalkTalkTokenType.Name
+                                                            row = 7
+                                                            column = 3
+                                                          )
+                                                          args = [
+                                                                   Argument(
+                                                                     chalkTalkTarget = Phase1Token(
+                                                                       text = "'k is \integer'"
+                                                                       type = ChalkTalkTokenType.Statement
+                                                                       row = 7
+                                                                       column = 10
+                                                                     )
+                                                                   )
+                                                                 ]
+                                                        )
+                                                      ]
+                                           id = null
+                                         )
+                                       )
+                                     ]
+                            )
+                          ]
+               id = Phase1Token(
+                 text = "[\evens]"
+                 type = ChalkTalkTokenType.Id
+                 row = 0
+                 column = 0
+               )
+             )
+           ]
+)

--- a/src/test/resources/goldens/chalktalk/parses_collection_groups/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/parses_collection_groups/phase2-output.math
@@ -1,0 +1,9 @@
+[\evens]
+Defines: X
+computes:
+. collection:
+  of: '2*k'
+  over: '\integer'
+  for: k
+  where:
+  . 'k is \integer'

--- a/src/test/resources/goldens/chalktalk/parses_collection_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_collection_groups/phase2-structure.txt
@@ -1,0 +1,217 @@
+Document(
+  groups = [
+             DefinesGroup(
+               signature = "\evens"
+               id = IdStatement(
+                 text = "\evens"
+                 texTalkRoot = ValidationSuccessImpl(
+                   v = ExpressionTexTalkNode(
+                     children = [
+                                  Command(
+                                    parts = [
+                                              CommandPart(
+                                                name = TextTexTalkNode(
+                                                  type = TexTalkNodeType.Identifier
+                                                  tokenType = TexTalkTokenType.Identifier
+                                                  text = "evens"
+                                                  isVarArg = false
+                                                )
+                                                square = null
+                                                subSup = null
+                                                groups = [
+                                                         ]
+                                                paren = null
+                                                namedGroups = [
+                                                              ]
+                                              )
+                                            ]
+                                  )
+                                ]
+                   )
+                 )
+               )
+               definesSection = DefinesSection(
+                 targets = [
+                             AbstractionNode(
+                               abstraction = Abstraction(
+                                 isEnclosed = false
+                                 isVarArgs = false
+                                 parts = [
+                                           AbstractionPart(
+                                             name = Phase1Token(
+                                               text = "X"
+                                               type = ChalkTalkTokenType.Name
+                                               row = 1
+                                               column = 10
+                                             )
+                                             subParams = null
+                                             params = null
+                                             tail = null
+                                           )
+                                         ]
+                                 subParams = null
+                               )
+                             )
+                           ]
+               )
+               whenSection = null
+               meansSection = null
+               computesSection = ComputesSection(
+                 clauses = ClauseListNode(
+                   clauses = [
+                               CollectionGroup(
+                                 collectionSection = CollectionSection(
+                                 )
+                                 ofSection = OfSection(
+                                   statement = Statement(
+                                     text = "2*k"
+                                     texTalkRoot = ValidationSuccessImpl(
+                                       v = ExpressionTexTalkNode(
+                                         children = [
+                                                      OperatorTexTalkNode(
+                                                        lhs = TextTexTalkNode(
+                                                          type = TexTalkNodeType.Identifier
+                                                          tokenType = TexTalkTokenType.Identifier
+                                                          text = "2"
+                                                          isVarArg = false
+                                                        )
+                                                        command = TextTexTalkNode(
+                                                          type = TexTalkNodeType.Operator
+                                                          tokenType = TexTalkTokenType.Operator
+                                                          text = "*"
+                                                          isVarArg = false
+                                                        )
+                                                        rhs = TextTexTalkNode(
+                                                          type = TexTalkNodeType.Identifier
+                                                          tokenType = TexTalkTokenType.Identifier
+                                                          text = "k"
+                                                          isVarArg = false
+                                                        )
+                                                      )
+                                                    ]
+                                       )
+                                     )
+                                   )
+                                 )
+                                 overSection = OverSection(
+                                   statement = Statement(
+                                     text = "\integer"
+                                     texTalkRoot = ValidationSuccessImpl(
+                                       v = ExpressionTexTalkNode(
+                                         children = [
+                                                      Command(
+                                                        parts = [
+                                                                  CommandPart(
+                                                                    name = TextTexTalkNode(
+                                                                      type = TexTalkNodeType.Identifier
+                                                                      tokenType = TexTalkTokenType.Identifier
+                                                                      text = "integer"
+                                                                      isVarArg = false
+                                                                    )
+                                                                    square = null
+                                                                    subSup = null
+                                                                    groups = [
+                                                                             ]
+                                                                    paren = null
+                                                                    namedGroups = [
+                                                                                  ]
+                                                                  )
+                                                                ]
+                                                      )
+                                                    ]
+                                       )
+                                     )
+                                   )
+                                 )
+                                 forSection = ForSection(
+                                   targets = [
+                                               AbstractionNode(
+                                                 abstraction = Abstraction(
+                                                   isEnclosed = false
+                                                   isVarArgs = false
+                                                   parts = [
+                                                             AbstractionPart(
+                                                               name = Phase1Token(
+                                                                 text = "k"
+                                                                 type = ChalkTalkTokenType.Name
+                                                                 row = 6
+                                                                 column = 8
+                                                               )
+                                                               subParams = null
+                                                               params = null
+                                                               tail = null
+                                                             )
+                                                           ]
+                                                   subParams = null
+                                                 )
+                                               )
+                                             ]
+                                 )
+                                 whereSection = WhereSection(
+                                   clauses = ClauseListNode(
+                                     clauses = [
+                                                 Statement(
+                                                   text = "k is \integer"
+                                                   texTalkRoot = ValidationSuccessImpl(
+                                                     v = ExpressionTexTalkNode(
+                                                       children = [
+                                                                    IsTexTalkNode(
+                                                                      lhs = ParametersTexTalkNode(
+                                                                        items = [
+                                                                                  ExpressionTexTalkNode(
+                                                                                    children = [
+                                                                                                 TextTexTalkNode(
+                                                                                                   type = TexTalkNodeType.Identifier
+                                                                                                   tokenType = TexTalkTokenType.Identifier
+                                                                                                   text = "k"
+                                                                                                   isVarArg = false
+                                                                                                 )
+                                                                                               ]
+                                                                                  )
+                                                                                ]
+                                                                      )
+                                                                      rhs = ParametersTexTalkNode(
+                                                                        items = [
+                                                                                  ExpressionTexTalkNode(
+                                                                                    children = [
+                                                                                                 Command(
+                                                                                                   parts = [
+                                                                                                             CommandPart(
+                                                                                                               name = TextTexTalkNode(
+                                                                                                                 type = TexTalkNodeType.Identifier
+                                                                                                                 tokenType = TexTalkTokenType.Identifier
+                                                                                                                 text = "integer"
+                                                                                                                 isVarArg = false
+                                                                                                               )
+                                                                                                               square = null
+                                                                                                               subSup = null
+                                                                                                               groups = [
+                                                                                                                        ]
+                                                                                                               paren = null
+                                                                                                               namedGroups = [
+                                                                                                                             ]
+                                                                                                             )
+                                                                                                           ]
+                                                                                                 )
+                                                                                               ]
+                                                                                  )
+                                                                                ]
+                                                                      )
+                                                                    )
+                                                                  ]
+                                                     )
+                                                   )
+                                                 )
+                                               ]
+                                   )
+                                 )
+                               )
+                             ]
+                 )
+               )
+               usingSection = null
+               whereSection = null
+               metaDataSection = null
+             )
+           ]
+)


### PR DESCRIPTION
These groups are used to describe sets.