### PR TITLE
chore!: support new operator syntax

### DIFF
--- a/src/main/kotlin/mathlingua/textalk/Ast.kt
+++ b/src/main/kotlin/mathlingua/textalk/Ast.kt
@@ -248,7 +248,7 @@ data class CommandPart(
                     namedGroups.map { it.transform(transformer) as NamedGroupTexTalkNode }))
 }
 
-data class Command(val parts: List<CommandPart>) : TexTalkNode {
+data class Command(val parts: List<CommandPart>, val hasSuffix: Boolean) : TexTalkNode {
 
     override val type: TexTalkNodeType
         get() = TexTalkNodeType.Command
@@ -266,6 +266,9 @@ data class Command(val parts: List<CommandPart>) : TexTalkNode {
             }
             builder.append(parts[i].toCode(interceptor))
         }
+        if (hasSuffix) {
+            builder.append("/")
+        }
         return builder.toString()
     }
 
@@ -274,7 +277,8 @@ data class Command(val parts: List<CommandPart>) : TexTalkNode {
     }
 
     override fun transform(transformer: (texTalkNode: TexTalkNode) -> TexTalkNode) =
-        transformer(Command(parts = parts.map { it.transform(transformer) as CommandPart }))
+        transformer(
+            Command(parts = parts.map { it.transform(transformer) as CommandPart }, hasSuffix))
 }
 
 data class ExpressionTexTalkNode(val children: List<TexTalkNode>) : TexTalkNode {

--- a/src/main/kotlin/mathlingua/textalk/PostProcessing.kt
+++ b/src/main/kotlin/mathlingua/textalk/PostProcessing.kt
@@ -376,7 +376,7 @@ private fun identifyInfixCommandOperators(
                     val lhs = section[0]
                     val cmd = section[1]
                     val rhs = section[2]
-                    if (cmd !is Command) {
+                    if (cmd !is Command || !cmd.hasSuffix) {
                         throw ParseException(
                             ParseError(
                                 message = "Expected an argument but found ${cmd.toCode()}",
@@ -402,7 +402,7 @@ private fun identifyInfixCommandOperators(
                         ParseError(
                             message =
                                 "Multiple infix operators cannot be side by side ('${it.toCode()}').  " +
-                                    "They can only be one of the forms: '\\x \\op \\y', '\\x \\op y', 'x \\op \\y', or 'x \\op y'",
+                                    "They can only be one of the forms: '\\x \\op/ \\y', '\\x \\op/ y', 'x \\op/ \\y', or 'x \\op/ y'",
                             row = -1,
                             column = -1))
                 }

--- a/src/main/kotlin/mathlingua/transform/CommandUtil.kt
+++ b/src/main/kotlin/mathlingua/transform/CommandUtil.kt
@@ -280,7 +280,7 @@ internal fun glueCommands(commands: List<Command>): List<Command> {
         val parts = mutableListOf<CommandPart>()
         parts.addAll(cmd.parts)
         parts.addAll(last.parts)
-        newCommands.add(Command(parts = parts))
+        newCommands.add(Command(parts = parts, false))
     }
     return newCommands
 }

--- a/src/main/kotlin/mathlingua/transform/SignatureUtil.kt
+++ b/src/main/kotlin/mathlingua/transform/SignatureUtil.kt
@@ -114,7 +114,7 @@ internal fun getMergedCommandSignature(expressionNode: ExpressionTexTalkNode): S
     }
 
     if (commandParts.isNotEmpty()) {
-        return Command(parts = commandParts).signature()
+        return Command(parts = commandParts, false).signature()
     }
 
     return null

--- a/src/test/kotlin/mathlingua/MathLinguaTest.kt
+++ b/src/test/kotlin/mathlingua/MathLinguaTest.kt
@@ -392,7 +392,8 @@ internal class MathLinguaTest {
                                                                         isVarArg = false))))),
                                         isVarArg = false)),
                             paren = null,
-                            namedGroups = emptyList())))
+                            namedGroups = emptyList())),
+                false)
         val expected =
             mapOf(
                 OperatorTexTalkNode(lhs = null, command = expectedCommand, rhs = null) to

--- a/src/test/kotlin/mathlingua/transform/MatcherKtTest.kt
+++ b/src/test/kotlin/mathlingua/transform/MatcherKtTest.kt
@@ -57,12 +57,12 @@ class MatcherKtTest {
             mapOf(
                 OperatorTexTalkNode(
                     lhs = buildText("A"),
-                    command = buildCommand("\\set.in"),
-                    rhs = buildText("B")) to "A? \\in B?")
-        val node = buildNode("X \\set.in Y")
+                    command = buildCommand("\\set.in/"),
+                    rhs = buildText("B")) to "A? \\in/ B?")
+        val node = buildNode("X \\set.in/ Y")
         val expanded = expandAsWritten(node, patternToExpansion)
         assertThat(expanded.errors).isEmpty()
-        assertThat(expanded.text).isEqualTo("X \\in Y")
+        assertThat(expanded.text).isEqualTo("X \\in/ Y")
     }
 
     @Test
