### PR TITLE
feat: results support `if:` and `iff:` sections

### DIFF
--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/NeoValidation.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/NeoValidation.kt
@@ -120,6 +120,7 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike.axiom.AxiomGrou
 import mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike.axiom.AxiomSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike.conjecture.ConjectureGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike.conjecture.ConjectureSection
+import mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike.newIfOrIffSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.GivenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.TheoremGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.TheoremSection
@@ -517,6 +518,8 @@ val DEFAULT_THEOREM_SECTION = TheoremSection(names = emptyList())
 
 val DEFAULT_GIVEN_SECTION = GivenSection(targets = listOf())
 
+val DEFAULT_IF_OR_IFF_SECTION = newIfOrIffSection(DEFAULT_IF_SECTION)
+
 val DEFAULT_AXIOM_GROUP =
     AxiomGroup(
         signature = null,
@@ -524,6 +527,7 @@ val DEFAULT_AXIOM_GROUP =
         axiomSection = DEFAULT_AXIOM_SECTION,
         givenSection = DEFAULT_GIVEN_SECTION,
         whereSection = DEFAULT_WHERE_SECTION,
+        ifOrIffSection = DEFAULT_IF_OR_IFF_SECTION,
         thenSection = DEFAULT_THEN_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)
@@ -535,6 +539,7 @@ val DEFAULT_CONJECTURE_GROUP =
         conjectureSection = DEFAULT_CONJECTURE_SECTION,
         givenSection = DEFAULT_GIVEN_SECTION,
         whereSection = DEFAULT_WHERE_SECTION,
+        ifOrIffSection = DEFAULT_IF_OR_IFF_SECTION,
         thenSection = DEFAULT_THEN_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)
@@ -546,6 +551,7 @@ val DEFAULT_THEOREM_GROUP =
         theoremSection = DEFAULT_THEOREM_SECTION,
         givenSection = DEFAULT_GIVEN_SECTION,
         givenWhereSection = DEFAULT_WHERE_SECTION,
+        ifOrIffSection = DEFAULT_IF_OR_IFF_SECTION,
         thenSection = DEFAULT_THEN_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/IfOrIffSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/IfOrIffSection.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike
+
+import mathlingua.chalktalk.phase1.ast.Phase1Node
+import mathlingua.chalktalk.phase1.ast.Section
+import mathlingua.chalktalk.phase1.ast.getColumn
+import mathlingua.chalktalk.phase1.ast.getRow
+import mathlingua.chalktalk.phase2.ast.DEFAULT_IF_OR_IFF_SECTION
+import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.group.clause.If.IfSection
+import mathlingua.chalktalk.phase2.ast.group.clause.If.validateIfSection
+import mathlingua.chalktalk.phase2.ast.group.clause.iff.IffSection
+import mathlingua.chalktalk.phase2.ast.group.clause.iff.validateIffSection
+import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.support.MutableLocationTracker
+import mathlingua.support.ParseError
+
+interface IfOrIffSection {
+    fun isIf(): Boolean
+    fun asIf(): IfSection
+    fun isIff(): Boolean
+    fun asIff(): IffSection
+    fun resolve(): Phase2Node
+    fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node): IfOrIffSection
+}
+
+fun newIfOrIffSection(ifSection: IfSection): IfOrIffSection = IfOrIffSectionImpl(ifSection, null)
+
+fun newIfOrIffSection(iffSection: IffSection): IfOrIffSection = IfOrIffSectionImpl(null, iffSection)
+
+fun validateIfOrIffSection(
+    root: Phase1Node,
+    sections: Map<String, Section>,
+    errors: MutableList<ParseError>,
+    tracker: MutableLocationTracker
+): IfOrIffSection? {
+    val ifSection = neoIfNonNull(sections["if"]) { validateIfSection(it, errors, tracker) }
+    val iffSection = neoIfNonNull(sections["iff"]) { validateIffSection(it, errors, tracker) }
+
+    return if (ifSection == null && iffSection == null) {
+        null
+    } else if (ifSection != null && iffSection != null) {
+        errors.add(
+            ParseError(
+                message = "Either an 'if' or 'iff' section must be specified but not both",
+                row = getRow(root),
+                column = getColumn(root)))
+        DEFAULT_IF_OR_IFF_SECTION
+    } else if (ifSection != null) {
+        newIfOrIffSection(ifSection)
+    } else {
+        newIfOrIffSection(iffSection!!)
+    }
+}
+
+private data class IfOrIffSectionImpl(val ifSection: IfSection?, val iffSection: IffSection?) :
+    IfOrIffSection {
+    init {
+        if ((ifSection == null) == (iffSection == null)) {
+            throw IllegalArgumentException(
+                "Either an 'if' or an 'iff' section must be specified but not both.")
+        }
+    }
+
+    override fun isIf(): Boolean {
+        return ifSection != null
+    }
+
+    override fun asIf(): IfSection {
+        return ifSection!!
+    }
+
+    override fun isIff(): Boolean {
+        return iffSection != null
+    }
+
+    override fun asIff(): IffSection {
+        return iffSection!!
+    }
+
+    override fun resolve(): Phase2Node =
+        if (isIf()) {
+            asIf()
+        } else {
+            asIff()
+        }
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node): IfOrIffSection =
+        if (isIf()) {
+            newIfOrIffSection(asIf())
+        } else {
+            newIfOrIffSection(asIff())
+        }
+}

