### PR TITLE
feat: support the `mutually:` group

### DIFF
--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/Document.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/Document.kt
@@ -35,7 +35,6 @@ import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundat
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.validateFoundationGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.mutually.isMutuallyGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.mutually.validateMutuallyGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.mutually.validateMutuallySection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.StatesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.isStatesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.validateStatesGroup

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/Document.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/Document.kt
@@ -33,6 +33,9 @@ import mathlingua.common.chalktalk.phase2.ast.group.toplevel.entry.isEntryGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.entry.validateEntryGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.isFoundationGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.validateFoundationGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.mutually.isMutuallyGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.mutually.validateMutuallyGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.mutually.validateMutuallySection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.StatesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.isStatesGroup
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.states.validateStatesGroup
@@ -143,6 +146,12 @@ fun validateDocument(rawNode: Phase1Node, tracker: MutableLocationTracker): Vali
                 when (val viewsValidation = validateViewsGroup(group, tracker)) {
                     is ValidationSuccess -> allGroups.add(viewsValidation.value)
                     is ValidationFailure -> errors.addAll(viewsValidation.errors)
+                }
+            }
+            isMutuallyGroup(group) -> {
+                when (val mutuallyValidation = validateMutuallyGroup(group, tracker)) {
+                    is ValidationSuccess -> allGroups.add(mutuallyValidation.value)
+                    is ValidationFailure -> errors.addAll(mutuallyValidation.errors)
                 }
             }
             isEntryGroup(group) -> {

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/mutually/MutuallyGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/mutually/MutuallyGroup.kt
@@ -20,8 +20,6 @@ import mathlingua.common.chalktalk.phase2.CodeWriter
 import mathlingua.common.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.FoundationSection
-import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.validateFoundationSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.topLevelToCode
 import mathlingua.common.chalktalk.phase2.ast.group.toplevel.validateSingleSectionMetaDataGroup

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/mutually/MutuallyGroup.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/mutually/MutuallyGroup.kt
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.mutually
+
+import mathlingua.common.chalktalk.phase1.ast.Group
+import mathlingua.common.chalktalk.phase1.ast.Phase1Node
+import mathlingua.common.chalktalk.phase2.CodeWriter
+import mathlingua.common.chalktalk.phase2.ast.clause.firstSectionMatchesName
+import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.FoundationSection
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.validateFoundationSection
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.topLevelToCode
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.validateSingleSectionMetaDataGroup
+import mathlingua.common.support.MutableLocationTracker
+
+data class MutuallyGroup(
+    val mutuallySection: MutuallySection,
+    override val metaDataSection: MetaDataSection?
+) : TopLevelGroup(metaDataSection) {
+
+    override fun forEach(fn: (node: Phase2Node) -> Unit) {
+        fn(mutuallySection)
+        if (metaDataSection != null) {
+            fn(metaDataSection)
+        }
+    }
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) = topLevelToCode(
+        writer,
+        isArg,
+        indent,
+        null,
+        mutuallySection,
+        metaDataSection
+    )
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) = chalkTransformer(
+        MutuallyGroup(
+            mutuallySection = mutuallySection.transform(chalkTransformer) as MutuallySection,
+            metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?
+        )
+    )
+}
+
+fun isMutuallyGroup(node: Phase1Node) = firstSectionMatchesName(node, "Mutually")
+
+fun validateMutuallyGroup(groupNode: Group, tracker: MutableLocationTracker) = validateSingleSectionMetaDataGroup(
+    tracker,
+    groupNode,
+    "Mutually",
+    ::validateMutuallySection,
+    ::MutuallyGroup
+)

--- a/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/mutually/MutuallySection.kt
+++ b/src/main/kotlin/mathlingua/common/chalktalk/phase2/ast/group/toplevel/defineslike/mutually/MutuallySection.kt
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.mutually
+
+import mathlingua.common.chalktalk.phase1.ast.Phase1Node
+import mathlingua.common.chalktalk.phase2.CodeWriter
+import mathlingua.common.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.common.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
+import mathlingua.common.chalktalk.phase2.ast.validator.AtLeast
+import mathlingua.common.chalktalk.phase2.ast.validator.validateClauseList
+import mathlingua.common.support.MutableLocationTracker
+
+data class MutuallySection(val items: List<DefinesStatesOrViews>) : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) = items.forEach(fn)
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("Mutually")
+        for (item in items) {
+            writer.writeNewline()
+            writer.append(item, true, indent + 2)
+        }
+        return writer
+    }
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
+        chalkTransformer(MutuallySection(
+            items = items.map { chalkTransformer(it) as DefinesStatesOrViews }
+        ))
+}
+
+fun validateMutuallySection(node: Phase1Node, tracker: MutableLocationTracker) = validateClauseList(
+    AtLeast(1),
+    tracker,
+    node,
+    "Mutually"
+) {
+    val items = mutableListOf<DefinesStatesOrViews>()
+    for (clause in it.clauses) {
+        if (clause is DefinesStatesOrViews) {
+            items.add(clause)
+        } else {
+            throw Exception("Expected a Defines:, States:, or Views:")
+        }
+    }
+
+    MutuallySection(items = items)
+}


### PR DESCRIPTION
The `mutually:` group is used to specify definitions that are
mutually defined.  That is, one could define even and odd
integers at the same time that reference each other.