@@ -71,12 +71,12 @@ class MatcherKtTest {
             mapOf(
                 OperatorTexTalkNode(
                     lhs = buildText("A"),
-                    command = buildCommand("\\set.in{T}"),
-                    rhs = buildText("B")) to "A? \\in B? (with respect to T?)")
-        val node = buildNode("X \\set.in{Z} Y")
+                    command = buildCommand("\\set.in{T}/"),
+                    rhs = buildText("B")) to "A? \\in/ B? (with respect to T?)")
+        val node = buildNode("X \\set.in{Z}/ Y")
         val expanded = expandAsWritten(node, patternToExpansion)
         assertThat(expanded.errors).isEmpty()
-        assertThat(expanded.text).isEqualTo("X \\in Y (with respect to Z)")
+        assertThat(expanded.text).isEqualTo("X \\in/ Y (with respect to Z)")
     }
 
     @Test

--- a/src/test/kotlin/mathlingua/transform/SignatureUtilKtTest.kt
+++ b/src/test/kotlin/mathlingua/transform/SignatureUtilKtTest.kt
@@ -57,8 +57,8 @@ internal class SignatureUtilKtTest {
                     ParseError(
                         message =
                             "Multiple infix operators cannot be side by side ('\\abc \\xyz{x}').  They " +
-                                "can only be one of the forms: '\\x \\op \\y', '\\x \\op y', 'x \\op \\y', " +
-                                "or 'x \\op y'",
+                                "can only be one of the forms: '\\x \\op/ \\y', '\\x \\op/ y', 'x \\op/ \\y', " +
+                                "or 'x \\op/ y'",
                         row = -1,
                         column = -1)))
     }
@@ -67,7 +67,7 @@ internal class SignatureUtilKtTest {
     fun findAllStatementSignaturesInfixTest() {
         val validation =
             MathLingua.parse(
-                "[x \\abc y]\nDefines: y\nwhere: 'something'\nmeans: 'something'\n" +
+                "[x \\abc/ y]\nDefines: y\nwhere: 'something'\nmeans: 'something'\n" +
                     "written: \"something\"")
         val doc = (validation as ValidationSuccess).value
         val defines = doc.defines()

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-structure.txt
@@ -43,6 +43,7 @@ Document(
                                                               ]
                                               )
                                             ]
+                                    hasSuffix = false
                                   )
                                 ]
                    )
@@ -117,6 +118,7 @@ Document(
                                                                                                            ]
                                                                                            )
                                                                                          ]
+                                                                                 hasSuffix = false
                                                                                )
                                                                              ]
                                                                 )

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-structure.txt
@@ -25,6 +25,7 @@ Document(
                                                               ]
                                               )
                                             ]
+                                    hasSuffix = false
                                   )
                                 ]
                    )
@@ -99,6 +100,7 @@ Document(
                                                                                                            ]
                                                                                            )
                                                                                          ]
+                                                                                 hasSuffix = false
                                                                                )
                                                                              ]
                                                                 )
@@ -184,6 +186,7 @@ Document(
                                                                                                                ]
                                                                                                )
                                                                                              ]
+                                                                                     hasSuffix = false
                                                                                    )
                                                                                  ]
                                                                     )

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
@@ -42,6 +42,7 @@ Document(
                                                               ]
                                               )
                                             ]
+                                    hasSuffix = false
                                   )
                                 ]
                    )
@@ -123,6 +124,7 @@ Document(
                                                                                                            ]
                                                                                            )
                                                                                          ]
+                                                                                 hasSuffix = false
                                                                                )
                                                                              ]
                                                                 )

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-structure.txt
@@ -86,6 +86,7 @@ Document(
                                                                                                            ]
                                                                                            )
                                                                                          ]
+                                                                                 hasSuffix = false
                                                                                )
                                                                              ]
                                                                 )

--- a/src/test/resources/goldens/textalk/commands/parses_commands_with_a_single_bare_sub_param/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_commands_with_a_single_bare_sub_param/phase1-structure.txt
@@ -55,6 +55,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_commands_with_a_single_bare_sub_param_and_a_single_bare_sup_param/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_commands_with_a_single_bare_sub_param_and_a_single_bare_sup_param/phase1-structure.txt
@@ -72,6 +72,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_commands_with_a_single_bare_sup_param/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_commands_with_a_single_bare_sup_param/phase1-structure.txt
@@ -55,6 +55,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_()/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_()/phase1-structure.txt
@@ -35,6 +35,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]/phase1-structure.txt
@@ -35,6 +35,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_multi_args/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_multi_args/phase1-structure.txt
@@ -55,6 +55,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_multi_args_and_sub-sup/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_multi_args_and_sub-sup/phase1-structure.txt
@@ -92,6 +92,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_multi_args_and_sub-sup_and_()/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_multi_args_and_sub-sup_and_()/phase1-structure.txt
@@ -109,6 +109,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_multi_args_and_sub-sup_and_()_and_multi_args/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_multi_args_and_sub-sup_and_()_and_multi_args/phase1-structure.txt
@@ -129,6 +129,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_multi_args_and_sub-sup_and_{}/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_multi_args_and_sub-sup_and_{}/phase1-structure.txt
@@ -110,6 +110,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_{}/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_{}/phase1-structure.txt
@@ -53,6 +53,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_{}_and_multi_args/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_[]_and_{}_and_multi_args/phase1-structure.txt
@@ -93,6 +93,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_{}/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_{}/phase1-structure.txt
@@ -36,6 +36,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_{}_and_multi_args/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/commands/parses_single_name_command_with_{}_and_multi_args/phase1-structure.txt
@@ -56,6 +56,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/expressions/parses_expressions/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/expressions/parses_expressions/phase1-structure.txt
@@ -76,6 +76,7 @@ ExpressionTexTalkNode(
                                                  ]
                                  )
                                ]
