### PR TITLE
feat: `Foundation:` group accepts defs as argument

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Clause.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Clause.kt
@@ -43,6 +43,12 @@ import mathlingua.common.chalktalk.phase2.ast.group.clause.not.isNotGroup
 import mathlingua.common.chalktalk.phase2.ast.group.clause.not.validateNotGroup
 import mathlingua.common.chalktalk.phase2.ast.group.clause.or.isOrGroup
 import mathlingua.common.chalktalk.phase2.ast.group.clause.or.validateOrGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.isDefinesGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.validateDefinesGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.isRepresentsGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.validateRepresentsGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.views.isViewsGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.views.validateViewsGroup
 import mathlingua.common.chalktalk.phase2.ast.section.identifySections
 import mathlingua.common.support.MutableLocationTracker
 import mathlingua.common.support.ParseError
@@ -124,7 +130,44 @@ private val CLAUSE_VALIDATORS = listOf(
         ValidationPair(
             ::isMatchingGroup,
             ::validateMatchingGroup
-        )
+        ),
+        ValidationPair(
+            ::isDefinesGroup
+        ) { node, tracker ->
+            if (node is Group) {
+                validateDefinesGroup(node, tracker)
+            } else {
+                validationFailure(listOf(
+                    ParseError("Expected a group", getRow(node), getColumn(node))
+                ))
+            }
+        },
+        ValidationPair(
+            ::isRepresentsGroup
+        ) { node, tracker ->
+            if (node is Group) {
+                validateRepresentsGroup(node, tracker)
+            } else {
+                validationFailure(
+                    listOf(
+                        ParseError("Expected a group", getRow(node), getColumn(node))
+                    )
+                )
+            }
+        },
+        ValidationPair(
+            ::isViewsGroup
+        ) { node, tracker ->
+            if (node is Group) {
+                validateViewsGroup(node, tracker)
+            } else {
+                validationFailure(
+                    listOf(
+                        ParseError("Expected a group", getRow(node), getColumn(node))
+                    )
+                )
+            }
+        }
 )
 
 fun validateClause(rawNode: Phase1Node, tracker: MutableLocationTracker): Validation<Clause> {

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/exists/SuchThatSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/exists/SuchThatSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class SuchThatSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class SuchThatSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateSuchThatSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        AtLeast(1),
         tracker,
         node,
         "suchThat",
-        false,
         ::SuchThatSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/expands/AsSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/expands/AsSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class AsSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class AsSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateAsSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        AtLeast(1),
         tracker,
         node,
         "as",
-        false,
         ::AsSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/if/Else.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/if/Else.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class ElseSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class ElseSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateElseSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+    AtLeast(1),
     tracker,
     node,
     "else",
-    true,
     ::ElseSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/if/ElseIfSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/if/ElseIfSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class ElseIfSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class ElseIfSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateElseIfSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+    AtLeast(1),
     tracker,
     node,
     "elseIf",
-    true,
     ::ElseIfSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/if/IfSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/if/IfSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class IfSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class IfSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateIfSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        AtLeast(1),
         tracker,
         node,
         "if",
-        true,
         ::IfSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/if/ThenSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/if/ThenSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class ThenSection(val clauses: ClauseListNode) : Phase2Node {
@@ -44,9 +45,9 @@ data class ThenSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateThenSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        AtLeast(1),
         tracker,
         node,
         "then",
-        false,
         ::ThenSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/iff/IffSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/iff/IffSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class IffSection(val clauses: ClauseListNode) : Phase2Node {
@@ -44,9 +45,9 @@ data class IffSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateIffSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        AtLeast(1),
         tracker,
         node,
         "iff",
-        true,
         ::IffSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/matching/MatchingSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/matching/MatchingSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class MatchingSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class MatchingSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateMatchingSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+    AtLeast(1),
     tracker,
     node,
     "matching",
-    false,
     ::MatchingSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/not/NotSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/not/NotSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class NotSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class NotSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateNotSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        AtLeast(1),
         tracker,
         node,
         "not",
-        false,
         ::NotSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/or/OrSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/clause/or/OrSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class OrSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class OrSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateOrSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        AtLeast(1),
         tracker,
         node,
         "or",
-        false,
         ::OrSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/defines/ComputesSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/defines/ComputesSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.Exactly
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class ComputesSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class ComputesSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateComputesSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+    Exactly(1),
     tracker,
     node,
     "computes",
-    false,
     ::ComputesSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
@@ -39,6 +39,7 @@ import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.sec
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesRepresentsOrViews
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
@@ -60,7 +61,7 @@ data class DefinesGroup(
     val usingSection: UsingSection?,
     val writtenSection: WrittenSection?,
     override val metaDataSection: MetaDataSection?
-) : TopLevelGroup(metaDataSection) {
+) : TopLevelGroup(metaDataSection), DefinesRepresentsOrViews {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(id)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/defines/MeansSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/defines/MeansSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class MeansSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class MeansSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateMeansSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        AtLeast(1),
         tracker,
         node,
         "means",
-        false,
         ::MeansSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/foundation/FoundationGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/foundation/FoundationGroup.kt
@@ -17,61 +17,26 @@
 package mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation
 
 import mathlingua.common.support.MutableLocationTracker
-import mathlingua.common.support.ParseError
-import mathlingua.common.support.Validation
-import mathlingua.common.support.ValidationFailure
-import mathlingua.common.support.ValidationSuccess
-import mathlingua.common.chalktalk.phase1.ast.ChalkTalkTokenType
 import mathlingua.common.chalktalk.phase1.ast.Group
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
-import mathlingua.common.chalktalk.phase1.ast.Phase1Token
-import mathlingua.common.chalktalk.phase1.ast.Section
-import mathlingua.common.chalktalk.phase1.ast.getColumn
-import mathlingua.common.chalktalk.phase1.ast.getRow
 import mathlingua.common.chalktalk.phase2.CodeWriter
+import mathlingua.common.chalktalk.phase2.ast.clause.Clause
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.common.chalktalk.phase2.ast.clause.AbstractionNode
-import mathlingua.common.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.common.chalktalk.phase2.ast.clause.firstSectionMatchesName
-import mathlingua.common.chalktalk.phase2.ast.clause.validateIdStatement
-import mathlingua.common.chalktalk.phase2.ast.section.*
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.MeansSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.validateMeansSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.common.textalk.Command
-import mathlingua.common.transform.signature
-import mathlingua.common.support.validationFailure
-import mathlingua.common.support.validationSuccess
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.validateSingleSectionMetaDataGroup
+
+interface DefinesRepresentsOrViews : Clause
 
 data class FoundationGroup(
-    val signature: String?,
-    val id: IdStatement,
     val foundationSection: FoundationSection,
-    val whenSection: WhenSection?,
-    val meansSection: MeansSection?,
-    val writtenSection: WrittenSection?,
     override val metaDataSection: MetaDataSection?
 ) : TopLevelGroup(metaDataSection) {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
-        fn(id)
         fn(foundationSection)
-        if (whenSection != null) {
-            fn(whenSection)
-        }
-        if (meansSection != null) {
-            fn(meansSection)
-        }
-        if (writtenSection != null) {
-            fn(writtenSection)
-        }
         if (metaDataSection != null) {
             fn(metaDataSection)
         }
@@ -81,22 +46,14 @@ data class FoundationGroup(
         writer,
         isArg,
         indent,
-        id,
+        null,
         foundationSection,
-        whenSection,
-        meansSection,
-        writtenSection,
         metaDataSection
     )
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(
         FoundationGroup(
-        signature = signature,
-        id = id.transform(chalkTransformer) as IdStatement,
         foundationSection = foundationSection.transform(chalkTransformer) as FoundationSection,
-        whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
-        meansSection = meansSection?.transform(chalkTransformer) as MeansSection?,
-        writtenSection = writtenSection?.transform(chalkTransformer) as WrittenSection?,
         metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?
     )
     )
@@ -104,218 +61,10 @@ data class FoundationGroup(
 
 fun isFoundationGroup(node: Phase1Node) = firstSectionMatchesName(node, "Foundation")
 
-fun validateFoundationGroup(groupNode: Group, tracker: MutableLocationTracker): Validation<FoundationGroup> {
-    val validation = validateFoundationGroupImpl(groupNode, tracker)
-    if (validation is ValidationFailure) {
-        return validation
-    }
-
-    val errors = mutableListOf<ParseError>()
-    val foundationally = (validation as ValidationSuccess).value
-    val idParen = if (foundationally.id.texTalkRoot is ValidationSuccess) {
-        val commandParts = (foundationally.id.texTalkRoot.value.children.find {
-            it is Command
-        } as Command?)?.parts ?: emptyList()
-
-        val partsWithParens = commandParts.filter { it.paren != null }
-        if (partsWithParens.isNotEmpty() && partsWithParens.size != 1) {
-            val location = tracker.getLocationOf(foundationally.id)
-            errors.add(
-                ParseError(
-                    message = "A signature can only contain zero or one set of parens",
-                    row = location?.row ?: -1,
-                    column = location?.column ?: -1
-                )
-            )
-        }
-
-        if (partsWithParens.isEmpty()) {
-            null
-        } else {
-            partsWithParens[0].paren
-        }
-    } else {
-        null
-    }
-
-    if (errors.isNotEmpty()) {
-        return validationFailure(errors)
-    } else if (idParen == null) {
-        return validationSuccess(foundationally)
-    }
-
-    // it is ok for the id to not have a () but the definition to
-    // contain one such as
-    //
-    //   [\function]
-    //   Foundation: f(x)
-    //   means: ...
-
-    // if the targets is empty then `validation` above would have been
-    // a ValidationFailure and the code would not have reached this point
-    val target = foundationally.foundationSection.targets[0]
-    val location = tracker.getLocationOf(target)
-
-    if (target !is AbstractionNode) {
-        errors.add(
-            ParseError(
-                message = "If the signature of a Foundation contains a parens then it must define " +
-                    "a function type with a matching signature in parens",
-                row = location?.row ?: -1,
-                column = location?.column ?: -1
-            )
-        )
-    } else {
-        if (target.abstraction.isVarArgs ||
-            target.abstraction.isEnclosed ||
-            !target.abstraction.subParams.isNullOrEmpty() ||
-            target.abstraction.parts.size != 1) {
-            errors.add(
-                ParseError(
-                    message = "If the signature of a Foundation contains a parens then " +
-                        "the function type it defines cannot describe a sequence like, set like, or variadic form.",
-                    row = location?.row ?: -1,
-                    column = location?.column ?: -1
-                )
-            )
-        } else {
-            val func = target.abstraction.parts[0]
-            val idForm = idParen.toCode().replace(" ", "")
-            val defForm = func.toCode().replace(func.name.text, "").replace(" ", "")
-            if (idForm != defForm) {
-                errors.add(
-                    ParseError(
-                        message = "If the signature of a Foundation contains a parens then " +
-                            "then the defines must define a function like that has the exact same " +
-                            "signature as the parens in the signature of the Foundation.",
-                        row = location?.row ?: -1,
-                        column = location?.column ?: -1
-                    )
-                )
-            }
-        }
-    }
-
-    return if (errors.isEmpty()) {
-        validationSuccess(foundationally)
-    } else {
-        validationFailure(errors)
-    }
-}
-
-private fun validateFoundationGroupImpl(
-    groupNode: Group,
-    tracker: MutableLocationTracker
-): Validation<FoundationGroup> {
-    val errors = ArrayList<ParseError>()
-    val group = groupNode.resolve()
-    var id: IdStatement? = null
-    if (group.id != null) {
-        val (rawText, _, row, column) = group.id
-        // The id token is of type Id and the text is of the form "[...]"
-        // Convert it to look like a statement.
-        val statementText = "'" + rawText.substring(1, rawText.length - 1) + "'"
-        val stmtToken = Phase1Token(
-            statementText, ChalkTalkTokenType.Statement,
-            row, column
-        )
-        when (val idValidation = validateIdStatement(stmtToken, tracker)) {
-            is ValidationSuccess -> id = idValidation.value
-            is ValidationFailure -> errors.addAll(idValidation.errors)
-        }
-    } else {
-        val type = if (group.sections.isNotEmpty()) {
-            group.sections.first().name.text
-        } else {
-            "Defines, Represents, or Foundation"
-        }
-        errors.add(
-            ParseError(
-                "A $type must have an Id",
-                getRow(group), getColumn(group)
-            )
-        )
-    }
-
-    val sections = group.sections
-
-    val sectionMap: Map<String, List<Section>>
-    try {
-        sectionMap = identifySections(
-            sections,
-            "Foundation", "when?", "means?", "written?", "Metadata?"
-        )
-    } catch (e: ParseError) {
-        errors.add(ParseError(e.message, e.row, e.column))
-        return validationFailure(errors)
-    }
-
-    val foundation = sectionMap["Foundation"]!!
-    val whenNode = sectionMap["when"] ?: emptyList()
-    val means = sectionMap["means"]
-    val written = sectionMap["written"] ?: emptyList()
-    val metadata = sectionMap["Metadata"] ?: emptyList()
-
-    var foundationSection: FoundationSection? = null
-    when (val foundationValidation = validateFoundationSection(foundation[0], tracker)) {
-        is ValidationSuccess -> foundationSection = foundationValidation.value
-        is ValidationFailure -> errors.addAll(foundationValidation.errors)
-    }
-
-    var whenSection: WhenSection? = null
-    if (whenNode.isNotEmpty()) {
-        when (val assumingValidation = validateWhenSection(whenNode[0], tracker)) {
-            is ValidationSuccess -> whenSection = assumingValidation.value
-            is ValidationFailure -> errors.addAll(assumingValidation.errors)
-        }
-    }
-
-    var meansSection: MeansSection? = null
-    if (means != null) {
-        when (val endValidation = validateMeansSection(means[0], tracker)) {
-            is ValidationSuccess -> meansSection = endValidation.value
-            is ValidationFailure -> errors.addAll(endValidation.errors)
-        }
-    }
-
-    var writtenSection: WrittenSection? = null
-    if (written.isNotEmpty()) {
-        when (val writtenValidation = validateWrittenSection(written[0], tracker)) {
-            is ValidationSuccess -> writtenSection = writtenValidation.value
-            is ValidationFailure -> errors.addAll(writtenValidation.errors)
-        }
-    }
-
-    var metaDataSection: MetaDataSection? = null
-    if (metadata.isNotEmpty()) {
-        when (val metaDataValidation = validateMetaDataSection(metadata[0], tracker)) {
-            is ValidationSuccess -> metaDataSection = metaDataValidation.value
-            is ValidationFailure -> errors.addAll(metaDataValidation.errors)
-        }
-    }
-
-    if (meansSection == null) {
-        errors.add(
-            ParseError(
-                "A Foundation must have a 'means' section.",
-                getRow(group), getColumn(group)
-            )
-        )
-    }
-
-    return if (errors.isNotEmpty()) {
-        validationFailure(errors)
-    } else validationSuccess(
-        tracker,
-        groupNode,
-        FoundationGroup(
-            id?.signature(),
-            id!!,
-            foundationSection!!,
-            whenSection,
-            meansSection,
-            writtenSection,
-            metaDataSection
-        )
-    )
-}
+fun validateFoundationGroup(groupNode: Group, tracker: MutableLocationTracker) = validateSingleSectionMetaDataGroup(
+    tracker,
+    groupNode,
+    "Foundation",
+    ::validateFoundationSection,
+    ::FoundationGroup
+)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/represents/RepresentsGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/represents/RepresentsGroup.kt
@@ -40,6 +40,7 @@ import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesRepresentsOrViews
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
@@ -57,7 +58,7 @@ data class RepresentsGroup(
     val usingSection: UsingSection?,
     val writtenSection: WrittenSection?,
     override val metaDataSection: MetaDataSection?
-) : TopLevelGroup(metaDataSection) {
+) : TopLevelGroup(metaDataSection), DefinesRepresentsOrViews {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(id)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/represents/ThatSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/represents/ThatSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class ThatSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class ThatSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateThatSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        AtLeast(1),
         tracker,
         node,
         "that",
-        false,
         ::ThatSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/shared/UsingSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/shared/UsingSection.kt
@@ -20,6 +20,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.ZeroOrMore
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 import mathlingua.common.support.MutableLocationTracker
 
@@ -43,9 +44,9 @@ data class UsingSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateUsingSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+    ZeroOrMore(),
     tracker,
     node,
     "using",
-    false,
     ::UsingSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/shared/WhenSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/shared/WhenSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class WhenSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class WhenSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateWhenSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        AtLeast(1),
         tracker,
         node,
         "when",
-        false,
         ::WhenSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/shared/WhereSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/shared/WhereSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class WhereSection(val clauses: ClauseListNode) : Phase2Node {
@@ -45,9 +46,9 @@ data class WhereSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateWhereSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+        AtLeast(1),
         tracker,
         node,
         "where",
-        false,
         ::WhereSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/views/SingleToSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/views/SingleToSection.kt
@@ -21,6 +21,7 @@ import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.validator.Exactly
 import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 
 data class SingleToSection(val clauses: ClauseListNode) : Phase2Node {
@@ -42,9 +43,9 @@ data class SingleToSection(val clauses: ClauseListNode) : Phase2Node {
 }
 
 fun validateSingleToSection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+    Exactly(1),
     tracker,
     node,
     "to",
-    false,
     ::SingleToSection
 )

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/views/ViewsGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/views/ViewsGroup.kt
@@ -37,6 +37,7 @@ import mathlingua.common.chalktalk.phase2.ast.section.*
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesRepresentsOrViews
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.topLevelToCode
@@ -53,7 +54,7 @@ data class ViewsGroup(
     val asSection: SingleAsSection,
     val usingSection: UsingSection?,
     override val metaDataSection: MetaDataSection?
-) : TopLevelGroup(metaDataSection) {
+) : TopLevelGroup(metaDataSection), DefinesRepresentsOrViews {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(id)

--- a/src/test/resources/goldens/messages/Axiom_with_id/messages.txt
+++ b/src/test/resources/goldens/messages/Axiom_with_id/messages.txt
@@ -8,7 +8,7 @@ EndMessage:
 Row: 2
 Column: 1
 Message:
-Section 'then' requires at least one argument.
+Expected at least 1 arguments but found 0
 EndMessage:
 
 

--- a/src/test/resources/goldens/messages/Conjecture_with_id/messages.txt
+++ b/src/test/resources/goldens/messages/Conjecture_with_id/messages.txt
@@ -8,7 +8,5 @@ EndMessage:
 Row: 2
 Column: 1
 Message:
-Section 'then' requires at least one argument.
+Expected at least 1 arguments but found 0
 EndMessage:
-
-

--- a/src/test/resources/goldens/messages/Result_requires_argument/messages.txt
+++ b/src/test/resources/goldens/messages/Result_requires_argument/messages.txt
@@ -1,7 +1,5 @@
 Row: 1
 Column: 1
 Message:
-Section 'then' requires at least one argument.
+Expected at least 1 arguments but found 0
 EndMessage:
-
-

--- a/src/test/resources/goldens/messages/exists_without_such_that_clause/messages.txt
+++ b/src/test/resources/goldens/messages/exists_without_such_that_clause/messages.txt
@@ -1,7 +1,12 @@
 Row: 3
 Column: 3
 Message:
-Section 'suchThat' requires at least one argument.
+Expected at least 1 arguments but found 0
 EndMessage:
 
 
+Row: 1
+Column: 1
+Message:
+Expected at least 1 arguments but found 0
+EndMessage:

--- a/src/test/resources/goldens/messages/exists_without_target/messages.txt
+++ b/src/test/resources/goldens/messages/exists_without_target/messages.txt
@@ -4,4 +4,8 @@ Message:
 Section 'exists' requires at least one argument.
 EndMessage:
 
-
+Row: 1
+Column: 1
+Message:
+Expected at least 1 arguments but found 0
+EndMessage:

--- a/src/test/resources/goldens/messages/for_with_invalid_target/messages.txt
+++ b/src/test/resources/goldens/messages/for_with_invalid_target/messages.txt
@@ -4,4 +4,8 @@ Message:
 Expected an Target
 EndMessage:
 
-
+Row: 1
+Column: 1
+Message:
+Expected at least 1 arguments but found 0
+EndMessage:

--- a/src/test/resources/goldens/messages/for_without_target/messages.txt
+++ b/src/test/resources/goldens/messages/for_without_target/messages.txt
@@ -5,3 +5,8 @@ Section 'for' requires at least one argument.
 EndMessage:
 
 
+Row: 1
+Column: 1
+Message:
+Expected at least 1 arguments but found 0
+EndMessage:

--- a/src/test/resources/goldens/messages/if_without_then_clause/messages.txt
+++ b/src/test/resources/goldens/messages/if_without_then_clause/messages.txt
@@ -1,7 +1,17 @@
+Row: 2
+Column: 3
+Message:
+Expected at least 1 arguments but found 0
+EndMessage:
+
 Row: 3
 Column: 3
 Message:
-Section 'then' requires at least one argument.
+Expected at least 1 arguments but found 0
 EndMessage:
 
-
+Row: 1
+Column: 1
+Message:
+Expected at least 1 arguments but found 0
+EndMessage:

--- a/src/test/resources/goldens/messages/iff_without_then_clause/messages.txt
+++ b/src/test/resources/goldens/messages/iff_without_then_clause/messages.txt
@@ -1,7 +1,19 @@
-Row: 3
+Row: 2
 Column: 3
 Message:
-Section 'then' requires at least one argument.
+Expected at least 1 arguments but found 0
 EndMessage:
 
 
+Row: 3
+Column: 3
+Message:
+Expected at least 1 arguments but found 0
+EndMessage:
+
+
+Row: 1
+Column: 1
+Message:
+Expected at least 1 arguments but found 0
+EndMessage:


### PR DESCRIPTION
The syntax of a `Foundation:` group is:
```
Foundation:
. x
```
where `x` is a `Defines`, `Represents`, or `Views`.
