### PR TITLE
fix: address `Foundation:` not parsing

### DIFF
--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/Clause.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/Clause.kt
@@ -153,7 +153,7 @@ fun validateClause(
 
     for (pair in NEO_CLAUSE_VALIDATORS) {
         if (pair.matches(node)) {
-            return pair.validate(rawNode, errors, tracker) as Clause
+            return pair.validate(node, errors, tracker) as Clause
         }
     }
 

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/ClauseListNode.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/ClauseListNode.kt
@@ -62,7 +62,7 @@ fun validateClauseListNode(
                 DEFAULT_CLAUSE_LIST_NODE
             } else {
                 ClauseListNode(
-                    clauses = it.args.map { arg -> validateClause(arg, errors, tracker) })
+                    clauses = it.args.map { arg -> validateClause(arg.resolve(), errors, tracker) })
             }
         }
     }

--- a/src/test/resources/mathlingua.math
+++ b/src/test/resources/mathlingua.math
@@ -91,6 +91,18 @@ Foundation:
   written: "X?"
 
 
+Foundation:
+. [\X]
+  Defines: X
+  where: 'X is \set'
+  collects:
+  . given: x
+    where: 'x'
+    all: 'x'
+    suchThat: 'x'
+  written: "X"
+
+
 Mutually:
 . [\X]
   Defines: X


### PR DESCRIPTION
If a `Foundation:` contained a `Defines:collects:` group then
it was being incorrectly parsed as having an error.  Now it
is parsed correctly.
