### PR TITLE
chore: address a jacoco error when running tests

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -16,5 +16,10 @@
       <option name="name" value="MavenRepo" />
       <option name="url" value="https://repo.maven.apache.org/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://oss.sonatype.org/content/repositories/snapshots" />
+    </remote-repository>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,12 @@ mainClassName = 'mathlingua.MainKt'
 
 repositories {
     mavenCentral()
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots"
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
 }
 
 dependencies {
@@ -78,7 +84,7 @@ testlogger {
 }
 
 jacoco {
-    toolVersion = '0.8.4'
+    toolVersion = '0.8.7-SNAPSHOT'
 }
 
 spotless {


### PR DESCRIPTION
A stack trace is printed when running tests that is caused by
a problem internal to jacoco.  It will be fixed in version 0.8.7,
which isn't released yet.  Until it is, the SNAPSHOT version will
be used.
