### PR TITLE
chore!: rename `Represents:` to `States:`

### DIFF
--- a/src/main/kotlin/mathlingua/Main.kt
+++ b/src/main/kotlin/mathlingua/Main.kt
@@ -33,7 +33,7 @@ import mathlingua.common.support.ParseError
 import mathlingua.common.support.ValidationFailure
 import mathlingua.common.support.ValidationSuccess
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.DefinesGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.RepresentsGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.StatesGroup
 import java.io.File
 import java.nio.file.Paths
 import kotlin.system.exitProcess
@@ -173,8 +173,8 @@ private suspend fun runMlg(
                         emptyList()
                     }
 
-                    val represents = if (expand) {
-                        doc.represents()
+                    val states = if (expand) {
+                        doc.states()
                     } else {
                         emptyList()
                     }
@@ -182,7 +182,7 @@ private suspend fun runMlg(
                     outputBuilder.append(MathLingua.prettyPrint(
                             node = doc,
                             defines = defines,
-                            represents = represents,
+                            states = states,
                             html = output.toLowerCase() == "html"))
                 }
             }
@@ -327,9 +327,9 @@ private fun processFile(file: File, allSignatures: MutableSet<String>, defSignat
                 }
             }
 
-            for (rep in document.represents()) {
-                if (rep.signature != null) {
-                    defSignatures.add(rep.signature)
+            for (st in document.states()) {
+                if (st.signature != null) {
+                    defSignatures.add(st.signature)
                 }
             }
             emptyList()
@@ -433,7 +433,7 @@ private class Render : CliktCommand("Generates either HTML or MathLingua code wi
             }
             is ValidationSuccess -> {
                 val defines = mutableListOf<DefinesGroup>()
-                val represents = mutableListOf<RepresentsGroup>()
+                val states = mutableListOf<StatesGroup>()
 
                 val cwd = Paths.get(".").toAbsolutePath().normalize().toFile()
                 val filterItems = (filter ?: "").split(",")
@@ -462,7 +462,7 @@ private class Render : CliktCommand("Generates either HTML or MathLingua code wi
                             val result = MathLingua.parse(it.readText())
                             if (result is ValidationSuccess) {
                                 defines.addAll(result.value.defines())
-                                represents.addAll(result.value.represents())
+                                states.addAll(result.value.states())
                             }
                         }
                     }.toTypedArray())
@@ -471,7 +471,7 @@ private class Render : CliktCommand("Generates either HTML or MathLingua code wi
                 val content = MathLingua.prettyPrint(
                     node = validation.value,
                     defines = defines,
-                    represents = represents,
+                    states = states,
                     html = format == "html"
                 )
 

--- a/src/main/kotlin/mathlingua/common/MathLingua.kt
+++ b/src/main/kotlin/mathlingua/common/MathLingua.kt
@@ -27,7 +27,7 @@ import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resultlike.axiom.AxiomGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resultlike.conjecture.ConjectureGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.DefinesGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.RepresentsGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.StatesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resource.ResourceGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.TheoremGroup
 import mathlingua.common.chalktalk.phase2.ast.validateDocument
@@ -100,7 +100,7 @@ object MathLingua {
 
     private fun getContent(group: TopLevelGroup) =
             when (group) {
-                is RepresentsGroup -> group.copy(
+                is StatesGroup -> group.copy(
                         id = IdStatement(
                                 text = "",
                                 texTalkRoot = validationSuccess(
@@ -200,7 +200,7 @@ object MathLingua {
                         is DefinesGroup -> {
                             group.signature
                         }
-                        is RepresentsGroup -> {
+                        is StatesGroup -> {
                             group.signature
                         }
                         else -> {
@@ -328,7 +328,7 @@ object MathLingua {
                         )
                     }
                 })
-                result.addAll(document.represents().mapNotNull {
+                result.addAll(document.states().mapNotNull {
                     if (it.signature == null) {
                         null
                     } else {
@@ -352,7 +352,7 @@ object MathLingua {
         row: Int,
         column: Int,
         defines: List<DefinesGroup>,
-        represents: List<RepresentsGroup>
+        represents: List<StatesGroup>
     ): Validation<Document> = when (val validation = parseWithLocations(text)) {
         is ValidationFailure -> validationFailure(validation.errors)
         is ValidationSuccess -> {
@@ -368,7 +368,7 @@ object MathLingua {
 
     fun getPatternsToWrittenAs(
         defines: List<DefinesGroup>,
-        represents: List<RepresentsGroup>
+        represents: List<StatesGroup>
     ): Map<OperatorTexTalkNode, String> {
         val result = mutableMapOf<OperatorTexTalkNode, String>()
         for (rep in represents) {
@@ -411,7 +411,7 @@ object MathLingua {
         return result
     }
 
-    fun expandWrittenAs(node: TexTalkNode, defines: List<DefinesGroup>, represents: List<RepresentsGroup>) =
+    fun expandWrittenAs(node: TexTalkNode, defines: List<DefinesGroup>, represents: List<StatesGroup>) =
         expandAsWritten(node, getPatternsToWrittenAs(defines, represents))
 
     fun expandWrittenAs(
@@ -445,7 +445,7 @@ object MathLingua {
         }
         val represents = when (totalTextValidation) {
             is ValidationFailure -> emptyList()
-            is ValidationSuccess -> totalTextValidation.value.represents()
+            is ValidationSuccess -> totalTextValidation.value.states()
         }
 
         val result = StringBuilder()
@@ -471,13 +471,13 @@ object MathLingua {
     fun prettyPrint(
         node: Phase2Node,
         defines: List<DefinesGroup>,
-        represents: List<RepresentsGroup>,
+        states: List<StatesGroup>,
         html: Boolean
     ): String {
         val writer = if (html) {
-            HtmlCodeWriter(defines = defines, represents = represents)
+            HtmlCodeWriter(defines = defines, states = states)
         } else {
-            MathLinguaCodeWriter(defines = defines, represents = represents)
+            MathLinguaCodeWriter(defines = defines, states = states)
         }
         val code = node.toCode(false, 0, writer = writer).getCode()
         return if (html) {

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/Document.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/Document.kt
@@ -33,9 +33,9 @@ import mathlingua.common.chalktalk.phase2.ast.group.toplevel.entry.isEntryGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.entry.validateEntryGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.isFoundationGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.validateFoundationGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.RepresentsGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.isRepresentsGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.validateRepresentsGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.StatesGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.isStatesGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.validateStatesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resource.ResourceGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resource.isResourceGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resource.validateResourceGroup
@@ -57,7 +57,7 @@ data class Document(
 ) : Phase2Node {
 
     fun defines() = groups.filterIsInstance<DefinesGroup>()
-    fun represents() = groups.filterIsInstance<RepresentsGroup>()
+    fun states() = groups.filterIsInstance<StatesGroup>()
     fun theorems() = groups.filterIsInstance<TheoremGroup>()
     fun axioms() = groups.filterIsInstance<AxiomGroup>()
     fun conjectures() = groups.filterIsInstance<ConjectureGroup>()
@@ -127,10 +127,10 @@ fun validateDocument(rawNode: Phase1Node, tracker: MutableLocationTracker): Vali
                     is ValidationFailure -> errors.addAll(definesValidation.errors)
                 }
             }
-            isRepresentsGroup(group) -> {
-                when (val representsValidation = validateRepresentsGroup(group, tracker)) {
-                    is ValidationSuccess -> allGroups.add(representsValidation.value)
-                    is ValidationFailure -> errors.addAll(representsValidation.errors)
+            isStatesGroup(group) -> {
+                when (val statesValidation = validateStatesGroup(group, tracker)) {
+                    is ValidationSuccess -> allGroups.add(statesValidation.value)
+                    is ValidationFailure -> errors.addAll(statesValidation.errors)
                 }
             }
             isFoundationGroup(group) -> {

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Clause.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/clause/Clause.kt
@@ -45,8 +45,8 @@ import mathlingua.common.chalktalk.phase2.ast.group.clause.or.isOrGroup
 import mathlingua.common.chalktalk.phase2.ast.group.clause.or.validateOrGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.isDefinesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.validateDefinesGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.isRepresentsGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.validateRepresentsGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.isStatesGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.validateStatesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.views.isViewsGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.views.validateViewsGroup
 import mathlingua.common.chalktalk.phase2.ast.section.identifySections
@@ -143,10 +143,10 @@ private val CLAUSE_VALIDATORS = listOf(
             }
         },
         ValidationPair(
-            ::isRepresentsGroup
+            ::isStatesGroup
         ) { node, tracker ->
             if (node is Group) {
-                validateRepresentsGroup(node, tracker)
+                validateStatesGroup(node, tracker)
             } else {
                 validationFailure(
                     listOf(

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/common/Phase2Node.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/common/Phase2Node.kt
@@ -26,7 +26,7 @@ interface Phase2Node {
         indent: Int,
         writer: CodeWriter = MathLinguaCodeWriter(
                 defines = emptyList(),
-                represents = emptyList())
+                states = emptyList())
     ): CodeWriter
     fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node): Phase2Node
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
@@ -39,7 +39,7 @@ import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.sec
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesRepresentsOrViews
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
@@ -61,7 +61,7 @@ data class DefinesGroup(
     val usingSection: UsingSection?,
     val writtenSection: WrittenSection?,
     override val metaDataSection: MetaDataSection?
-) : TopLevelGroup(metaDataSection), DefinesRepresentsOrViews {
+) : TopLevelGroup(metaDataSection), DefinesStatesOrViews {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(id)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/foundation/FoundationGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/foundation/FoundationGroup.kt
@@ -28,7 +28,7 @@ import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.topLevelToCode
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.validateSingleSectionMetaDataGroup
 
-interface DefinesRepresentsOrViews : Clause
+interface DefinesStatesOrViews : Clause
 
 data class FoundationGroup(
     val foundationSection: FoundationSection,

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/foundation/FoundationSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/foundation/FoundationSection.kt
@@ -25,7 +25,7 @@ import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
 import java.lang.ClassCastException
 import java.lang.Exception
 
-data class FoundationSection(val content: DefinesRepresentsOrViews) : Phase2Node {
+data class FoundationSection(val content: DefinesStatesOrViews) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(content)
     }
@@ -40,7 +40,7 @@ data class FoundationSection(val content: DefinesRepresentsOrViews) : Phase2Node
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
         chalkTransformer(FoundationSection(
-            content = chalkTransformer(content) as DefinesRepresentsOrViews
+            content = chalkTransformer(content) as DefinesStatesOrViews
         ))
 }
 
@@ -51,7 +51,7 @@ fun validateFoundationSection(node: Phase1Node, tracker: MutableLocationTracker)
     "Foundation"
 ) {
     try {
-        FoundationSection(content = it.clauses[0] as DefinesRepresentsOrViews)
+        FoundationSection(content = it.clauses[0] as DefinesStatesOrViews)
     } catch (e: ClassCastException) {
         throw Exception("Expected a Defines, Represents, or a Views group")
     }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/states/StatesSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/states/StatesSection.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents
+package mathlingua.common.chalktalk.phase2.ast.group.toplevel.states
 
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node
 import mathlingua.common.chalktalk.phase1.ast.Section
@@ -28,24 +28,24 @@ import mathlingua.common.support.Validation
 import mathlingua.common.support.validationFailure
 import mathlingua.common.support.validationSuccess
 
-class RepresentsSection : Phase2Node {
+class StatesSection : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
-        writer.writeHeader("Represents")
+        writer.writeHeader("States")
         return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(this)
 }
 
-fun validateRepresentsSection(node: Phase1Node, tracker: MutableLocationTracker): Validation<RepresentsSection> {
+fun validateStatesSection(node: Phase1Node, tracker: MutableLocationTracker): Validation<StatesSection> {
     val errors = ArrayList<ParseError>()
     if (node !is Section) {
         errors.add(
                 ParseError(
-                        "Expected a RepresentsSection",
+                        "Expected a StatesSection",
                         getRow(node), getColumn(node)
                 )
         )
@@ -55,16 +55,16 @@ fun validateRepresentsSection(node: Phase1Node, tracker: MutableLocationTracker)
     if (sect.args.isNotEmpty()) {
         errors.add(
                 ParseError(
-                        "A Represents cannot have any arguments",
+                        "A States cannot have any arguments",
                         getRow(node), getColumn(node)
                 )
         )
     }
 
-    if (sect.name.text != "Represents") {
+    if (sect.name.text != "States") {
         errors.add(
                 ParseError(
-                        "Expected a section named Represents",
+                        "Expected a section named States",
                         getRow(node), getColumn(node)
                 )
         )
@@ -73,6 +73,6 @@ fun validateRepresentsSection(node: Phase1Node, tracker: MutableLocationTracker)
     return if (errors.isNotEmpty()) {
         validationFailure(errors)
     } else {
-        validationSuccess(tracker, node, RepresentsSection())
+        validationSuccess(tracker, node, StatesSection())
     }
 }

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/states/ThatSection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/states/ThatSection.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents
+package mathlingua.common.chalktalk.phase2.ast.group.toplevel.states
 
 import mathlingua.common.support.MutableLocationTracker
 import mathlingua.common.chalktalk.phase1.ast.Phase1Node

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/views/ViewsGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/views/ViewsGroup.kt
@@ -37,7 +37,7 @@ import mathlingua.common.chalktalk.phase2.ast.section.*
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesRepresentsOrViews
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.topLevelToCode
@@ -54,7 +54,7 @@ data class ViewsGroup(
     val asSection: SingleAsSection,
     val usingSection: UsingSection?,
     override val metaDataSection: MetaDataSection?
-) : TopLevelGroup(metaDataSection), DefinesRepresentsOrViews {
+) : TopLevelGroup(metaDataSection), DefinesStatesOrViews {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(id)

--- a/src/main/kotlin/mathlingua/common/transform/SignatureUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/SignatureUtil.kt
@@ -22,7 +22,7 @@ import mathlingua.common.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.common.chalktalk.phase2.ast.clause.Statement
 import mathlingua.common.chalktalk.phase2.ast.section.TextSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.DefinesGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.RepresentsGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.StatesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.common.support.Location
 import mathlingua.common.support.LocationTracker
@@ -120,7 +120,7 @@ internal fun getMergedCommandSignature(expressionNode: ExpressionTexTalkNode): S
 internal fun getSignature(group: TopLevelGroup): String? {
     return when (group) {
         is DefinesGroup -> group.id.signature()
-        is RepresentsGroup -> group.id.signature()
+        is StatesGroup -> group.id.signature()
         else -> null
     }
 }

--- a/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
+++ b/src/main/kotlin/mathlingua/common/transform/TransformUtil.kt
@@ -30,7 +30,7 @@ import mathlingua.common.chalktalk.phase2.ast.group.clause.`if`.ThenSection
 import mathlingua.common.chalktalk.phase2.ast.group.clause.exists.ExistsGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.DefinesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.MeansSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.RepresentsGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.StatesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.common.textalk.Command
 import mathlingua.common.textalk.ExpressionTexTalkNode
@@ -205,10 +205,10 @@ internal fun moveStatementInlineCommandsToIsNode(
 
 internal fun replaceRepresents(
     root: Phase2Node,
-    represents: List<RepresentsGroup>,
+    represents: List<StatesGroup>,
     target: Phase2Node
 ): RootTarget<Phase2Node, Phase2Node> {
-    val repMap = mutableMapOf<String, RepresentsGroup>()
+    val repMap = mutableMapOf<String, StatesGroup>()
     for (rep in represents) {
         val sig = rep.signature
         if (sig != null) {
@@ -510,7 +510,7 @@ internal fun buildIfThens(def: DefinesGroup) =
             elseSection = null
     )
 
-internal fun buildIfThens(rep: RepresentsGroup) = rep.thatSections.map {
+internal fun buildIfThens(rep: StatesGroup) = rep.thatSections.map {
     IfGroup(
             ifSection = IfSection(
                     clauses = rep.whenSection?.clauses
@@ -542,7 +542,7 @@ internal fun getDefinesIdVars(def: DefinesGroup): List<String> {
     return vars
 }
 
-internal fun getRepresentsIdVars(rep: RepresentsGroup): List<String> {
+internal fun getRepresentsIdVars(rep: StatesGroup): List<String> {
     val vars = mutableListOf<String>()
     if (rep.id.texTalkRoot is ValidationSuccess) {
         vars.addAll(getVars(rep.id.texTalkRoot.value))
@@ -554,7 +554,7 @@ internal fun expandAtNode(
     root: Phase2Node,
     target: Phase2Node,
     defines: List<DefinesGroup>,
-    represents: List<RepresentsGroup>
+    represents: List<StatesGroup>
 ): Phase2Node {
     var transformed = root
     var realTarget = target
@@ -585,7 +585,7 @@ internal fun expandAtNode(
     return transformed
 }
 
-internal fun fullExpandOnce(doc: Document) = expandAtNode(doc, doc, doc.defines(), doc.represents()) as Document
+internal fun fullExpandOnce(doc: Document) = expandAtNode(doc, doc, doc.defines(), doc.states()) as Document
 
 internal fun fullExpandComplete(doc: Document, maxSteps: Int = 10): Document {
     val snapshots = mutableSetOf<String>()

--- a/src/main/kotlin/mathlingua/common/translate/LatexTranslator.kt
+++ b/src/main/kotlin/mathlingua/common/translate/LatexTranslator.kt
@@ -49,25 +49,25 @@ import mathlingua.common.chalktalk.phase2.ast.group.clause.iff.IffSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.MeansSection
 import mathlingua.common.chalktalk.phase2.ast.group.clause.not.NotSection
 import mathlingua.common.chalktalk.phase2.ast.group.clause.or.OrSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.RepresentsSection
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.StatesSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resource.ResourceSection
 import mathlingua.common.chalktalk.phase2.ast.group.clause.exists.SuchThatSection
 import mathlingua.common.chalktalk.phase2.ast.section.TextSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.ThatSection
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.ThatSection
 import mathlingua.common.chalktalk.phase2.ast.group.clause.`if`.ThenSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.TheoremSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resultlike.axiom.AxiomGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resultlike.conjecture.ConjectureGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.defines.DefinesGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.represents.RepresentsGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.StatesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resource.ResourceGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.TheoremGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 
 class LatexTranslator(
     val defines: List<DefinesGroup>,
-    val represents: List<RepresentsGroup>
+    val represents: List<StatesGroup>
 ) {
     val buffer = mutableListOf<String>()
 
@@ -189,7 +189,7 @@ class LatexTranslator(
         }
     }
 
-    fun translate(representsGroup: RepresentsGroup?) {
+    fun translate(representsGroup: StatesGroup?) {
         if (representsGroup != null) {
             append(representsGroup.id.text)
             append("represents")
@@ -209,7 +209,7 @@ class LatexTranslator(
     fun translate(topLevelGroup: TopLevelGroup?) {
         when (topLevelGroup) {
             is DefinesGroup -> translate(topLevelGroup)
-            is RepresentsGroup -> translate(topLevelGroup)
+            is StatesGroup -> translate(topLevelGroup)
             is TheoremGroup -> translate(topLevelGroup)
             is AxiomGroup -> translate(topLevelGroup)
             is ConjectureGroup -> translate(topLevelGroup)
@@ -348,8 +348,8 @@ class LatexTranslator(
         }
     }
 
-    fun translate(representsSection: RepresentsSection?) {
-        if (representsSection != null) {
+    fun translate(statesSection: StatesSection?) {
+        if (statesSection != null) {
             append("represents")
         }
     }

--- a/src/test/kotlin/mathlingua/common/MathLinguaTest.kt
+++ b/src/test/kotlin/mathlingua/common/MathLinguaTest.kt
@@ -264,13 +264,13 @@ internal class MathLinguaTest {
     fun expandWrittenAs() {
         val validation = MathLingua.parse("""
             [\or{a}{b}]
-            Represents:
+            States:
             that: "something"
             written: "a? \text{ or } b?"
         """.trimIndent())
         assertThat(validation is ValidationSuccess)
         val doc = (validation as ValidationSuccess).value
-        val map = MathLingua.getPatternsToWrittenAs(emptyList(), doc.represents())
+        val map = MathLingua.getPatternsToWrittenAs(emptyList(), doc.states())
         val expectedCommand = Command(
             parts = listOf(
                 CommandPart(

--- a/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
@@ -148,7 +148,7 @@ fun main() {
             phase2Tree.expandPath(path)
             phase2Tree.selectionPath = path
 
-            val newDoc = expandAtNode(doc, nearestNode, doc.defines(), doc.represents())
+            val newDoc = expandAtNode(doc, nearestNode, doc.defines(), doc.states())
 
             outputArea.text = newDoc.toCode(false, 0, HtmlCodeWriter(emptyList(), emptyList())).getCode()
             outputTree.model = DefaultTreeModel(
@@ -273,7 +273,7 @@ fun main() {
                     }
 
                     if (replaceReps.isSelected) {
-                        transformed = replaceRepresents(transformed, transformed.represents(), transformed).root as Document
+                        transformed = replaceRepresents(transformed, transformed.states(), transformed).root as Document
                     }
 
                     if (replaceIsNodes.isSelected) {

--- a/src/test/resources/goldens/messages/Represents_without_id/input.math
+++ b/src/test/resources/goldens/messages/Represents_without_id/input.math
@@ -1,2 +1,0 @@
-Represents:
-that: x

--- a/src/test/resources/goldens/messages/States_without_id/input.math
+++ b/src/test/resources/goldens/messages/States_without_id/input.math
@@ -1,0 +1,2 @@
+States:
+that: x

--- a/src/test/resources/goldens/messages/States_without_id/messages.txt
+++ b/src/test/resources/goldens/messages/States_without_id/messages.txt
@@ -1,7 +1,7 @@
 Row: 0
 Column: 0
 Message:
-A Represents must have an Id
+A States must have an Id
 EndMessage:
 
 


### PR DESCRIPTION
The new word `States:` more aligns with the fact that `States:`
items correspond to a `Prop` in other languages such as Coq or
Lean.
