### PR TITLE
chore: fix dup tests running on GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   test:


### PR DESCRIPTION
Previously, when a pull request was opened the tests would be run
twice on Ubuntu and twice on OS X.
