### PR TITLE
chore!: remove `where:` after `using:`

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/TopLevelGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/TopLevelGroup.kt
@@ -78,10 +78,9 @@ fun <G : Phase2Node, S> validateResultLikeGroup(
     buildGroup: (
         sect: S,
         givenSection: GivenSection?,
-        givenWhereSection: WhereSection?,
+        whereSection: WhereSection?,
         thenSection: ThenSection,
         using: UsingSection?,
-        usingWhere: WhereSection?,
         metadata: MetaDataSection?
     ) -> G
 ): Validation<G> {
@@ -102,7 +101,7 @@ fun <G : Phase2Node, S> validateResultLikeGroup(
     try {
         sectionMap = identifySections(
                 sections, resultLikeName, "given?", "where?", "then",
-                "using?", "where?", "Metadata?"
+                "using?", "Metadata?"
         )
     } catch (e: ParseError) {
         errors.add(ParseError(e.message, e.row, e.column))
@@ -111,10 +110,9 @@ fun <G : Phase2Node, S> validateResultLikeGroup(
 
     val resultLike = sectionMap[resultLikeName]!!
     val given = sectionMap["given"] ?: emptyList()
-    val givenWhere = sectionMap["where"] ?: emptyList()
+    val where = sectionMap["where"] ?: emptyList()
     val then = sectionMap["then"] ?: emptyList()
     val using = sectionMap["using"] ?: emptyList()
-    val usingWhere = sectionMap["where1"] ?: emptyList()
     val metadata = sectionMap["Metadata"] ?: emptyList()
 
     var resultLikeSection: S? = null
@@ -131,11 +129,11 @@ fun <G : Phase2Node, S> validateResultLikeGroup(
         }
     }
 
-    var givenWhereSection: WhereSection? = null
-    if (givenWhere.isNotEmpty()) {
-        when (val givenWhereValidation = validateWhereSection(givenWhere[0], tracker)) {
-            is ValidationSuccess -> givenWhereSection = givenWhereValidation.value
-            is ValidationFailure -> errors.addAll(givenWhereValidation.errors)
+    var whereSection: WhereSection? = null
+    if (where.isNotEmpty()) {
+        when (val whereValidation = validateWhereSection(where[0], tracker)) {
+            is ValidationSuccess -> whereSection = whereValidation.value
+            is ValidationFailure -> errors.addAll(whereValidation.errors)
         }
     }
 
@@ -161,14 +159,6 @@ fun <G : Phase2Node, S> validateResultLikeGroup(
         }
     }
 
-    var usingWhereSection: WhereSection? = null
-    if (usingWhere.isNotEmpty()) {
-        when (val usingWhereValidation = validateWhereSection(usingWhere[0], tracker)) {
-            is ValidationSuccess -> usingWhereSection = usingWhereValidation.value
-            is ValidationFailure -> errors.addAll(usingWhereValidation.errors)
-        }
-    }
-
     return if (errors.isNotEmpty()) {
         validationFailure(errors)
     } else validationSuccess(
@@ -177,10 +167,9 @@ fun <G : Phase2Node, S> validateResultLikeGroup(
             buildGroup(
                 resultLikeSection!!,
                 givenSection,
-                givenWhereSection,
+                whereSection,
                 thenSection!!,
                 usingSection,
-                usingWhereSection,
                 metaDataSection
             ))
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
@@ -40,8 +40,6 @@ import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.sec
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
@@ -60,7 +58,6 @@ data class DefinesGroup(
     val meansSection: MeansSection?,
     val computesSection: ComputesSection?,
     val usingSection: UsingSection?,
-    val whereSection: WhereSection?,
     val writtenSection: WrittenSection?,
     override val metaDataSection: MetaDataSection?
 ) : TopLevelGroup(metaDataSection) {
@@ -80,9 +77,6 @@ data class DefinesGroup(
         if (usingSection != null) {
             fn(usingSection)
         }
-        if (whereSection != null) {
-            fn(whereSection)
-        }
         if (writtenSection != null) {
             fn(writtenSection)
         }
@@ -96,7 +90,6 @@ data class DefinesGroup(
         sections.add(meansSection)
         sections.add(computesSection)
         sections.add(usingSection)
-        sections.add(whereSection)
         sections.add(writtenSection)
         sections.add(metaDataSection)
         return topLevelToCode(
@@ -117,7 +110,6 @@ data class DefinesGroup(
             meansSection = meansSection?.transform(chalkTransformer) as MeansSection?,
             computesSection = computesSection?.transform(chalkTransformer) as ComputesSection?,
             usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
-            whereSection = whereSection?.transform(chalkTransformer) as WhereSection?,
             writtenSection = writtenSection?.transform(chalkTransformer) as WrittenSection?,
             metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?
     )
@@ -266,7 +258,7 @@ private fun validateDefinesGroupImpl(
         sectionMap = identifySections(
             sections,
             "Defines", "when?", "means?", "computes?",
-            "using?", "where?", "written?", "Metadata?"
+            "using?", "written?", "Metadata?"
         )
     } catch (e: ParseError) {
         errors.add(ParseError(e.message, e.row, e.column))
@@ -278,7 +270,6 @@ private fun validateDefinesGroupImpl(
     val means = sectionMap["means"]
     val computes = sectionMap["computes"]
     val using = sectionMap["using"] ?: emptyList()
-    val where = sectionMap["where"] ?: emptyList()
     val written = sectionMap["written"] ?: emptyList()
     val metadata = sectionMap["Metadata"] ?: emptyList()
 
@@ -320,14 +311,6 @@ private fun validateDefinesGroupImpl(
         }
     }
 
-    var whereSection: WhereSection? = null
-    if (where.isNotEmpty()) {
-        when (val whereValidation = validateWhereSection(where[0], tracker)) {
-            is ValidationSuccess -> whereSection = whereValidation.value
-            is ValidationFailure -> errors.addAll(whereValidation.errors)
-        }
-    }
-
     var writtenSection: WrittenSection? = null
     if (written.isNotEmpty()) {
         when (val writtenValidation = validateWrittenSection(written[0], tracker)) {
@@ -366,7 +349,6 @@ private fun validateDefinesGroupImpl(
             meansSection,
             computesSection,
             usingSection,
-            whereSection,
             writtenSection,
             metaDataSection
         )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/represents/RepresentsGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/represents/RepresentsGroup.kt
@@ -43,8 +43,6 @@ import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.Written
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.topLevelToCode
 import mathlingua.common.transform.signature
 import mathlingua.common.support.validationFailure
@@ -57,7 +55,6 @@ data class RepresentsGroup(
     val whenSection: WhenSection?,
     val thatSections: List<ThatSection>,
     val usingSection: UsingSection?,
-    val whereSection: WhereSection?,
     val writtenSection: WrittenSection?,
     override val metaDataSection: MetaDataSection?
 ) : TopLevelGroup(metaDataSection) {
@@ -72,9 +69,6 @@ data class RepresentsGroup(
         if (usingSection != null) {
             fn(usingSection)
         }
-        if (whereSection != null) {
-            fn(whereSection)
-        }
         if (writtenSection != null) {
             fn(writtenSection)
         }
@@ -87,7 +81,6 @@ data class RepresentsGroup(
         val sections = mutableListOf(representsSection, whenSection)
         sections.addAll(thatSections)
         sections.add(usingSection)
-        sections.add(whereSection)
         sections.add(writtenSection)
         sections.add(metaDataSection)
         return topLevelToCode(
@@ -107,7 +100,6 @@ data class RepresentsGroup(
             whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
             thatSections = thatSections.map { chalkTransformer(it) as ThatSection },
             usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
-            whereSection = whereSection?.transform(chalkTransformer) as WhereSection?,
             writtenSection = writtenSection?.transform(chalkTransformer) as WrittenSection?,
             metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?
     )
@@ -164,7 +156,6 @@ fun validateRepresentsGroup(groupNode: Group, tracker: MutableLocationTracker): 
     val whenNode = sectionMap["when"] ?: emptyList()
     val ends = sectionMap["that"]!!
     val using = sectionMap["using"] ?: emptyList()
-    val where = sectionMap["where"] ?: emptyList()
     val written = sectionMap["written"] ?: emptyList()
     val metadata = sectionMap["Metadata"] ?: emptyList()
 
@@ -198,14 +189,6 @@ fun validateRepresentsGroup(groupNode: Group, tracker: MutableLocationTracker): 
         }
     }
 
-    var whereSection: WhereSection? = null
-    if (where.isNotEmpty()) {
-        when (val whereValidation = validateWhereSection(where[0], tracker)) {
-            is ValidationSuccess -> whereSection = whereValidation.value
-            is ValidationFailure -> errors.addAll(whereValidation.errors)
-        }
-    }
-
     var writtenSection: WrittenSection? = null
     if (written.isNotEmpty()) {
         when (val writtenValidation = validateWrittenSection(written[0], tracker)) {
@@ -235,7 +218,6 @@ fun validateRepresentsGroup(groupNode: Group, tracker: MutableLocationTracker): 
             // must be reversed here to be in the correct order
             endSections.reversed(),
             usingSection,
-            whereSection,
             writtenSection,
             metaDataSection
         )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/resultlike/axiom/AxiomGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/resultlike/axiom/AxiomGroup.kt
@@ -34,10 +34,9 @@ import mathlingua.common.chalktalk.phase2.ast.group.toplevel.validateResultLikeG
 data class AxiomGroup(
     val axiomSection: AxiomSection,
     val givenSection: GivenSection?,
-    val givenWhereSection: WhereSection?,
+    val whereSection: WhereSection?,
     val thenSection: ThenSection,
     val usingSection: UsingSection?,
-    val usingWhereSection: WhereSection?,
     override val metaDataSection: MetaDataSection?
 ) : TopLevelGroup(metaDataSection) {
 
@@ -49,13 +48,10 @@ data class AxiomGroup(
         if (givenSection != null) {
             fn(givenSection)
         }
-        if (givenWhereSection != null) {
-            fn(givenWhereSection)
+        if (whereSection != null) {
+            fn(whereSection)
         }
         fn(thenSection)
-        if (usingWhereSection != null) {
-            fn(usingWhereSection)
-        }
         if (metaDataSection != null) {
             fn(metaDataSection)
         }
@@ -63,18 +59,17 @@ data class AxiomGroup(
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
             topLevelToCode(writer, isArg, indent, null, axiomSection,
-                givenSection, givenWhereSection, thenSection,
-                usingSection, usingWhereSection, metaDataSection)
+                givenSection, whereSection, thenSection,
+                usingSection, metaDataSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(
                 AxiomGroup(
                     axiomSection = axiomSection.transform(chalkTransformer) as AxiomSection,
                     givenSection = givenSection?.transform(chalkTransformer) as GivenSection?,
-                    givenWhereSection = givenWhereSection?.transform(chalkTransformer) as WhereSection?,
+                    whereSection = whereSection?.transform(chalkTransformer) as WhereSection?,
                     thenSection = thenSection.transform(chalkTransformer) as ThenSection,
                     usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
-                    usingWhereSection = usingWhereSection?.transform(chalkTransformer) as WhereSection?,
                     metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?
             )
             )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/resultlike/conjecture/ConjectureGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/resultlike/conjecture/ConjectureGroup.kt
@@ -37,7 +37,6 @@ data class ConjectureGroup(
     val givenWhereSection: WhereSection?,
     val thenSection: ThenSection,
     val usingSection: UsingSection?,
-    val usingWhereSection: WhereSection?,
     override val metaDataSection: MetaDataSection?
 ) : TopLevelGroup(metaDataSection) {
 
@@ -53,9 +52,6 @@ data class ConjectureGroup(
             fn(givenWhereSection)
         }
         fn(thenSection)
-        if (usingWhereSection != null) {
-            fn(usingWhereSection)
-        }
         if (metaDataSection != null) {
             fn(metaDataSection)
         }
@@ -64,7 +60,7 @@ data class ConjectureGroup(
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
             topLevelToCode(writer, isArg, indent, null, conjectureSection,
                 givenSection, givenWhereSection, thenSection,
-                usingSection, usingWhereSection, metaDataSection)
+                usingSection, metaDataSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
             chalkTransformer(
@@ -74,7 +70,6 @@ data class ConjectureGroup(
                     givenWhereSection = givenWhereSection?.transform(chalkTransformer) as WhereSection?,
                     thenSection = thenSection.transform(chalkTransformer) as ThenSection,
                     usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
-                    usingWhereSection = usingWhereSection?.transform(chalkTransformer) as WhereSection?,
                     metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?
             )
             )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/resultlike/theorem/TheoremGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/resultlike/theorem/TheoremGroup.kt
@@ -36,7 +36,6 @@ data class TheoremGroup(
     val givenWhereSection: WhereSection?,
     val thenSection: ThenSection,
     val usingSection: UsingSection?,
-    val usingWhereSection: WhereSection?,
     override val metaDataSection: MetaDataSection?
 ) : TopLevelGroup(metaDataSection) {
 
@@ -52,9 +51,6 @@ data class TheoremGroup(
             fn(givenWhereSection)
         }
         fn(thenSection)
-        if (usingWhereSection != null) {
-            fn(usingWhereSection)
-        }
         if (metaDataSection != null) {
             fn(metaDataSection)
         }
@@ -63,7 +59,7 @@ data class TheoremGroup(
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
             topLevelToCode(writer, isArg, indent, null,
                 theoremSection, givenSection, givenWhereSection, thenSection,
-                usingSection, usingWhereSection, metaDataSection)
+                usingSection, metaDataSection)
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(
         TheoremGroup(
@@ -72,7 +68,6 @@ data class TheoremGroup(
             givenWhereSection = givenWhereSection?.transform(chalkTransformer) as WhereSection?,
             thenSection = thenSection.transform(chalkTransformer) as ThenSection,
             usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
-            usingWhereSection = usingWhereSection?.transform(chalkTransformer) as WhereSection?,
             metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?
     )
     )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/shared/UsingSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/shared/UsingSection.kt
@@ -18,31 +18,34 @@ package mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared
 
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
+import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.common.chalktalk.phase2.ast.clause.Target
-import mathlingua.common.chalktalk.phase2.ast.validator.validateTargetList
-import mathlingua.common.chalktalk.phase2.ast.section.appendTargetArgs
+import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 import mathlingua.common.support.MutableLocationTracker
 
-data class UsingSection(val targets: List<Target>) : Phase2Node {
-    override fun forEach(fn: (node: Phase2Node) -> Unit) = targets.forEach(fn)
+data class UsingSection(val clauses: ClauseListNode) : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
         writer.writeHeader("using")
-        appendTargetArgs(writer, targets, indent + 2)
+        if (clauses.clauses.isNotEmpty()) {
+            writer.writeNewline()
+        }
+        writer.append(clauses, true, indent + 2)
         return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
         chalkTransformer(UsingSection(
-            targets = targets.map { it.transform(chalkTransformer) as Target }
+            clauses = clauses.transform(chalkTransformer) as ClauseListNode
         ))
 }
 
-fun validateUsingSection(node: Phase1Node, tracker: MutableLocationTracker) = validateTargetList(
+fun validateUsingSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
     tracker,
     node,
     "using",
+    false,
     ::UsingSection
 )

--- a/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
@@ -490,7 +490,6 @@ internal fun toCanonicalForm(def: DefinesGroup) = DefinesGroup(
                 )
         ),
         usingSection = def.usingSection,
-        whereSection = def.whereSection,
         metaDataSection = def.metaDataSection,
         computesSection = def.computesSection,
         writtenSection = def.writtenSection

--- a/src/test/resources/goldens/chalktalk/handle_varargs_with_defined_length/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handle_varargs_with_defined_length/phase2-structure.txt
@@ -84,7 +84,6 @@ Document(
                )
                computesSection = null
                usingSection = null
-               whereSection = null
                writtenSection = null
                metaDataSection = null
              )

--- a/src/test/resources/goldens/chalktalk/handles_a_single_classification_in_metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles_a_single_classification_in_metadata/phase2-structure.txt
@@ -17,7 +17,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = MetaDataSection(
                  items = [
                            StringSectionGroup(

--- a/src/test/resources/goldens/chalktalk/handles_a_single_tag_in_metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles_a_single_tag_in_metadata/phase2-structure.txt
@@ -17,7 +17,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = MetaDataSection(
                  items = [
                            StringSectionGroup(

--- a/src/test/resources/goldens/chalktalk/handles_defines_with_multi_means/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles_defines_with_multi_means/phase2-structure.txt
@@ -120,7 +120,6 @@ Document(
                )
                computesSection = null
                usingSection = null
-               whereSection = null
                writtenSection = null
                metaDataSection = null
              )

--- a/src/test/resources/goldens/chalktalk/handles_latex_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles_latex_groups/phase2-structure.txt
@@ -19,7 +19,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/handles_multiple_classifications_in_metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles_multiple_classifications_in_metadata/phase2-structure.txt
@@ -17,7 +17,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = MetaDataSection(
                  items = [
                            StringSectionGroup(

--- a/src/test/resources/goldens/chalktalk/handles_multiple_tags_in_metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles_multiple_tags_in_metadata/phase2-structure.txt
@@ -17,7 +17,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = MetaDataSection(
                  items = [
                            StringSectionGroup(

--- a/src/test/resources/goldens/chalktalk/handles_sequence_abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/handles_sequence_abstractions/phase2-structure.txt
@@ -64,7 +64,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_abstractions_with_empty_sub_params_and_empty_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_abstractions_with_empty_sub_params_and_empty_params/phase2-structure.txt
@@ -69,7 +69,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_abstractions_with_empty_sub_params_and_non-empty_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_abstractions_with_empty_sub_params_and_non-empty_params/phase2-structure.txt
@@ -81,7 +81,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_abstractions_with_multiple_sub_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_abstractions_with_multiple_sub_params/phase2-structure.txt
@@ -86,7 +86,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_abstractions_with_multiple_sub_params_and_multiple_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_abstractions_with_multiple_sub_params_and_multiple_params/phase2-structure.txt
@@ -93,7 +93,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_abstractions_with_non-empty_sub_params_and_empty_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_abstractions_with_non-empty_sub_params_and_empty_params/phase2-structure.txt
@@ -81,7 +81,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_abstractions_with_one_sub_param/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_abstractions_with_one_sub_param/phase2-structure.txt
@@ -74,7 +74,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_abstractions_with_one_sub_param_and_multiple_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_abstractions_with_one_sub_param_and_multiple_params/phase2-structure.txt
@@ -87,7 +87,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_collection_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_collection_groups/phase2-structure.txt
@@ -210,7 +210,6 @@ Document(
                  )
                )
                usingSection = null
-               whereSection = null
                writtenSection = null
                metaDataSection = null
              )

--- a/src/test/resources/goldens/chalktalk/parses_enclosed_abstractions_with_sub_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_enclosed_abstractions_with_sub_params/phase2-structure.txt
@@ -74,7 +74,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_enclosed_plain_abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_enclosed_plain_abstractions/phase2-structure.txt
@@ -67,7 +67,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_enclosed_regular_abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_enclosed_regular_abstractions/phase2-structure.txt
@@ -74,7 +74,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_mapping_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_mapping_groups/phase2-structure.txt
@@ -204,7 +204,6 @@ Document(
                  )
                )
                usingSection = null
-               whereSection = null
                writtenSection = null
                metaDataSection = null
              )

--- a/src/test/resources/goldens/chalktalk/parses_multi_var_abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_multi_var_abstractions/phase2-structure.txt
@@ -53,7 +53,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_multiple_arguments_indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_multiple_arguments_indented/phase2-structure.txt
@@ -74,7 +74,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_multiple_arguments_mixed_indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_multiple_arguments_mixed_indented/phase2-structure.txt
@@ -134,7 +134,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_multiple_arguments_single_line/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_multiple_arguments_single_line/phase2-structure.txt
@@ -74,7 +74,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_names_with_.../phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_names_with_.../phase2-structure.txt
@@ -34,7 +34,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_nested_names_with_.../phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_nested_names_with_.../phase2-structure.txt
@@ -41,7 +41,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_operator_identifiers/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_operator_identifiers/phase2-structure.txt
@@ -34,7 +34,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_single_argument_indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_single_argument_indented/phase2-structure.txt
@@ -34,7 +34,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_single_argument_on_same_line/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_single_argument_on_same_line/phase2-structure.txt
@@ -34,7 +34,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_single_var_abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_single_var_abstractions/phase2-structure.txt
@@ -41,7 +41,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/parses_text_elements/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_text_elements/phase2-structure.txt
@@ -53,7 +53,6 @@ Document(
                )
                computesSection = null
                usingSection = null
-               whereSection = null
                writtenSection = null
                metaDataSection = null
              )

--- a/src/test/resources/goldens/chalktalk/parses_text_identifiers/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/parses_text_identifiers/phase2-structure.txt
@@ -34,7 +34,6 @@ Document(
                  )
                )
                usingSection = null
-               usingWhereSection = null
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/messages/Defines_assuming_spelled_wrong/messages.txt
+++ b/src/test/resources/goldens/messages/Defines_assuming_spelled_wrong/messages.txt
@@ -8,7 +8,6 @@ when?:
 means?:
 computes?:
 using?:
-where?:
 written?:
 Metadata?:
 


### PR DESCRIPTION
Now instead of
```
Theorem:
given: x, y
where: 'x, y is \something'
then: 'x + y is \something'
using: +(a, b)
where: 'a + b := a \something.+ b'
```
one instead writes
```
Theorem:
given: x, y
where: 'x, y is \something'
then: 'x + y is \something'
using: 'a + y := a \sometihng.+ b'
```
