### PR TITLE
feat: support operator symbols in commands

### DIFF
--- a/src/main/kotlin/mathlingua/common/textalk/TexTalkParser.kt
+++ b/src/main/kotlin/mathlingua/common/textalk/TexTalkParser.kt
@@ -156,6 +156,25 @@ private class TexTalkParserImpl : TexTalkParser {
                 }
                 if (has(TexTalkTokenType.Period)) {
                     expect(TexTalkTokenType.Period) // move past the .
+                    if (has(TexTalkTokenType.Operator)) {
+                        val operator = expect(TexTalkTokenType.Operator)
+                        parts.add(
+                            CommandPart(
+                                name = TextTexTalkNode(
+                                    type = TexTalkNodeType.Identifier,
+                                    tokenType = TexTalkTokenType.Operator,
+                                    text = operator.text,
+                                    isVarArg = false
+                                ),
+                                square = null,
+                                subSup = null,
+                                groups = emptyList(),
+                                paren = null,
+                                namedGroups = emptyList()
+                            )
+                        )
+                        break
+                    }
                 } else {
                     break
                 }

--- a/src/test/kotlin/TestUtil.kt
+++ b/src/test/kotlin/TestUtil.kt
@@ -26,7 +26,7 @@ import java.nio.file.Paths
 // This is useful if a change was made that impacts a lot of golden files, and
 // you want to regenerate them and use `git diff` to see how your change
 // impacted the tests.
-internal const val OVERWRITE_GOLDEN_FILES = true
+internal const val OVERWRITE_GOLDEN_FILES = false
 
 data class TestCase(
     val name: String,

--- a/src/test/resources/goldens/chalktalk/parses_mapping_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_mapping_groups/phase2-structure.txt
@@ -87,38 +87,42 @@ Document(
                                  mappingSection = MappingSection(
                                  )
                                  fromSection = FromSection(
-                                   statement = Statement(
-                                     text = "A"
-                                     texTalkRoot = ValidationSuccessImpl(
-                                       v = ExpressionTexTalkNode(
-                                         children = [
-                                                      TextTexTalkNode(
-                                                        type = TexTalkNodeType.Identifier
-                                                        tokenType = TexTalkTokenType.Identifier
-                                                        text = "A"
-                                                        isVarArg = false
+                                   statements = [
+                                                  Statement(
+                                                    text = "A"
+                                                    texTalkRoot = ValidationSuccessImpl(
+                                                      v = ExpressionTexTalkNode(
+                                                        children = [
+                                                                     TextTexTalkNode(
+                                                                       type = TexTalkNodeType.Identifier
+                                                                       tokenType = TexTalkTokenType.Identifier
+                                                                       text = "A"
+                                                                       isVarArg = false
+                                                                     )
+                                                                   ]
                                                       )
-                                                    ]
-                                       )
-                                     )
-                                   )
+                                                    )
+                                                  )
+                                                ]
                                  )
                                  toSection = ToSection(
-                                   statement = Statement(
-                                     text = "A"
-                                     texTalkRoot = ValidationSuccessImpl(
-                                       v = ExpressionTexTalkNode(
-                                         children = [
-                                                      TextTexTalkNode(
-                                                        type = TexTalkNodeType.Identifier
-                                                        tokenType = TexTalkTokenType.Identifier
-                                                        text = "A"
-                                                        isVarArg = false
+                                   statements = [
+                                                  Statement(
+                                                    text = "A"
+                                                    texTalkRoot = ValidationSuccessImpl(
+                                                      v = ExpressionTexTalkNode(
+                                                        children = [
+                                                                     TextTexTalkNode(
+                                                                       type = TexTalkNodeType.Identifier
+                                                                       tokenType = TexTalkTokenType.Identifier
+                                                                       text = "A"
+                                                                       isVarArg = false
+                                                                     )
+                                                                   ]
                                                       )
-                                                    ]
-                                       )
-                                     )
-                                   )
+                                                    )
+                                                  )
+                                                ]
                                  )
                                  asSection = AsSection(
                                    clauses = ClauseListNode(

--- a/src/test/resources/goldens/textalk/parses_named_operators/input.math
+++ b/src/test/resources/goldens/textalk/parses_named_operators/input.math
@@ -1,0 +1,1 @@
+a \integer.+ b

--- a/src/test/resources/goldens/textalk/parses_named_operators/phase1-output.math
+++ b/src/test/resources/goldens/textalk/parses_named_operators/phase1-output.math
@@ -1,0 +1,1 @@
+a \integer.+ b

--- a/src/test/resources/goldens/textalk/parses_named_operators/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/parses_named_operators/phase1-structure.txt
@@ -1,0 +1,52 @@
+ExpressionTexTalkNode(
+  children = [
+               OperatorTexTalkNode(
+                 lhs = TextTexTalkNode(
+                   type = TexTalkNodeType.Identifier
+                   tokenType = TexTalkTokenType.Identifier
+                   text = "a"
+                   isVarArg = false
+                 )
+                 command = Command(
+                   parts = [
+                             CommandPart(
+                               name = TextTexTalkNode(
+                                 type = TexTalkNodeType.Identifier
+                                 tokenType = TexTalkTokenType.Identifier
+                                 text = "integer"
+                                 isVarArg = false
+                               )
+                               square = null
+                               subSup = null
+                               groups = [
+                                        ]
+                               paren = null
+                               namedGroups = [
+                                             ]
+                             ),
+                             CommandPart(
+                               name = TextTexTalkNode(
+                                 type = TexTalkNodeType.Identifier
+                                 tokenType = TexTalkTokenType.Operator
+                                 text = "+"
+                                 isVarArg = false
+                               )
+                               square = null
+                               subSup = null
+                               groups = [
+                                        ]
+                               paren = null
+                               namedGroups = [
+                                             ]
+                             )
+                           ]
+                 )
+                 rhs = TextTexTalkNode(
+                   type = TexTalkNodeType.Identifier
+                   tokenType = TexTalkTokenType.Identifier
+                   text = "b"
+                   isVarArg = false
+                 )
+               )
+             ]
+)


### PR DESCRIPTION
Commands can now be of the form
```
a \integer.+ b
```