+                       hasSuffix = false
                      )
                    )
                    command = TextTexTalkNode(
@@ -138,6 +139,7 @@ ExpressionTexTalkNode(
                                                ]
                                )
                              ]
+                     hasSuffix = false
                    )
                  )
                )

--- a/src/test/resources/goldens/textalk/is/parses_is_statements_with_commands/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/is/parses_is_statements_with_commands/phase1-structure.txt
@@ -37,6 +37,7 @@ ExpressionTexTalkNode(
                                                                         ]
                                                         )
                                                       ]
+                                              hasSuffix = false
                                             )
                                           ]
                              )

--- a/src/test/resources/goldens/textalk/is/parses_is_statements_with_multi_commands/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/is/parses_is_statements_with_multi_commands/phase1-structure.txt
@@ -37,6 +37,7 @@ ExpressionTexTalkNode(
                                                                         ]
                                                         )
                                                       ]
+                                              hasSuffix = false
                                             ),
                                             Command(
                                               parts = [
@@ -56,6 +57,7 @@ ExpressionTexTalkNode(
                                                                         ]
                                                         )
                                                       ]
+                                              hasSuffix = false
                                             ),
                                             Command(
                                               parts = [
@@ -75,6 +77,7 @@ ExpressionTexTalkNode(
                                                                         ]
                                                         )
                                                       ]
+                                              hasSuffix = false
                                             )
                                           ]
                              )

--- a/src/test/resources/goldens/textalk/names/parses_complex_compound_name/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/names/parses_complex_compound_name/phase1-structure.txt
@@ -197,6 +197,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/names/parses_compound_name_command/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/names/parses_compound_name_command/phase1-structure.txt
@@ -48,6 +48,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/names/parses_single_name_command/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/names/parses_single_name_command/phase1-structure.txt
@@ -18,6 +18,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/goldens/textalk/operators/parses_named_operators/input.math
+++ b/src/test/resources/goldens/textalk/operators/parses_named_operators/input.math
@@ -1,1 +1,1 @@
-a \integer.+ b
+a \integer.+/ b

--- a/src/test/resources/goldens/textalk/operators/parses_named_operators/phase1-output.math
+++ b/src/test/resources/goldens/textalk/operators/parses_named_operators/phase1-output.math
@@ -1,1 +1,1 @@
-a \integer.+ b
+a \integer.+/ b

--- a/src/test/resources/goldens/textalk/operators/parses_named_operators/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/operators/parses_named_operators/phase1-structure.txt
@@ -40,6 +40,7 @@ ExpressionTexTalkNode(
                                              ]
                              )
                            ]
+                   hasSuffix = true
                  )
                  rhs = TextTexTalkNode(
                    type = TexTalkNodeType.Identifier

--- a/src/test/resources/goldens/textalk/varargs/handles_varargs_in_groups/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/varargs/handles_varargs_in_groups/phase1-structure.txt
@@ -54,6 +54,7 @@ ExpressionTexTalkNode(
                                            ]
                            )
                          ]
+                 hasSuffix = false
                )
              ]
 )

--- a/src/test/resources/mathlingua.math
+++ b/src/test/resources/mathlingua.math
@@ -21,7 +21,7 @@ written: "\textrm{some.function}(x?)"
 Defines: Z := (X, +)
 instantiated:
 . 'X := \set'
-. 'x + y := x \integer.+ y'
+. 'x + y := x \integer.+/ y'
 written: "\mathbb{Z}"
 
 
@@ -126,10 +126,10 @@ as: 'X'
 [x + y]
 Evaluates:
 when: 'x, y is \natural'
-then: 'x + y := x \natural.+ y'
+then: 'x + y := x \natural.+/ y'
 when: 'x, y is \real'
-then: 'x + y := x \real.+ y'
-else: 'x + y := x \complex.+ y'
+then: 'x + y := x \real.+/ y'
+else: 'x + y := x \complex.+/ y'
 
 
 Theorem: "some name"


### PR DESCRIPTION
Now operators are specified with a trailing `/`.  That is,
```
x \plus/ y
```