--- a/src/test/resources/goldens/chalktalk/abstractions/handles_sequence_abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/handles_sequence_abstractions/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_empty_sub_params_and_empty_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_empty_sub_params_and_empty_params/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_empty_sub_params_and_non-empty_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_empty_sub_params_and_non-empty_params/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_multiple_sub_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_multiple_sub_params/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_multiple_sub_params_and_multiple_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_multiple_sub_params_and_multiple_params/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_non-empty_sub_params_and_empty_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_non-empty_sub_params_and_empty_params/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param_and_multiple_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param_and_multiple_params/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_enclosed_abstractions_with_sub_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_enclosed_abstractions_with_sub_params/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_enclosed_plain_abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_enclosed_plain_abstractions/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_enclosed_regular_abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_enclosed_regular_abstractions/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_multi_var_abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_multi_var_abstractions/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_single_var_abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_single_var_abstractions/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/args/parses_multiple_arguments_indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/parses_multiple_arguments_indented/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/args/parses_multiple_arguments_mixed_indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/parses_multiple_arguments_mixed_indented/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/args/parses_multiple_arguments_single_line/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/parses_multiple_arguments_single_line/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/args/parses_single_argument_indented/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/parses_single_argument_indented/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/args/parses_single_argument_on_same_line/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/parses_single_argument_on_same_line/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/identifiers/parses_names_with_.../phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/identifiers/parses_names_with_.../phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/identifiers/parses_nested_names_with_.../phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/identifiers/parses_nested_names_with_.../phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/identifiers/parses_operator_identifiers/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/identifiers/parses_operator_identifiers/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/metadata/handles_a_single_classification_in_metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/metadata/handles_a_single_classification_in_metadata/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/metadata/handles_a_single_tag_in_metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/metadata/handles_a_single_tag_in_metadata/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/metadata/handles_latex/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/metadata/handles_latex/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/metadata/handles_multiple_classifications_in_metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/metadata/handles_multiple_classifications_in_metadata/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/metadata/handles_multiple_tags_in_metadata/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/metadata/handles_multiple_tags_in_metadata/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/text/parses_text_identifiers/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_identifiers/phase2-structure.txt
@@ -9,6 +9,7 @@ Document(
                )
                givenSection = null
                givenWhereSection = null
+               ifOrIffSection = null
                thenSection = ThenSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/mathlingua.math
+++ b/src/test/resources/mathlingua.math
@@ -138,16 +138,46 @@ where: 'x, y is \something'
 then: 'x + y is \something'
 
 
+Theorem:
+if: 'x'
+then: 'y'
+
+
+Theorem:
+iff: 'x'
+then: 'y'
+
+
 Axiom: "some name"
 given: x, y
 where: 'x, y is \something'
 then: 'x + y is \something'
 
 
+Axiom:
+if: 'x'
+then: 'y'
+
+
+Axiom:
+iff: 'x'
+then: 'y'
+
+
 Conjecture: "some name"
 given: x, y
 where: 'x, y is \something'
 then: 'x + y is \something'
+
+
+Conjecture:
+if: 'x'
+then: 'y'
+
+
+Conjecture:
+iff: 'x'
+then: 'y'
 
 
 [some.resource]


### PR DESCRIPTION
Now `Theorem:`, `Axiom:`, and `Conjecture:` support optional
`if:` and `iff:` sections.  Neither is required.  However, if
one of them is specified, then the other cannot be specified.

That is, the following syntax is supported:
```
Theorem:
if: 'x'
then: 'y'
```
and
```
Theorem:
iff: 'x'
then: 'y'
```
