### PR TITLE
fix: pretty pring expansion uses foundations

### DIFF
--- a/src/main/kotlin/mathlingua/Main.kt
+++ b/src/main/kotlin/mathlingua/Main.kt
@@ -37,6 +37,8 @@ import java.io.File
 import java.nio.file.Paths
 import kotlin.system.exitProcess
 import kotlinx.coroutines.runBlocking
+import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.FoundationGroup
+import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.mutually.MutuallyGroup
 
 private const val TOOL_VERSION = "0.7"
 private const val MATHLINGUA_VERSION = "0.7"
@@ -178,11 +180,25 @@ private suspend fun runMlg(
                         emptyList()
                     }
 
+                    val foundations = if (expand) {
+                        doc.foundations()
+                    } else {
+                        emptyList()
+                    }
+
+                    val mutuallyGroups = if (expand) {
+                        doc.mutually()
+                    } else {
+                        emptyList()
+                    }
+
                     outputBuilder.append(
                         MathLingua.prettyPrint(
                             node = doc,
                             defines = defines,
                             states = states,
+                            foundations = foundations,
+                            mutuallyGroups = mutuallyGroups,
                             html = output.toLowerCase() == "html"))
                 }
             }
@@ -434,6 +450,8 @@ private class Render : CliktCommand("Generates either HTML or MathLingua code wi
             is ValidationSuccess -> {
                 val defines = mutableListOf<DefinesGroup>()
                 val states = mutableListOf<StatesGroup>()
+                val foundations = mutableListOf<FoundationGroup>()
+                val mutuallyGroups = mutableListOf<MutuallyGroup>()
 
                 val cwd = Paths.get(".").toAbsolutePath().normalize().toFile()
                 val filterItems = (filter ?: "").split(",")
@@ -463,6 +481,8 @@ private class Render : CliktCommand("Generates either HTML or MathLingua code wi
                             if (result is ValidationSuccess) {
                                 defines.addAll(result.value.defines())
                                 states.addAll(result.value.states())
+                                foundations.addAll(result.value.foundations())
+                                mutuallyGroups.addAll(result.value.mutually())
                             }
                         }
                     }.toTypedArray())
@@ -472,6 +492,8 @@ private class Render : CliktCommand("Generates either HTML or MathLingua code wi
                     node = validation.value,
                     defines = defines,
                     states = states,
+                    foundations = foundations,
+                    mutuallyGroups = mutuallyGroups,
                     html = format == "html"
                 )
 

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/Document.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/Document.kt
@@ -34,10 +34,12 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.defines.isDefi
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.defines.validateDefinesGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.evaluates.isEvaluatesGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.evaluates.validateEvaluatesGroup
+import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.FoundationGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.entry.isEntryGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.entry.validateEntryGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.isFoundationGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.validateFoundationGroup
+import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.mutually.MutuallyGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.mutually.isMutuallyGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.mutually.validateMutuallyGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.states.StatesGroup
@@ -65,6 +67,8 @@ data class Document(
 
     fun defines() = groups.filterIsInstance<DefinesGroup>()
     fun states() = groups.filterIsInstance<StatesGroup>()
+    fun foundations() = groups.filterIsInstance<FoundationGroup>()
+    fun mutually() = groups.filterIsInstance<MutuallyGroup>()
     fun theorems() = groups.filterIsInstance<TheoremGroup>()
     fun axioms() = groups.filterIsInstance<AxiomGroup>()
     fun conjectures() = groups.filterIsInstance<ConjectureGroup>()

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/common/Phase2Node.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/common/Phase2Node.kt
@@ -26,7 +26,9 @@ interface Phase2Node {
         indent: Int,
         writer: CodeWriter = MathLinguaCodeWriter(
                 defines = emptyList(),
-                states = emptyList())
+                states = emptyList(),
+                foundations = emptyList(),
+                mutuallyGroups = emptyList())
     ): CodeWriter
     fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node): Phase2Node
 }

--- a/src/main/kotlin/mathlingua/translate/LatexTranslator.kt
+++ b/src/main/kotlin/mathlingua/translate/LatexTranslator.kt
@@ -64,10 +64,14 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.states.StatesG
 import mathlingua.chalktalk.phase2.ast.group.toplevel.resource.ResourceGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.TheoremGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
+import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.FoundationGroup
+import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.mutually.MutuallyGroup
 
 class LatexTranslator(
     val defines: List<DefinesGroup>,
-    val represents: List<StatesGroup>
+    val represents: List<StatesGroup>,
+    val foundations: List<FoundationGroup>,
+    val mutuallyGroups: List<MutuallyGroup>
 ) {
     val buffer = mutableListOf<String>()
 
@@ -112,7 +116,7 @@ class LatexTranslator(
     fun translate(statement: Statement?) {
         if (statement != null) {
             val text = if (statement.texTalkRoot is ValidationSuccess) {
-                MathLingua.expandWrittenAs(statement.texTalkRoot.value, defines, represents).text
+                MathLingua.expandWrittenAs(statement.texTalkRoot.value, defines, represents, foundations, mutuallyGroups).text
             } else {
                 statement.text
             }

--- a/src/test/kotlin/mathlingua/MathLinguaTest.kt
+++ b/src/test/kotlin/mathlingua/MathLinguaTest.kt
@@ -276,7 +276,7 @@ internal class MathLinguaTest {
         """.trimIndent())
         assertThat(validation is ValidationSuccess)
         val doc = (validation as ValidationSuccess).value
-        val map = MathLingua.getPatternsToWrittenAs(emptyList(), doc.states())
+        val map = MathLingua.getPatternsToWrittenAs(emptyList(), doc.states(), emptyList(), emptyList())
         val expectedCommand = Command(
             parts = listOf(
                 CommandPart(

--- a/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
@@ -158,7 +158,7 @@ fun main() {
 
             val newDoc = expandAtNode(doc, nearestNode, doc.defines(), doc.states())
 
-            outputArea.text = newDoc.toCode(false, 0, HtmlCodeWriter(emptyList(), emptyList())).getCode()
+            outputArea.text = newDoc.toCode(false, 0, HtmlCodeWriter(emptyList(), emptyList(), emptyList(), emptyList())).getCode()
             outputTree.model = DefaultTreeModel(
                 toTreeNode(
                     tracker,


### PR DESCRIPTION
When pretty printing code, `Foundation:` and `Mutually:` groups
were not being used to determine how to pretty print commands.
Now they are being used.
