### PR TITLE
chore: remove `neo` from function names

### DIFF
--- a/src/main/kotlin/mathlingua/chalktalk/phase1/ChalkTalkParser.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase1/ChalkTalkParser.kt
@@ -48,9 +48,7 @@ private val INVALID = Phase1Token("INVALID", ChalkTalkTokenType.Invalid, -1, -1)
 private class ChalkTalkParserImpl : ChalkTalkParser {
     override fun parse(chalkTalkLexer: ChalkTalkLexer): ChalkTalkParseResult {
         val worker = ParserWorker(chalkTalkLexer)
-        val errors = worker.errors
-        val root: Root? = worker.root()
-        return ChalkTalkParseResult(root, errors)
+        return ChalkTalkParseResult(worker.root(), worker.errors)
     }
 }
 

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/Validation.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/Validation.kt
@@ -142,9 +142,7 @@ import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
 import mathlingua.support.validationFailure
 
-fun <T : Phase2Node> neoTrack(
-    node: Phase1Node, tracker: MutableLocationTracker, builder: () -> T
-): T {
+fun <T : Phase2Node> track(node: Phase1Node, tracker: MutableLocationTracker, builder: () -> T): T {
     val phase2Node = builder()
     tracker.setLocationOf(phase2Node, Location(row = getRow(node), column = getColumn(node)))
     return phase2Node
@@ -261,7 +259,7 @@ fun <T> validateTargetSection(
         }
     }
 
-fun neoGetOptionalId(
+fun getOptionalId(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ): IdStatement? {
     val group = node.resolve()
@@ -277,13 +275,13 @@ fun neoGetOptionalId(
     }
 }
 
-fun neoGetId(
+fun getId(
     node: Phase1Node,
     errors: MutableList<ParseError>,
     default: IdStatement,
     tracker: MutableLocationTracker
 ): IdStatement {
-    val id = neoGetOptionalId(node, errors, tracker)
+    val id = getOptionalId(node, errors, tracker)
     return if (id != null) {
         id
     } else {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/AbstractionNode.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/AbstractionNode.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase1.ast.Abstraction
 import mathlingua.chalktalk.phase1.ast.Phase1Node
 import mathlingua.chalktalk.phase2.ast.DEFAULT_ABSTRACTION
 import mathlingua.chalktalk.phase2.ast.common.ZeroPartNode
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateByTransform
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -32,7 +32,7 @@ fun isAbstraction(node: Phase1Node) = node is Abstraction
 fun validateAbstractionNode(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateByTransform(
             node = node.resolve(),
             errors = errors,

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/AssignmentNode.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/AssignmentNode.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase1.ast.Assignment
 import mathlingua.chalktalk.phase1.ast.Phase1Node
 import mathlingua.chalktalk.phase2.ast.DEFAULT_ASSIGNMENT
 import mathlingua.chalktalk.phase2.ast.common.ZeroPartNode
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateByTransform
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -32,7 +32,7 @@ fun isAssignment(node: Phase1Node) = node is Assignment
 fun validateAssignmentNode(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateByTransform(
             node = node.resolve(),
             errors = errors,

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/Clause.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/Clause.kt
@@ -18,7 +18,6 @@ package mathlingua.chalktalk.phase2.ast.clause
 
 import mathlingua.chalktalk.phase1.ast.Group
 import mathlingua.chalktalk.phase1.ast.Phase1Node
-import mathlingua.chalktalk.phase1.ast.Section
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.clause.If.isIfGroup
@@ -61,7 +60,6 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.views.isViewsG
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.views.validateViewsGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
-import mathlingua.support.Validation
 
 interface Clause : Phase2Node
 
@@ -108,50 +106,45 @@ fun toCode(
     return writer
 }
 
-data class Validator(
-    val name: String,
-    val optional: Boolean,
-    val validate: (section: Section, tracker: MutableLocationTracker) -> Validation<Phase2Node>)
-
-private data class NeoValidationPair<T>(
+private data class ValidationPair<T>(
     val matches: (node: Phase1Node) -> Boolean,
     val validate:
         (node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker) -> T)
 
-private val NEO_CLAUSE_VALIDATORS =
+private val CLAUSE_VALIDATORS =
     listOf(
-        NeoValidationPair<Clause>(::isAbstraction, ::validateAbstractionNode),
-        NeoValidationPair(::isTuple, ::validateTupleNode),
-        NeoValidationPair(::isAssignment, ::validateAssignmentNode),
-        NeoValidationPair(::isIdentifier, ::validateIdentifier),
-        NeoValidationPair(::isStatement, ::validateStatement),
-        NeoValidationPair(::isText, ::validateText),
-        NeoValidationPair(::isForGroup, ::validateForGroup),
-        NeoValidationPair(::isExistsGroup, ::validateExistsGroup),
-        NeoValidationPair(::isNotGroup, ::validateNotGroup),
-        NeoValidationPair(::isOrGroup, ::validateOrGroup),
-        NeoValidationPair(::isAndGroup, ::validateAndGroup),
-        NeoValidationPair(::isIfGroup, ::validateIfGroup),
-        NeoValidationPair(::isIffGroup, ::validateIffGroup),
-        NeoValidationPair(::isExpandsGroup, ::validateExpandsGroup),
-        NeoValidationPair(::isMappingGroup, ::validateMappingGroup),
-        NeoValidationPair(::isCollectionGroup, ::validateCollectionGroup),
-        NeoValidationPair(::isMatchingGroup, ::validateMatchingGroup),
-        NeoValidationPair(::isConstantGroup, ::validateConstantGroup),
-        NeoValidationPair(::isConstructorGroup, ::validateConstructorGroup),
-        NeoValidationPair(::isInductivelyGroup, ::validateInductivelyGroup),
-        NeoValidationPair(::isPiecewiseGroup, ::validatePiecewiseGroup),
-        NeoValidationPair(::isEvaluatesGroup, ::validateEvaluatesGroup),
-        NeoValidationPair(::isDefinesGroup, ::validateDefinesGroup),
-        NeoValidationPair(::isStatesGroup, ::validateStatesGroup),
-        NeoValidationPair(::isViewsGroup, ::validateViewsGroup))
+        ValidationPair<Clause>(::isAbstraction, ::validateAbstractionNode),
+        ValidationPair(::isTuple, ::validateTupleNode),
+        ValidationPair(::isAssignment, ::validateAssignmentNode),
+        ValidationPair(::isIdentifier, ::validateIdentifier),
+        ValidationPair(::isStatement, ::validateStatement),
+        ValidationPair(::isText, ::validateText),
+        ValidationPair(::isForGroup, ::validateForGroup),
+        ValidationPair(::isExistsGroup, ::validateExistsGroup),
+        ValidationPair(::isNotGroup, ::validateNotGroup),
+        ValidationPair(::isOrGroup, ::validateOrGroup),
+        ValidationPair(::isAndGroup, ::validateAndGroup),
+        ValidationPair(::isIfGroup, ::validateIfGroup),
+        ValidationPair(::isIffGroup, ::validateIffGroup),
+        ValidationPair(::isExpandsGroup, ::validateExpandsGroup),
+        ValidationPair(::isMappingGroup, ::validateMappingGroup),
+        ValidationPair(::isCollectionGroup, ::validateCollectionGroup),
+        ValidationPair(::isMatchingGroup, ::validateMatchingGroup),
+        ValidationPair(::isConstantGroup, ::validateConstantGroup),
+        ValidationPair(::isConstructorGroup, ::validateConstructorGroup),
+        ValidationPair(::isInductivelyGroup, ::validateInductivelyGroup),
+        ValidationPair(::isPiecewiseGroup, ::validatePiecewiseGroup),
+        ValidationPair(::isEvaluatesGroup, ::validateEvaluatesGroup),
+        ValidationPair(::isDefinesGroup, ::validateDefinesGroup),
+        ValidationPair(::isStatesGroup, ::validateStatesGroup),
+        ValidationPair(::isViewsGroup, ::validateViewsGroup))
 
 fun validateClause(
     rawNode: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ): Clause {
     val node = rawNode.resolve()
 
-    for (pair in NEO_CLAUSE_VALIDATORS) {
+    for (pair in CLAUSE_VALIDATORS) {
         if (pair.matches(node)) {
             return pair.validate(node, errors, tracker) as Clause
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/ClauseListNode.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/ClauseListNode.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase1.ast.getRow
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_CLAUSE_LIST_NODE
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -51,7 +51,7 @@ data class ClauseListNode(val clauses: List<Clause>) : Phase2Node {
 fun validateClauseListNode(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, DEFAULT_CLAUSE_LIST_NODE) {
             if (it.args.isEmpty()) {
                 errors.add(

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/IdStatement.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/IdStatement.kt
@@ -19,7 +19,7 @@ package mathlingua.chalktalk.phase2.ast.clause
 import mathlingua.chalktalk.phase1.ast.Phase1Node
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
 import mathlingua.support.Validation
@@ -44,7 +44,7 @@ data class IdStatement(val text: String, val texTalkRoot: Validation<ExpressionT
 fun validateIdStatement(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         val statement = validateStatement(node.resolve(), errors, tracker)
         IdStatement(text = statement.text, texTalkRoot = statement.texTalkRoot)
     }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/Identifier.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/Identifier.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase1.ast.Phase1Token
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_IDENTIFIER
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateByTransform
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -45,7 +45,7 @@ fun isIdentifier(node: Phase1Node) = node is Phase1Token && node.type === ChalkT
 fun validateIdentifier(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateByTransform(
             node = node.resolve(),
             errors = errors,

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/MappingNode.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/MappingNode.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase1.ast.Mapping
 import mathlingua.chalktalk.phase1.ast.Phase1Node
 import mathlingua.chalktalk.phase2.ast.DEFAULT_MAPPING_NODE
 import mathlingua.chalktalk.phase2.ast.common.ZeroPartNode
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateByTransform
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -29,10 +29,10 @@ data class MappingNode(val mapping: Mapping) : ZeroPartNode(mapping)
 
 fun isMapping(node: Phase1Node) = node is Mapping
 
-fun neoMappingNode(
+fun validateMappingNode(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateByTransform(
             node = node.resolve(),
             errors = errors,

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/Statement.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/Statement.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase1.ast.Phase1Token
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_STATEMENT
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateByTransform
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -53,7 +53,7 @@ fun isStatement(node: Phase1Node) =
 fun validateStatement(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateByTransform(
             node = node.resolve(),
             errors = errors,

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/Text.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/Text.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase1.ast.Phase1Token
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_TEXT
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateByTransform
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -45,7 +45,7 @@ fun isText(node: Phase1Node) = node is Phase1Token && node.type === ChalkTalkTok
 fun validateText(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateByTransform(
             node = node.resolve(),
             errors = errors,

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/TupleNode.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/clause/TupleNode.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase1.ast.Phase1Node
 import mathlingua.chalktalk.phase1.ast.Tuple
 import mathlingua.chalktalk.phase2.ast.DEFAULT_TUPLE
 import mathlingua.chalktalk.phase2.ast.common.ZeroPartNode
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateByTransform
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -32,7 +32,7 @@ fun isTuple(node: Phase1Node) = node is Tuple
 fun validateTupleNode(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateByTransform(
             node = node.resolve(),
             errors = errors,

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/If/Else.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/If/Else.kt
@@ -23,7 +23,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_ELSE_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -51,7 +51,7 @@ fun isElseSection(sec: Section) = sec.name.text == "else"
 fun validateElseSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "else", DEFAULT_ELSE_SECTION) {
             ElseSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/If/IfGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/If/IfGroup.kt
@@ -24,9 +24,9 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_THEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Clause
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -55,16 +55,16 @@ fun isIfGroup(node: Phase1Node) = firstSectionMatchesName(node, "if")
 fun validateIfGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "if", DEFAULT_IF_GROUP) { group ->
-            neoIdentifySections(group, errors, DEFAULT_IF_GROUP, listOf("if", "then")) { sections ->
+            identifySections(group, errors, DEFAULT_IF_GROUP, listOf("if", "then")) { sections ->
                 IfGroup(
                     ifSection =
-                        neoEnsureNonNull(sections["if"], DEFAULT_IF_SECTION) {
+                        ensureNonNull(sections["if"], DEFAULT_IF_SECTION) {
                             validateIfSection(it, errors, tracker)
                         },
                     thenSection =
-                        neoEnsureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
+                        ensureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
                             validateThenSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/If/IfSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/If/IfSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_IF_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -47,7 +47,7 @@ data class IfSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateIfSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "if", DEFAULT_IF_SECTION) {
             IfSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/If/ThenSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/If/ThenSection.kt
@@ -23,7 +23,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_THEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -51,7 +51,7 @@ fun isThenSection(sec: Section) = sec.name.text == "then"
 fun validateThenSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "then", DEFAULT_THEN_SECTION) {
             ThenSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/and/AndGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/and/AndGroup.kt
@@ -22,9 +22,9 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_AND_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Clause
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.OnePartNode
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -37,12 +37,12 @@ fun isAndGroup(node: Phase1Node) = firstSectionMatchesName(node, "and")
 fun validateAndGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "and", DEFAULT_AND_GROUP) { group ->
-            neoIdentifySections(group, errors, DEFAULT_AND_GROUP, listOf("and")) { sections ->
+            identifySections(group, errors, DEFAULT_AND_GROUP, listOf("and")) { sections ->
                 AndGroup(
                     andSection =
-                        neoEnsureNonNull(sections["and"], DEFAULT_AND_SECTION) {
+                        ensureNonNull(sections["and"], DEFAULT_AND_SECTION) {
                             validateAndSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/and/AndSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/and/AndSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_AND_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -48,7 +48,7 @@ data class AndSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateAndSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "and", DEFAULT_AND_SECTION) {
             AndSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/collection/CollectionGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/collection/CollectionGroup.kt
@@ -30,10 +30,10 @@ import mathlingua.chalktalk.phase2.ast.group.clause.forAll.ForAllSection
 import mathlingua.chalktalk.phase2.ast.group.clause.forAll.validateForSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -82,30 +82,30 @@ fun isCollectionGroup(node: Phase1Node) = firstSectionMatchesName(node, "collect
 fun validateCollectionGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "collection", DEFAULT_COLLECTION_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group,
                 errors,
                 DEFAULT_COLLECTION_GROUP,
                 listOf("collection", "of", "in?", "forAll", "where")) { sections ->
                 CollectionGroup(
                     collectionSection =
-                        neoEnsureNonNull(sections["collection"], DEFAULT_COLLECTION_SECTION) {
+                        ensureNonNull(sections["collection"], DEFAULT_COLLECTION_SECTION) {
                             validateCollectionSection(it, errors, tracker)
                         },
                     ofSection =
-                        neoEnsureNonNull(sections["of"], DEFAULT_OF_SECTION) {
+                        ensureNonNull(sections["of"], DEFAULT_OF_SECTION) {
                             validateOfSection(it, errors, tracker)
                         },
                     inSection =
-                        neoIfNonNull(sections["in"]) { validateInSection(it, errors, tracker) },
+                        ifNonNull(sections["in"]) { validateInSection(it, errors, tracker) },
                     forAllSection =
-                        neoEnsureNonNull(sections["forAll"], DEFAULT_FOR_ALL_SECTION) {
+                        ensureNonNull(sections["forAll"], DEFAULT_FOR_ALL_SECTION) {
                             validateForSection(it, errors, tracker)
                         },
                     whereSection =
-                        neoEnsureNonNull(sections["where"], DEFAULT_WHERE_SECTION) {
+                        ensureNonNull(sections["where"], DEFAULT_WHERE_SECTION) {
                             validateWhereSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/collection/CollectionSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/collection/CollectionSection.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase1.ast.Phase1Node
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_COLLECTION_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -41,7 +41,7 @@ class CollectionSection : Phase2Node {
 fun validateCollectionSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "collection", DEFAULT_COLLECTION_SECTION) {
             CollectionSection()
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/collection/InSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/collection/InSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_IN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Statement
 import mathlingua.chalktalk.phase2.ast.clause.validateStatement
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -47,7 +47,7 @@ data class InSection(val statement: Statement) : Phase2Node {
 fun validateInSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "in", DEFAULT_IN_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_IN_SECTION, "statement") {
                 InSection(statement = validateStatement(it, errors, tracker))

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/collection/OfSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/collection/OfSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_OF_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Statement
 import mathlingua.chalktalk.phase2.ast.clause.validateStatement
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -47,7 +47,7 @@ data class OfSection(val statement: Statement) : Phase2Node {
 fun validateOfSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "of", DEFAULT_OF_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_OF_SECTION, "statement") {
                 OfSection(statement = validateStatement(it, errors, tracker))

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/exists/ExistsGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/exists/ExistsGroup.kt
@@ -25,10 +25,10 @@ import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.ThreePartNode
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -47,22 +47,20 @@ fun isExistsGroup(node: Phase1Node) = firstSectionMatchesName(node, "exists")
 fun validateExistsGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "exists", DEFAULT_EXISTS_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group, errors, DEFAULT_EXISTS_GROUP, listOf("exists", "where?", "suchThat")) {
             sections ->
                 ExistsGroup(
                     existsSection =
-                        neoEnsureNonNull(sections["exists"], DEFAULT_EXISTS_SECTION) {
+                        ensureNonNull(sections["exists"], DEFAULT_EXISTS_SECTION) {
                             validateExistsSection(it, errors, tracker)
                         },
                     whereSection =
-                        neoIfNonNull(sections["where"]) {
-                            validateWhereSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     suchThatSection =
-                        neoEnsureNonNull(sections["suchThat"], DEFAULT_SUCH_THAT_SECTION) {
+                        ensureNonNull(sections["suchThat"], DEFAULT_SUCH_THAT_SECTION) {
                             validateSuchThatSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/exists/ExistsSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/exists/ExistsSection.kt
@@ -21,8 +21,8 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_EXISTS_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Target
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
 import mathlingua.chalktalk.phase2.ast.section.appendTargetArgs
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateTargetSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -46,7 +46,7 @@ data class ExistsSection(val identifiers: List<Target>) : Phase2Node {
 fun validateExistsSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateTargetSection(
             node.resolve(), errors, "exists", DEFAULT_EXISTS_SECTION, tracker, ::ExistsSection)
     }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/exists/SuchThatSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/exists/SuchThatSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_SUCH_THAT_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -48,7 +48,7 @@ data class SuchThatSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateSuchThatSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "suchThat", DEFAULT_SUCH_THAT_SECTION) {
             SuchThatSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/expands/AsSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/expands/AsSection.kt
@@ -23,7 +23,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_AS_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -50,7 +50,7 @@ fun isAsSection(sec: Section) = sec.name.text == "as"
 fun validateAsSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "as", DEFAULT_AS_SECTION) {
             AsSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/expands/ExpandsGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/expands/ExpandsGroup.kt
@@ -22,9 +22,9 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_EXPANDS_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Clause
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.TwoPartNode
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -37,17 +37,17 @@ fun isExpandsGroup(node: Phase1Node) = firstSectionMatchesName(node, "expands")
 fun validateExpandsGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "expands", DEFAULT_AS_SECTION) { group ->
-            neoIdentifySections(group, errors, DEFAULT_AS_SECTION, listOf("expands", "as")) {
+            identifySections(group, errors, DEFAULT_AS_SECTION, listOf("expands", "as")) {
             sections ->
                 ExpandsGroup(
                     expandsSection =
-                        neoEnsureNonNull(sections["expands"], DEFAULT_EXPANDS_SECTION) {
+                        ensureNonNull(sections["expands"], DEFAULT_EXPANDS_SECTION) {
                             validateExpandsSection(it, errors, tracker)
                         },
                     asSection =
-                        neoEnsureNonNull(sections["as"], DEFAULT_AS_SECTION) {
+                        ensureNonNull(sections["as"], DEFAULT_AS_SECTION) {
                             validateAsSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/expands/ExpandsSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/expands/ExpandsSection.kt
@@ -24,8 +24,8 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_EXPANDS_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.AbstractionNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
 import mathlingua.chalktalk.phase2.ast.section.appendTargetArgs
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -60,7 +60,7 @@ private fun isValidAbstraction(abstraction: Abstraction) =
 fun validateExpandsSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node, errors, "expands", DEFAULT_EXPANDS_SECTION) { section ->
             if (section.args.isEmpty() ||
                 section.args.any {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/forAll/ForAllGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/forAll/ForAllGroup.kt
@@ -29,10 +29,10 @@ import mathlingua.chalktalk.phase2.ast.group.clause.exists.SuchThatSection
 import mathlingua.chalktalk.phase2.ast.group.clause.exists.validateSuchThatSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -52,28 +52,26 @@ fun isForGroup(node: Phase1Node) = firstSectionMatchesName(node, "forAll")
 fun validateForGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "forAll", DEFAULT_FOR_ALL_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group,
                 errors,
                 DEFAULT_FOR_ALL_GROUP,
                 listOf("forAll", "where?", "suchThat?", "then")) { sections ->
                 ForAllGroup(
                     forAllSection =
-                        neoEnsureNonNull(sections["forAll"], DEFAULT_FOR_ALL_SECTION) {
+                        ensureNonNull(sections["forAll"], DEFAULT_FOR_ALL_SECTION) {
                             validateForSection(it, errors, tracker)
                         },
                     whereSection =
-                        neoIfNonNull(sections["where"]) {
-                            validateWhereSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     suchThatSection =
-                        neoIfNonNull(sections["suchThat"]) {
+                        ifNonNull(sections["suchThat"]) {
                             validateSuchThatSection(it, errors, tracker)
                         },
                     thenSection =
-                        neoEnsureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
+                        ensureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
                             validateThenSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/forAll/ForAllSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/forAll/ForAllSection.kt
@@ -21,8 +21,8 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_FOR_ALL_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Target
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
 import mathlingua.chalktalk.phase2.ast.section.appendTargetArgs
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateTargetSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -45,7 +45,7 @@ data class ForAllSection(val targets: List<Target>) : Phase2Node {
 fun validateForSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateTargetSection(
             node.resolve(), errors, "forAll", DEFAULT_FOR_ALL_SECTION, tracker, ::ForAllSection)
     }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/from/FromGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/from/FromGroup.kt
@@ -28,9 +28,9 @@ import mathlingua.chalktalk.phase2.ast.group.clause.mapping.FromSection
 import mathlingua.chalktalk.phase2.ast.group.clause.mapping.ToSection
 import mathlingua.chalktalk.phase2.ast.group.clause.mapping.validateFromSection
 import mathlingua.chalktalk.phase2.ast.group.clause.mapping.validateToSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -56,17 +56,16 @@ fun isFromGroup(node: Phase1Node) = firstSectionMatchesName(node, "from")
 fun validateFromGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "from", DEFAULT_FROM_GROUP) { group ->
-            neoIdentifySections(group, errors, DEFAULT_FROM_GROUP, listOf("from", "to")) {
-            sections ->
+            identifySections(group, errors, DEFAULT_FROM_GROUP, listOf("from", "to")) { sections ->
                 FromGroup(
                     fromSection =
-                        neoEnsureNonNull(sections["from"], DEFAULT_FROM_SECTION) {
+                        ensureNonNull(sections["from"], DEFAULT_FROM_SECTION) {
                             validateFromSection(it, errors, tracker)
                         },
                     toSection =
-                        neoEnsureNonNull(sections["to"], DEFAULT_TO_SECTION) {
+                        ensureNonNull(sections["to"], DEFAULT_TO_SECTION) {
                             validateToSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/given/AllSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/given/AllSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_ALL_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Statement
 import mathlingua.chalktalk.phase2.ast.clause.validateStatement
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -47,7 +47,7 @@ data class AllSection(val statement: Statement) : Phase2Node {
 fun validateAllSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "all", DEFAULT_ALL_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_ALL_SECTION, "statement") {
                 AllSection(statement = validateStatement(it, errors, tracker))

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/given/GivenGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/given/GivenGroup.kt
@@ -30,10 +30,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.GivenSe
 import mathlingua.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.validateGivenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -53,26 +53,26 @@ fun isGivenGroup(node: Phase1Node) = firstSectionMatchesName(node, "given")
 fun validateGivenGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "given", DEFAULT_GIVEN_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group, errors, DEFAULT_GIVEN_GROUP, listOf("given", "where", "all", "suchThat?")) {
             sections ->
                 GivenGroup(
                     givenSection =
-                        neoEnsureNonNull(sections["given"], DEFAULT_GIVEN_SECTION) {
+                        ensureNonNull(sections["given"], DEFAULT_GIVEN_SECTION) {
                             validateGivenSection(it, errors, tracker)
                         },
                     whereSection =
-                        neoEnsureNonNull(sections["where"], DEFAULT_WHERE_SECTION) {
+                        ensureNonNull(sections["where"], DEFAULT_WHERE_SECTION) {
                             validateWhereSection(it, errors, tracker)
                         },
                     allSection =
-                        neoEnsureNonNull(sections["all"], DEFAULT_ALL_SECTION) {
+                        ensureNonNull(sections["all"], DEFAULT_ALL_SECTION) {
                             validateAllSection(it, errors, tracker)
                         },
                     suchThatSection =
-                        neoIfNonNull(sections["suchThat"]) {
+                        ifNonNull(sections["suchThat"]) {
                             validateSuchThatSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/iff/IffGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/iff/IffGroup.kt
@@ -25,9 +25,9 @@ import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.TwoPartNode
 import mathlingua.chalktalk.phase2.ast.group.clause.If.ThenSection
 import mathlingua.chalktalk.phase2.ast.group.clause.If.validateThenSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -40,17 +40,16 @@ fun isIffGroup(node: Phase1Node) = firstSectionMatchesName(node, "iff")
 fun validateIffGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "iff", DEFAULT_IFF_GROUP) { group ->
-            neoIdentifySections(group, errors, DEFAULT_IFF_GROUP, listOf("iff", "then")) {
-            sections ->
+            identifySections(group, errors, DEFAULT_IFF_GROUP, listOf("iff", "then")) { sections ->
                 IffGroup(
                     iffSection =
-                        neoEnsureNonNull(sections["iff"], DEFAULT_IFF_SECTION) {
+                        ensureNonNull(sections["iff"], DEFAULT_IFF_SECTION) {
                             validateIffSection(it, errors, tracker)
                         },
                     thenSection =
-                        neoEnsureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
+                        ensureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
                             validateThenSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/iff/IffSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/iff/IffSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_IFF_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -48,7 +48,7 @@ data class IffSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateIffSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "iff", DEFAULT_IFF_SECTION) {
             IffSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/ConstantGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/ConstantGroup.kt
@@ -20,9 +20,9 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_CONSTANT_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Clause
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.OnePartNode
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -35,13 +35,13 @@ fun isConstantGroup(node: Phase1Node) = firstSectionMatchesName(node, "constant"
 fun validateConstantGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "constant", DEFAULT_CONSTANT_GROUP) { group ->
-            neoIdentifySections(group, errors, DEFAULT_CONSTANT_GROUP, listOf("constant")) {
+            identifySections(group, errors, DEFAULT_CONSTANT_GROUP, listOf("constant")) {
             sections ->
                 ConstantGroup(
                     constantSection =
-                        neoEnsureNonNull(sections["constant"], DEFAULT_CONSTANT_SECTION) {
+                        ensureNonNull(sections["constant"], DEFAULT_CONSTANT_SECTION) {
                             validateConstantSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/ConstantSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/ConstantSection.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_CONSTANT_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -46,7 +46,7 @@ data class ConstantSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateConstantSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "constant", DEFAULT_CONSTANT_SECTION) {
             ConstantSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/ConstructorGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/ConstructorGroup.kt
@@ -23,9 +23,9 @@ import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.TwoPartNode
 import mathlingua.chalktalk.phase2.ast.group.clause.mapping.FromSection
 import mathlingua.chalktalk.phase2.ast.group.clause.mapping.validateFromSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -42,18 +42,18 @@ fun isConstructorGroup(node: Phase1Node) = firstSectionMatchesName(node, "constr
 fun validateConstructorGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "constructor", DEFAULT_CONSTRUCTOR_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group, errors, DEFAULT_CONSTRUCTOR_GROUP, listOf("constructor", "from")) {
             sections ->
                 ConstructorGroup(
                     constructorSection =
-                        neoEnsureNonNull(sections["constructor"], DEFAULT_CONSTRUCTOR_SECTION) {
+                        ensureNonNull(sections["constructor"], DEFAULT_CONSTRUCTOR_SECTION) {
                             validateConstructorSection(it, errors, tracker)
                         },
                     fromSection =
-                        neoEnsureNonNull(sections["from"], DEFAULT_FROM_SECTION) {
+                        ensureNonNull(sections["from"], DEFAULT_FROM_SECTION) {
                             validateFromSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/ConstructorSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/ConstructorSection.kt
@@ -19,8 +19,8 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_CONSTRUCTOR_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Target
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
 import mathlingua.chalktalk.phase2.ast.section.appendTargetArgs
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateTargetSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -43,7 +43,7 @@ data class ConstructorSection(val targets: List<Target>) : Phase2Node {
 fun validateConstructorSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateTargetSection(
             node.resolve(),
             errors,

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/InductivelyFromSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/InductivelyFromSection.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_INDUCTIVELY_FROM_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -46,7 +46,7 @@ data class InductivelyFromSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateInductivelyFromSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "from", DEFAULT_INDUCTIVELY_FROM_SECTION) {
             InductivelyFromSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/InductivelyGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/InductivelyGroup.kt
@@ -21,9 +21,9 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_INDUCTIVELY_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Clause
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.TwoPartNode
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -40,18 +40,18 @@ fun isInductivelyGroup(node: Phase1Node) = firstSectionMatchesName(node, "induct
 fun validateInductivelyGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "inductively", DEFAULT_INDUCTIVELY_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group, errors, DEFAULT_INDUCTIVELY_GROUP, listOf("inductively", "from")) {
             sections ->
                 InductivelyGroup(
                     inductivelySection =
-                        neoEnsureNonNull(sections["inductively"], DEFAULT_INDUCTIVELY_SECTION) {
+                        ensureNonNull(sections["inductively"], DEFAULT_INDUCTIVELY_SECTION) {
                             validateInductivelySection(it, errors, tracker)
                         },
                     fromSection =
-                        neoEnsureNonNull(sections["from"], DEFAULT_INDUCTIVELY_FROM_SECTION) {
+                        ensureNonNull(sections["from"], DEFAULT_INDUCTIVELY_FROM_SECTION) {
                             validateInductivelyFromSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/InductivelySection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/inductively/InductivelySection.kt
@@ -18,7 +18,7 @@ import mathlingua.chalktalk.phase1.ast.Phase1Node
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_INDUCTIVELY_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -39,7 +39,7 @@ class InductivelySection : Phase2Node {
 fun validateInductivelySection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "inductively", DEFAULT_INDUCTIVELY_SECTION) {
             InductivelySection()
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/mapping/FromSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/mapping/FromSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_FROM_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Statement
 import mathlingua.chalktalk.phase2.ast.clause.validateStatement
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -54,7 +54,7 @@ data class FromSection(val statements: List<Statement>) : Phase2Node {
 fun validateFromSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "from", DEFAULT_FROM_SECTION) {
             FromSection(statements = it.args.map { arg -> validateStatement(arg, errors, tracker) })
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/mapping/MappingGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/mapping/MappingGroup.kt
@@ -28,9 +28,9 @@ import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.clause.expands.AsSection
 import mathlingua.chalktalk.phase2.ast.group.clause.expands.validateAsSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -66,26 +66,26 @@ fun isMappingGroup(node: Phase1Node) = firstSectionMatchesName(node, "mapping")
 fun validateMappingGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "mapping", DEFAULT_MAPPING_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group, errors, DEFAULT_MAPPING_GROUP, listOf("mapping", "from", "to", "as")) {
             sections ->
                 MappingGroup(
                     mappingSection =
-                        neoEnsureNonNull(sections["mapping"], DEFAULT_MAPPING_SECTION) {
+                        ensureNonNull(sections["mapping"], DEFAULT_MAPPING_SECTION) {
                             validateMappingSection(it, errors, tracker)
                         },
                     fromSection =
-                        neoEnsureNonNull(sections["from"], DEFAULT_FROM_SECTION) {
+                        ensureNonNull(sections["from"], DEFAULT_FROM_SECTION) {
                             validateFromSection(it, errors, tracker)
                         },
                     thenSection =
-                        neoEnsureNonNull(sections["to"], DEFAULT_TO_SECTION) {
+                        ensureNonNull(sections["to"], DEFAULT_TO_SECTION) {
                             validateToSection(it, errors, tracker)
                         },
                     asSection =
-                        neoEnsureNonNull(sections["as"], DEFAULT_AS_SECTION) {
+                        ensureNonNull(sections["as"], DEFAULT_AS_SECTION) {
                             validateAsSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/mapping/MappingSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/mapping/MappingSection.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase1.ast.Phase1Node
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_MAPPING_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -41,7 +41,7 @@ class MappingSection : Phase2Node {
 fun validateMappingSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "mapping", DEFAULT_MAPPING_SECTION) {
             MappingSection()
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/mapping/ToSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/mapping/ToSection.kt
@@ -23,7 +23,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_TO_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Statement
 import mathlingua.chalktalk.phase2.ast.clause.validateStatement
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -57,7 +57,7 @@ fun isToSection(sec: Section) = sec.name.text == "to"
 fun validateToSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "to", DEFAULT_TO_SECTION) {
             ToSection(statements = it.args.map { arg -> validateStatement(arg, errors, tracker) })
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/matching/MatchingGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/matching/MatchingGroup.kt
@@ -22,9 +22,9 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_MATCHING_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Clause
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.OnePartNode
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -37,13 +37,13 @@ fun isMatchingGroup(node: Phase1Node) = firstSectionMatchesName(node, "matching"
 fun validateMatchingGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "matching", DEFAULT_MATCHING_GROUP) { group ->
-            neoIdentifySections(group, errors, DEFAULT_MATCHING_GROUP, listOf("matching")) {
+            identifySections(group, errors, DEFAULT_MATCHING_GROUP, listOf("matching")) {
             sections ->
                 MatchingGroup(
                     matchingSection =
-                        neoEnsureNonNull(sections["matching"], DEFAULT_MATCHING_SECTION) {
+                        ensureNonNull(sections["matching"], DEFAULT_MATCHING_SECTION) {
                             validateMatchingSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/matching/MatchingSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/matching/MatchingSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_MATCHING_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -48,7 +48,7 @@ data class MatchingSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateMatchingSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "matching", DEFAULT_MATCHING_SECTION) {
             MatchingSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/not/NotGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/not/NotGroup.kt
@@ -22,9 +22,9 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_NOT_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Clause
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.OnePartNode
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -37,12 +37,12 @@ fun isNotGroup(node: Phase1Node) = firstSectionMatchesName(node, "not")
 fun validateNotGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "not", DEFAULT_NOT_GROUP) { group ->
-            neoIdentifySections(group, errors, DEFAULT_NOT_GROUP, listOf("not")) { sections ->
+            identifySections(group, errors, DEFAULT_NOT_GROUP, listOf("not")) { sections ->
                 NotGroup(
                     notSection =
-                        neoEnsureNonNull(sections["not"], DEFAULT_NOT_SECTION) {
+                        ensureNonNull(sections["not"], DEFAULT_NOT_SECTION) {
                             validateNotSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/not/NotSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/not/NotSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_NOT_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -48,7 +48,7 @@ data class NotSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateNotSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "not", DEFAULT_NOT_SECTION) {
             NotSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/or/OrGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/or/OrGroup.kt
@@ -22,9 +22,9 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_OR_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Clause
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.OnePartNode
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -36,12 +36,12 @@ fun isOrGroup(node: Phase1Node) = firstSectionMatchesName(node, "or")
 fun validateOrGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "or", DEFAULT_OR_GROUP) { group ->
-            neoIdentifySections(group, errors, DEFAULT_OR_GROUP, listOf("or")) { sections ->
+            identifySections(group, errors, DEFAULT_OR_GROUP, listOf("or")) { sections ->
                 OrGroup(
                     orSection =
-                        neoEnsureNonNull(sections["or"], DEFAULT_OR_SECTION) {
+                        ensureNonNull(sections["or"], DEFAULT_OR_SECTION) {
                             validateOrSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/or/OrSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/or/OrSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_OR_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -47,7 +47,7 @@ data class OrSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateOrSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "or", DEFAULT_OR_SECTION) {
             OrSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/piecewise/PiecewiseGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/piecewise/PiecewiseGroup.kt
@@ -33,7 +33,7 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.isWhenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -83,7 +83,7 @@ fun isPiecewiseGroup(node: Phase1Node) = firstSectionMatchesName(node, "piecewis
 fun validatePiecewiseGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "piecewise", DEFAULT_PIECEWISE_GROUP) { group ->
             if (group.sections.isEmpty() || !isPiecewiseSection(group.sections.first())) {
                 errors.add(

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/piecewise/PiecewiseSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/clause/piecewise/PiecewiseSection.kt
@@ -19,7 +19,7 @@ import mathlingua.chalktalk.phase1.ast.Section
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_PIECEWISE_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -42,7 +42,7 @@ fun isPiecewiseSection(section: Section) = section.name.text == "piecewise"
 fun validatePiecewiseSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "piecewise", DEFAULT_PIECEWISE_SECTION) {
             PiecewiseSection()
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/WrittenSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/WrittenSection.kt
@@ -25,7 +25,7 @@ import mathlingua.chalktalk.phase1.ast.getRow
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_WRITTEN_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -53,7 +53,7 @@ fun isWrittenSection(sec: Section) = sec.name.text == "written"
 fun validateWrittenSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "written", DEFAULT_WRITTEN_SECTION) { section ->
             if (section.args.isEmpty() ||
                 !section.args.all {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/CollectsSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/CollectsSection.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_COLLECTS_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.clause.given.GivenGroup
 import mathlingua.chalktalk.phase2.ast.group.clause.given.validateGivenGroup
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -47,7 +47,7 @@ data class CollectsSection(val givenGroup: GivenGroup) : Phase2Node {
 fun validateCollectsSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "collects", DEFAULT_COLLECTS_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_COLLECTS_SECTION, "given group") { arg ->
                 CollectsSection(givenGroup = validateGivenGroup(arg.resolve(), errors, tracker))

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
@@ -26,6 +26,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_WRITTEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.sectionsMatchNames
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getId
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
@@ -37,11 +38,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSectio
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -109,43 +109,39 @@ fun isDefinesCollectsGroup(node: Phase1Node) = sectionsMatchNames(node, "Defines
 fun validateDefinesCollectsGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Defines", DEFAULT_DEFINES_COLLECTS_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group,
                 errors,
                 DEFAULT_DEFINES_COLLECTS_GROUP,
                 listOf(
                     "Defines", "where?", "when?", "collects", "using?", "written", "Metadata?")) {
             sections ->
-                val id = neoGetId(group, errors, DEFAULT_ID_STATEMENT, tracker)
+                val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
                 DefinesCollectsGroup(
                     signature = id.signature(),
                     id = id,
                     definesSection =
-                        neoEnsureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
                             validateDefinesSection(it, errors, tracker)
                         },
                     whereSection =
-                        neoIfNonNull(sections["where"]) {
-                            validateWhereSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     whenSection =
-                        neoIfNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
                     collectsSection =
-                        neoEnsureNonNull(sections["collects"], DEFAULT_COLLECTS_SECTION) {
+                        ensureNonNull(sections["collects"], DEFAULT_COLLECTS_SECTION) {
                             validateCollectsSection(it, errors, tracker)
                         },
                     usingSection =
-                        neoIfNonNull(sections["using"]) {
-                            validateUsingSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
                     writtenSection =
-                        neoEnsureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
                             validateWrittenSection(it, errors, tracker)
                         },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
@@ -26,6 +26,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_WRITTEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.sectionsMatchNames
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getId
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
@@ -37,11 +38,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSectio
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -109,43 +109,39 @@ fun isDefinesEvaluatedGroup(node: Phase1Node) = sectionsMatchNames(node, "Define
 fun validateDefinesEvaluatedGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Defines", DEFAULT_DEFINES_EVALUATED_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group,
                 errors,
                 DEFAULT_DEFINES_EVALUATED_GROUP,
                 listOf(
                     "Defines", "where?", "when?", "evaluated", "using?", "written", "Metadata?")) {
             sections ->
-                val id = neoGetId(group, errors, DEFAULT_ID_STATEMENT, tracker)
+                val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
                 DefinesEvaluatedGroup(
                     signature = id.signature(),
                     id = id,
                     definesSection =
-                        neoEnsureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
                             validateDefinesSection(it, errors, tracker)
                         },
                     whereSection =
-                        neoIfNonNull(sections["where"]) {
-                            validateWhereSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     whenSection =
-                        neoIfNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
                     evaluatedSection =
-                        neoEnsureNonNull(sections["evaluated"], DEFAULT_EVALUATED_SECTION) {
+                        ensureNonNull(sections["evaluated"], DEFAULT_EVALUATED_SECTION) {
                             validateEvaluatedSection(it, errors, tracker)
                         },
                     usingSection =
-                        neoIfNonNull(sections["using"]) {
-                            validateUsingSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
                     writtenSection =
-                        neoEnsureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
                             validateWrittenSection(it, errors, tracker)
                         },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
@@ -26,6 +26,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_WRITTEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.sectionsMatchNames
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getId
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
@@ -37,11 +38,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSectio
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -109,43 +109,39 @@ fun isDefinesGeneratedGroup(node: Phase1Node) = sectionsMatchNames(node, "Define
 fun validateDefinesGeneratedGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Defines", DEFAULT_DEFINES_GENERATED_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group,
                 errors,
                 DEFAULT_DEFINES_GENERATED_GROUP,
                 listOf(
                     "Defines", "where?", "when?", "generated", "using?", "written", "Metadata?")) {
             sections ->
-                val id = neoGetId(group, errors, DEFAULT_ID_STATEMENT, tracker)
+                val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
                 DefinesGeneratedGroup(
                     signature = id.signature(),
                     id = id,
                     definesSection =
-                        neoEnsureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
                             validateDefinesSection(it, errors, tracker)
                         },
                     whereSection =
-                        neoIfNonNull(sections["where"]) {
-                            validateWhereSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     whenSection =
-                        neoIfNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
                     generatedSection =
-                        neoEnsureNonNull(sections["generated"], DEFAULT_GENERATED_SECTION) {
+                        ensureNonNull(sections["generated"], DEFAULT_GENERATED_SECTION) {
                             validateGeneratedSection(it, errors, tracker)
                         },
                     usingSection =
-                        neoIfNonNull(sections["using"]) {
-                            validateUsingSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
                     writtenSection =
-                        neoEnsureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
                             validateWrittenSection(it, errors, tracker)
                         },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesInstantiatedGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesInstantiatedGroup.kt
@@ -26,6 +26,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_WRITTEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.sectionsMatchNames
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getId
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
@@ -35,11 +36,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.va
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -99,39 +99,37 @@ fun isDefinesInstantiatedGroup(node: Phase1Node) =
 fun validateDefinesInstantiatedGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Defines", DEFAULT_DEFINES_INSTANTIATED_GROUP) {
         group ->
-            neoIdentifySections(
+            identifySections(
                 group,
                 errors,
                 DEFAULT_DEFINES_INSTANTIATED_GROUP,
                 listOf("Defines", "when?", "instantiated", "using?", "written", "Metadata?")) {
             sections ->
-                val id = neoGetId(group, errors, DEFAULT_ID_STATEMENT, tracker)
+                val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
                 DefinesInstantiatedGroup(
                     signature = id.signature(),
                     id = id,
                     definesSection =
-                        neoEnsureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
                             validateDefinesSection(it, errors, tracker)
                         },
                     whenSection =
-                        neoIfNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
                     instantiatedSection =
-                        neoEnsureNonNull(sections["instantiated"], DEFAULT_INSTANTIATED_SECTION) {
+                        ensureNonNull(sections["instantiated"], DEFAULT_INSTANTIATED_SECTION) {
                             validateInstantiatedSection(it, errors, tracker)
                         },
                     usingSection =
-                        neoIfNonNull(sections["using"]) {
-                            validateUsingSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
                     writtenSection =
-                        neoEnsureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
                             validateWrittenSection(it, errors, tracker)
                         },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
@@ -26,6 +26,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_WRITTEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.sectionsMatchNames
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getId
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
@@ -37,11 +38,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSectio
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -109,42 +109,38 @@ fun isDefinesMapsGroup(node: Phase1Node) = sectionsMatchNames(node, "Defines", "
 fun validateDefinesMapsGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Defines", DEFAULT_DEFINES_MAPS_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group,
                 errors,
                 DEFAULT_DEFINES_MAPS_GROUP,
                 listOf("Defines", "where?", "when?", "maps", "using?", "written", "Metadata?")) {
             sections ->
-                val id = neoGetId(group, errors, DEFAULT_ID_STATEMENT, tracker)
+                val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
                 DefinesMapsGroup(
                     signature = id.signature(),
                     id = id,
                     definesSection =
-                        neoEnsureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
                             validateDefinesSection(it, errors, tracker)
                         },
                     whereSection =
-                        neoIfNonNull(sections["where"]) {
-                            validateWhereSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     whenSection =
-                        neoIfNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
                     mapsSection =
-                        neoEnsureNonNull(sections["maps"], DEFAULT_MAPS_SECTION) {
+                        ensureNonNull(sections["maps"], DEFAULT_MAPS_SECTION) {
                             validateMapsSection(it, errors, tracker)
                         },
                     usingSection =
-                        neoIfNonNull(sections["using"]) {
-                            validateUsingSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
                     writtenSection =
-                        neoEnsureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
                             validateWrittenSection(it, errors, tracker)
                         },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
@@ -26,6 +26,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_WRITTEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.sectionsMatchNames
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getId
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
@@ -37,11 +38,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSectio
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -109,42 +109,38 @@ fun isDefinesMeansGroup(node: Phase1Node) = sectionsMatchNames(node, "Defines", 
 fun validateDefinesMeansGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Defines", DEFAULT_DEFINES_MEANS_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group,
                 errors,
                 DEFAULT_DEFINES_MEANS_GROUP,
                 listOf("Defines", "where?", "when?", "means", "using?", "written", "Metadata?")) {
             sections ->
-                val id = neoGetId(group, errors, DEFAULT_ID_STATEMENT, tracker)
+                val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
                 DefinesMeansGroup(
                     signature = id.signature(),
                     id = id,
                     definesSection =
-                        neoEnsureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
                             validateDefinesSection(it, errors, tracker)
                         },
                     whereSection =
-                        neoIfNonNull(sections["where"]) {
-                            validateWhereSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     whenSection =
-                        neoIfNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
                     meansSection =
-                        neoEnsureNonNull(sections["means"], DEFAULT_MEANS_SECTION) {
+                        ensureNonNull(sections["means"], DEFAULT_MEANS_SECTION) {
                             validateMeansSection(it, errors, tracker)
                         },
                     usingSection =
-                        neoIfNonNull(sections["using"]) {
-                            validateUsingSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
                     writtenSection =
-                        neoEnsureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
                             validateWrittenSection(it, errors, tracker)
                         },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesSection.kt
@@ -21,8 +21,8 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_DEFINES_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Target
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
 import mathlingua.chalktalk.phase2.ast.section.appendTargetArgs
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateTargetSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -45,7 +45,7 @@ data class DefinesSection(val targets: List<Target>) : Phase2Node {
 fun validateDefinesSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateTargetSection(
             node.resolve(), errors, "Defines", DEFAULT_DEFINES_SECTION, tracker, ::DefinesSection)
     }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/EvaluatedSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/EvaluatedSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_EVALUATED_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -48,7 +48,7 @@ data class EvaluatedSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateEvaluatedSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "evaluated", DEFAULT_EVALUATED_SECTION) {
             EvaluatedSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/GeneratedSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/GeneratedSection.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_GENERATED_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.clause.inductively.InductivelyGroup
 import mathlingua.chalktalk.phase2.ast.group.clause.inductively.validateInductivelyGroup
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -48,7 +48,7 @@ data class GeneratedSection(val inductivelyGroup: InductivelyGroup) : Phase2Node
 fun validateGeneratedSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "generated", DEFAULT_GENERATED_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_GENERATED_SECTION, "generated group") {
                 GeneratedSection(inductivelyGroup = validateInductivelyGroup(it, errors, tracker))

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/InstatiatedSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/InstatiatedSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_INSTANTIATED_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Statement
 import mathlingua.chalktalk.phase2.ast.clause.validateStatement
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -54,7 +54,7 @@ data class InstantiatedSection(val statements: List<Statement>) : Phase2Node {
 fun validateInstantiatedSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "instantiated", DEFAULT_INSTANTIATED_SECTION) {
             InstantiatedSection(
                 statements = it.args.map { arg -> validateStatement(arg, errors, tracker) })

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/MapsSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/MapsSection.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_MAPS_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.clause.from.FromGroup
 import mathlingua.chalktalk.phase2.ast.group.clause.from.validateFromGroup
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -47,7 +47,7 @@ data class MapsSection(val fromGroup: FromGroup) : Phase2Node {
 fun validateMapsSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "maps", DEFAULT_MAPS_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_MAPS_SECTION, "from group") {
                 MapsSection(fromGroup = validateFromGroup(it, errors, tracker))

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/MeansSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/MeansSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_MEANS_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -48,7 +48,7 @@ data class MeansSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateMeansSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "means", DEFAULT_MEANS_SECTION) {
             MeansSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/ProvidedSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/defines/ProvidedSection.kt
@@ -23,7 +23,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_PROVIDED_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -51,7 +51,7 @@ fun isProvidedSection(sec: Section) = sec.name.text == "provided"
 fun validateProvidedSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "provided", DEFAULT_PROVIDED_SECTION) {
             ProvidedSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/evaluates/EvaluatesGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/evaluates/EvaluatesGroup.kt
@@ -24,6 +24,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_ID_STATEMENT
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getId
 import mathlingua.chalktalk.phase2.ast.group.clause.If.ElseSection
 import mathlingua.chalktalk.phase2.ast.group.clause.If.ThenSection
 import mathlingua.chalktalk.phase2.ast.group.clause.If.isElseSection
@@ -46,9 +47,8 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.va
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -120,9 +120,9 @@ fun isEvaluatesGroup(node: Phase1Node) = firstSectionMatchesName(node, "Evaluate
 fun validateEvaluatesGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node, errors, "Evaluates", DEFAULT_EVALUATES_GROUP) { group ->
-            val id = neoGetId(group, errors, DEFAULT_ID_STATEMENT, tracker)
+            val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
             if (group.sections.isEmpty() || !isEvaluatesSection(group.sections.first())) {
                 errors.add(
                     ParseError(
@@ -212,7 +212,7 @@ fun validateEvaluatesGroup(
                         signature = id.signature(),
                         id = id,
                         evaluatesSection =
-                            neoEnsureNonNull(group.sections[0], DEFAULT_EVALUATES_SECTION) {
+                            ensureNonNull(group.sections[0], DEFAULT_EVALUATES_SECTION) {
                                 validateEvaluatesSection(it, errors, tracker)
                             },
                         whenThen = whenToList,

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/evaluates/EvaluatesSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/evaluates/EvaluatesSection.kt
@@ -19,7 +19,7 @@ import mathlingua.chalktalk.phase1.ast.Section
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_EVALUATES_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -42,7 +42,7 @@ fun isEvaluatesSection(section: Section) = section.name.text == "Evaluates"
 fun validateEvaluatesSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "Evaluates", DEFAULT_EVALUATES_SECTION) {
             EvaluatesSection()
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/foundation/FoundationGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/foundation/FoundationGroup.kt
@@ -27,10 +27,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -64,18 +64,18 @@ fun isFoundationGroup(node: Phase1Node) = firstSectionMatchesName(node, "Foundat
 fun validateFoundationGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Foundation", DEFAULT_FOUNDATION_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group, errors, DEFAULT_FOUNDATION_GROUP, listOf("Foundation", "Metadata?")) {
             sections ->
                 FoundationGroup(
                     foundationSection =
-                        neoEnsureNonNull(sections["Foundation"], DEFAULT_FOUNDATION_SECTION) {
+                        ensureNonNull(sections["Foundation"], DEFAULT_FOUNDATION_SECTION) {
                             validateFoundationSection(it, errors, tracker)
                         },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/foundation/FoundationSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/foundation/FoundationSection.kt
@@ -21,7 +21,7 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_FOUNDATION_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -47,7 +47,7 @@ data class FoundationSection(val content: DefinesStatesOrViews) : Phase2Node {
 fun validateFoundationSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "Foundation", DEFAULT_FOUNDATION_SECTION) {
             val clauseList = validateClauseListNode(node, errors, tracker)
             if (clauseList.clauses.isEmpty() || clauseList.clauses[0] !is DefinesStatesOrViews) {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/mutually/MutuallyGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/mutually/MutuallyGroup.kt
@@ -24,10 +24,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -58,18 +58,18 @@ fun isMutuallyGroup(node: Phase1Node) = firstSectionMatchesName(node, "Mutually"
 fun validateMutuallyGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Mutually", DEFAULT_MUTUALLY_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group, errors, DEFAULT_MUTUALLY_GROUP, listOf("Mutually", "Metadata?")) {
             sections ->
                 MutuallyGroup(
                     mutuallySection =
-                        neoEnsureNonNull(sections["Mutually"], DEFAULT_MUTUALLY_SECTION) {
+                        ensureNonNull(sections["Mutually"], DEFAULT_MUTUALLY_SECTION) {
                             validateMutuallySection(it, errors, tracker)
                         },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/mutually/MutuallySection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/mutually/MutuallySection.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_MUTUALLY_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -46,7 +46,7 @@ data class MutuallySection(val items: List<DefinesStatesOrViews>) : Phase2Node {
 fun validateMutuallySection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "Mutually", DEFAULT_MUTUALLY_SECTION) {
             val clauseList = validateClauseListNode(node, errors, tracker)
             if (clauseList.clauses.isEmpty() ||

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/states/StatesGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/states/StatesGroup.kt
@@ -25,6 +25,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_THAT_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getId
 import mathlingua.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
@@ -36,11 +37,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.va
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -102,37 +102,35 @@ fun isStatesGroup(node: Phase1Node) = firstSectionMatchesName(node, "States")
 fun validateStatesGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "States", DEFAULT_STATES_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group,
                 errors,
                 DEFAULT_STATES_GROUP,
                 listOf("States", "when?", "that", "using?", "written?", "Metadata?")) { sections ->
-                val id = neoGetId(group, errors, DEFAULT_ID_STATEMENT, tracker)
+                val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
                 StatesGroup(
                     signature = id.signature(),
                     id = id,
                     statesSection =
-                        neoEnsureNonNull(sections["States"], DEFAULT_STATES_SECTION) {
+                        ensureNonNull(sections["States"], DEFAULT_STATES_SECTION) {
                             validateStatesSection(it, errors, tracker)
                         },
                     whenSection =
-                        neoIfNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
                     thatSection =
-                        neoEnsureNonNull(sections["that"], DEFAULT_THAT_SECTION) {
+                        ensureNonNull(sections["that"], DEFAULT_THAT_SECTION) {
                             validateThatSection(it, errors, tracker)
                         },
                     usingSection =
-                        neoIfNonNull(sections["using"]) {
-                            validateUsingSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
                     writtenSection =
-                        neoIfNonNull(sections["written"]) {
+                        ifNonNull(sections["written"]) {
                             validateWrittenSection(it, errors, tracker)
                         },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/states/StatesSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/states/StatesSection.kt
@@ -20,7 +20,7 @@ import mathlingua.chalktalk.phase1.ast.Phase1Node
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_STATES_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -41,7 +41,7 @@ class StatesSection : Phase2Node {
 fun validateStatesSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "States", DEFAULT_STATES_SECTION) {
             StatesSection()
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/states/ThatSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/states/ThatSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_THAT_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -48,7 +48,7 @@ data class ThatSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateThatSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "that", DEFAULT_THAT_SECTION) {
             ThatSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/views/SingleAsSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/views/SingleAsSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_SINGLE_AS_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Statement
 import mathlingua.chalktalk.phase2.ast.clause.validateStatement
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -48,7 +48,7 @@ data class SingleAsSection(val statement: Statement) : Phase2Node {
 fun validateSingleAsSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "as", DEFAULT_SINGLE_AS_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_SINGLE_AS_SECTION, "statement") {
                 SingleAsSection(statement = validateStatement(it, errors, tracker))

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/views/SingleFromSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/views/SingleFromSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_SINGLE_FROM_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Statement
 import mathlingua.chalktalk.phase2.ast.clause.validateStatement
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -48,7 +48,7 @@ data class SingleFromSection(val statement: Statement) : Phase2Node {
 fun validateSingleFromSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "from", DEFAULT_SINGLE_FROM_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_SINGLE_FROM_SECTION, "statement") {
                 SingleFromSection(statement = validateStatement(it, errors, tracker))

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/views/SingleToSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/views/SingleToSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_SINGLE_TO_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateStatement
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -46,7 +46,7 @@ data class SingleToSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateSingleToSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "to", DEFAULT_SINGLE_TO_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_SINGLE_TO_SECTION, "statement") {
                 SingleToSection(

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/views/ViewsGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/views/ViewsGroup.kt
@@ -27,6 +27,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_VIEWS_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getId
 import mathlingua.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
@@ -34,11 +35,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.Me
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -102,39 +102,37 @@ fun isViewsGroup(node: Phase1Node) = firstSectionMatchesName(node, "Views")
 fun validateViewsGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Views", DEFAULT_VIEWS_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group,
                 errors,
                 DEFAULT_VIEWS_GROUP,
                 listOf("Views", "from", "to", "as", "using?", "Metadata?")) { sections ->
-                val id = neoGetId(group, errors, DEFAULT_ID_STATEMENT, tracker)
+                val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
                 ViewsGroup(
                     signature = id.signature(),
                     id = id,
                     viewsSection =
-                        neoEnsureNonNull(sections["Views"], DEFAULT_VIEWS_SECTION) {
+                        ensureNonNull(sections["Views"], DEFAULT_VIEWS_SECTION) {
                             validateViewsSection(it, errors, tracker)
                         },
                     singleFromSection =
-                        neoEnsureNonNull(sections["from"], DEFAULT_SINGLE_FROM_SECTION) {
+                        ensureNonNull(sections["from"], DEFAULT_SINGLE_FROM_SECTION) {
                             validateSingleFromSection(it, errors, tracker)
                         },
                     singleToSection =
-                        neoEnsureNonNull(sections["to"], DEFAULT_SINGLE_TO_SECTION) {
+                        ensureNonNull(sections["to"], DEFAULT_SINGLE_TO_SECTION) {
                             validateSingleToSection(it, errors, tracker)
                         },
                     asSection =
-                        neoEnsureNonNull(sections["as"], DEFAULT_SINGLE_AS_SECTION) {
+                        ensureNonNull(sections["as"], DEFAULT_SINGLE_AS_SECTION) {
                             validateSingleAsSection(it, errors, tracker)
                         },
                     usingSection =
-                        neoIfNonNull(sections["using"]) {
-                            validateUsingSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/views/ViewsSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/defineslike/views/ViewsSection.kt
@@ -21,8 +21,8 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_VIEWS_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Target
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
 import mathlingua.chalktalk.phase2.ast.section.appendTargetArgs
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateTargetSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -45,7 +45,7 @@ data class ViewsSection(val targets: List<Target>) : Phase2Node {
 fun validateViewsSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateTargetSection(
             node.resolve(), errors, "Views", DEFAULT_VIEWS_SECTION, tracker, ::ViewsSection)
     }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/entry/ContentSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/entry/ContentSection.kt
@@ -24,7 +24,7 @@ import mathlingua.chalktalk.phase1.ast.getRow
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_CONTENT_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -47,7 +47,7 @@ data class ContentSection(val text: String) : Phase2Node {
 fun validateContentSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "content", DEFAULT_CONTENT_SECTION) { section ->
             if (section.args.isEmpty() ||
                 section.args[0].chalkTalkTarget !is Phase1Token ||

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/entry/EntryGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/entry/EntryGroup.kt
@@ -28,10 +28,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -69,28 +69,28 @@ fun isEntryGroup(node: Phase1Node) = firstSectionMatchesName(node, "Entry")
 fun validateEntryGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Entry", DEFAULT_ENTRY_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group,
                 errors,
                 DEFAULT_ENTRY_GROUP,
                 listOf("Entry", "type", "content", "Metadata?")) { sections ->
                 EntryGroup(
                     entrySection =
-                        neoEnsureNonNull(sections["Entry"], DEFAULT_ENTRY_SECTION) {
+                        ensureNonNull(sections["Entry"], DEFAULT_ENTRY_SECTION) {
                             validateEntrySection(it, errors, tracker)
                         },
                     typeSection =
-                        neoEnsureNonNull(sections["type"], DEFAULT_TYPE_SECTION) {
+                        ensureNonNull(sections["type"], DEFAULT_TYPE_SECTION) {
                             validateTypeSection(it, errors, tracker)
                         },
                     contentSection =
-                        neoEnsureNonNull(sections["content"], DEFAULT_CONTENT_SECTION) {
+                        ensureNonNull(sections["content"], DEFAULT_CONTENT_SECTION) {
                             validateContentSection(it, errors, tracker)
                         },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/entry/EntrySection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/entry/EntrySection.kt
@@ -24,7 +24,7 @@ import mathlingua.chalktalk.phase1.ast.getRow
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_ENTRY_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -55,7 +55,7 @@ data class EntrySection(val names: List<String>) : Phase2Node {
 fun validateEntrySection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "Entry", DEFAULT_ENTRY_SECTION) { section ->
             if (section.args.isNotEmpty() &&
                 !section.args.all {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/entry/TypeSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/entry/TypeSection.kt
@@ -24,7 +24,7 @@ import mathlingua.chalktalk.phase1.ast.getRow
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_TYPE_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -47,7 +47,7 @@ data class TypeSection(val text: String) : Phase2Node {
 fun validateTypeSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "type", DEFAULT_TYPE_SECTION) { section ->
             if (section.args.isEmpty() ||
                 section.args[0].chalkTalkTarget !is Phase1Token ||

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resource/ResourceGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resource/ResourceGroup.kt
@@ -27,10 +27,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -71,9 +71,9 @@ fun isResourceGroup(node: Phase1Node) = firstSectionMatchesName(node, "Resource"
 fun validateResourceGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Resource", DEFAULT_RESOURCE_GROUP) { group ->
-            neoIdentifySections(
+            identifySections(
                 group, errors, DEFAULT_RESOURCE_GROUP, listOf("Resource", "Metadata?")) {
             sections ->
                 if (group.id == null) {
@@ -82,11 +82,11 @@ fun validateResourceGroup(
                     ResourceGroup(
                         id = group.id.text.removeSurrounding("[", "]"),
                         sourceSection =
-                            neoEnsureNonNull(sections["Resource"], DEFAULT_RESOURCE_SECTION) {
+                            ensureNonNull(sections["Resource"], DEFAULT_RESOURCE_SECTION) {
                                 validateResourceSection(it, errors, tracker)
                             },
                         metaDataSection =
-                            neoIfNonNull(sections["Metadata"]) {
+                            ifNonNull(sections["Metadata"]) {
                                 validateMetaDataSection(it, errors, tracker)
                             })
                 }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resource/ResourceSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resource/ResourceSection.kt
@@ -28,7 +28,7 @@ import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.isSingleSectionGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.StringSectionGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.StringSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.Location
 import mathlingua.support.MutableLocationTracker
@@ -68,7 +68,7 @@ class ResourceSection(val items: List<StringSectionGroup>) : Phase2Node {
 fun validateResourceSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node, errors, "Resource", DEFAULT_RESOURCE_SECTION) { section ->
             val startErrorCount = errors.size
             val items = mutableListOf<StringSectionGroup>()

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/IfOrIffSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/IfOrIffSection.kt
@@ -26,7 +26,7 @@ import mathlingua.chalktalk.phase2.ast.group.clause.If.IfSection
 import mathlingua.chalktalk.phase2.ast.group.clause.If.validateIfSection
 import mathlingua.chalktalk.phase2.ast.group.clause.iff.IffSection
 import mathlingua.chalktalk.phase2.ast.group.clause.iff.validateIffSection
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
 
@@ -49,8 +49,8 @@ fun validateIfOrIffSection(
     errors: MutableList<ParseError>,
     tracker: MutableLocationTracker
 ): IfOrIffSection? {
-    val ifSection = neoIfNonNull(sections["if"]) { validateIfSection(it, errors, tracker) }
-    val iffSection = neoIfNonNull(sections["iff"]) { validateIffSection(it, errors, tracker) }
+    val ifSection = ifNonNull(sections["if"]) { validateIfSection(it, errors, tracker) }
+    val iffSection = ifNonNull(sections["iff"]) { validateIffSection(it, errors, tracker) }
 
     return if (ifSection == null && iffSection == null) {
         null

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/axiom/AxiomGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/axiom/AxiomGroup.kt
@@ -24,6 +24,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_THEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getOptionalId
 import mathlingua.chalktalk.phase2.ast.group.clause.If.ThenSection
 import mathlingua.chalktalk.phase2.ast.group.clause.If.validateThenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
@@ -38,11 +39,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.va
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetOptionalId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -116,10 +116,10 @@ fun isAxiomGroup(node: Phase1Node) = firstSectionMatchesName(node, "Axiom")
 fun validateAxiomGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Axiom", DEFAULT_AXIOM_GROUP) { group ->
-            val id = neoGetOptionalId(group, errors, tracker)
-            neoIdentifySections(
+            val id = getOptionalId(group, errors, tracker)
+            identifySections(
                 group,
                 errors,
                 DEFAULT_AXIOM_GROUP,
@@ -130,28 +130,22 @@ fun validateAxiomGroup(
                     signature = id?.signature(),
                     id = id,
                     axiomSection =
-                        neoEnsureNonNull(sections["Axiom"], DEFAULT_AXIOM_SECTION) {
+                        ensureNonNull(sections["Axiom"], DEFAULT_AXIOM_SECTION) {
                             validateAxiomSection(it, errors, tracker)
                         },
                     givenSection =
-                        neoIfNonNull(sections["given"]) {
-                            validateGivenSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["given"]) { validateGivenSection(it, errors, tracker) },
                     whereSection =
-                        neoIfNonNull(sections["where"]) {
-                            validateWhereSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     ifOrIffSection = validateIfOrIffSection(node, sections, errors, tracker),
                     thenSection =
-                        neoEnsureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
+                        ensureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
                             validateThenSection(it, errors, tracker)
                         },
                     usingSection =
-                        neoIfNonNull(sections["using"]) {
-                            validateUsingSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/axiom/AxiomSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/axiom/AxiomSection.kt
@@ -24,7 +24,7 @@ import mathlingua.chalktalk.phase1.ast.getRow
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_AXIOM_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -52,7 +52,7 @@ data class AxiomSection(val names: List<String>) : Phase2Node {
 fun validateAxiomSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "Axiom", DEFAULT_AXIOM_SECTION) { section ->
             if (section.args.isNotEmpty() &&
                 !section.args.all {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/conjecture/ConjectureGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/conjecture/ConjectureGroup.kt
@@ -24,6 +24,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_THEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getOptionalId
 import mathlingua.chalktalk.phase2.ast.group.clause.If.ThenSection
 import mathlingua.chalktalk.phase2.ast.group.clause.If.validateThenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
@@ -38,11 +39,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.va
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetOptionalId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -117,10 +117,10 @@ fun isConjectureGroup(node: Phase1Node) = firstSectionMatchesName(node, "Conject
 fun validateConjectureGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Conjecture", DEFAULT_CONJECTURE_GROUP) { group ->
-            val id = neoGetOptionalId(group, errors, tracker)
-            neoIdentifySections(
+            val id = getOptionalId(group, errors, tracker)
+            identifySections(
                 group,
                 errors,
                 DEFAULT_CONJECTURE_GROUP,
@@ -137,28 +137,22 @@ fun validateConjectureGroup(
                     signature = id?.signature(),
                     id = id,
                     conjectureSection =
-                        neoEnsureNonNull(sections["Conjecture"], DEFAULT_CONJECTURE_SECTION) {
+                        ensureNonNull(sections["Conjecture"], DEFAULT_CONJECTURE_SECTION) {
                             validateConjectureSection(it, errors, tracker)
                         },
                     givenSection =
-                        neoIfNonNull(sections["given"]) {
-                            validateGivenSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["given"]) { validateGivenSection(it, errors, tracker) },
                     whereSection =
-                        neoIfNonNull(sections["where"]) {
-                            validateWhereSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     ifOrIffSection = validateIfOrIffSection(node, sections, errors, tracker),
                     thenSection =
-                        neoEnsureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
+                        ensureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
                             validateThenSection(it, errors, tracker)
                         },
                     usingSection =
-                        neoIfNonNull(sections["using"]) {
-                            validateUsingSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/conjecture/ConjectureSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/conjecture/ConjectureSection.kt
@@ -24,7 +24,7 @@ import mathlingua.chalktalk.phase1.ast.getRow
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_CONJECTURE_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -52,7 +52,7 @@ data class ConjectureSection(val names: List<String>) : Phase2Node {
 fun validateConjectureSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "Conjecture", DEFAULT_CONJECTURE_SECTION) {
         section ->
             if (section.args.isNotEmpty() &&

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/theorem/GivenSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/theorem/GivenSection.kt
@@ -21,8 +21,8 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_GIVEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.Target
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
 import mathlingua.chalktalk.phase2.ast.section.appendTargetArgs
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateTargetSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -45,7 +45,7 @@ data class GivenSection(val targets: List<Target>) : Phase2Node {
 fun validateGivenSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateTargetSection(node.resolve(), errors, "given", DEFAULT_GIVEN_SECTION, tracker) {
         targets ->
             GivenSection(targets = targets)

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/theorem/TheoremGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/theorem/TheoremGroup.kt
@@ -24,6 +24,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_THEOREM_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.chalktalk.phase2.ast.getOptionalId
 import mathlingua.chalktalk.phase2.ast.group.clause.If.ThenSection
 import mathlingua.chalktalk.phase2.ast.group.clause.If.validateThenSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
@@ -36,11 +37,10 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.va
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.neoGetOptionalId
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -114,10 +114,10 @@ fun isTheoremGroup(node: Phase1Node) = firstSectionMatchesName(node, "Theorem")
 fun validateTheoremGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node.resolve(), errors, "Theorem", DEFAULT_THEOREM_GROUP) { group ->
-            val id = neoGetOptionalId(group, errors, tracker)
-            neoIdentifySections(
+            val id = getOptionalId(group, errors, tracker)
+            identifySections(
                 group,
                 errors,
                 DEFAULT_THEOREM_GROUP,
@@ -128,28 +128,22 @@ fun validateTheoremGroup(
                     signature = id?.signature(),
                     id = id,
                     theoremSection =
-                        neoEnsureNonNull(sections["Theorem"], DEFAULT_THEOREM_SECTION) {
+                        ensureNonNull(sections["Theorem"], DEFAULT_THEOREM_SECTION) {
                             validateTheoremSection(it, errors, tracker)
                         },
                     givenSection =
-                        neoIfNonNull(sections["given"]) {
-                            validateGivenSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["given"]) { validateGivenSection(it, errors, tracker) },
                     givenWhereSection =
-                        neoIfNonNull(sections["where"]) {
-                            validateWhereSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     ifOrIffSection = validateIfOrIffSection(node, sections, errors, tracker),
                     thenSection =
-                        neoEnsureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
+                        ensureNonNull(sections["then"], DEFAULT_THEN_SECTION) {
                             validateThenSection(it, errors, tracker)
                         },
                     usingSection =
-                        neoIfNonNull(sections["using"]) {
-                            validateUsingSection(it, errors, tracker)
-                        },
+                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
                     metaDataSection =
-                        neoIfNonNull(sections["Metadata"]) {
+                        ifNonNull(sections["Metadata"]) {
                             validateMetaDataSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/theorem/TheoremSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/resultlike/theorem/TheoremSection.kt
@@ -24,7 +24,7 @@ import mathlingua.chalktalk.phase1.ast.getRow
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_THEOREM_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -52,7 +52,7 @@ data class TheoremSection(val names: List<String>) : Phase2Node {
 fun validateTheoremSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "Theorem", DEFAULT_THEOREM_SECTION) { section ->
             if (section.args.isNotEmpty() &&
                 !section.args.all {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/UsingSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/UsingSection.kt
@@ -23,7 +23,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_USING_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -51,7 +51,7 @@ fun isUsingSection(sec: Section) = sec.name.text == "using"
 fun validateUsingSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "using", DEFAULT_USING_SECTION) {
             UsingSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/WhenSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/WhenSection.kt
@@ -23,7 +23,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_WHEN_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -51,7 +51,7 @@ fun isWhenSection(sec: Section) = sec.name.text == "when"
 fun validateWhenSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "when", DEFAULT_WHEN_SECTION) {
             WhenSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/WhereSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/WhereSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_WHERE_SECTION
 import mathlingua.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -48,7 +48,7 @@ data class WhereSection(val clauses: ClauseListNode) : Phase2Node {
 fun validateWhereSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node.resolve(), errors, "where", DEFAULT_WHERE_SECTION) {
             WhereSection(clauses = validateClauseListNode(it, errors, tracker))
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/ReferenceGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/ReferenceGroup.kt
@@ -23,9 +23,9 @@ import mathlingua.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.chalktalk.phase2.ast.common.OnePartNode
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.ReferenceSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateReferenceSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -38,13 +38,13 @@ fun isReferenceGroup(node: Phase1Node) = firstSectionMatchesName(node, "referenc
 fun validateReferenceGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateGroup(node, errors, "reference", DEFAULT_REFERENCE_GROUP) { group ->
-            neoIdentifySections(group, errors, DEFAULT_REFERENCE_GROUP, listOf("reference")) {
+            identifySections(group, errors, DEFAULT_REFERENCE_GROUP, listOf("reference")) {
             sections ->
                 ReferenceGroup(
                     referenceSection =
-                        neoEnsureNonNull(sections["reference"], DEFAULT_REFERENCE_SECTION) {
+                        ensureNonNull(sections["reference"], DEFAULT_REFERENCE_SECTION) {
                             validateReferenceSection(it, errors, tracker)
                         })
             }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/SourceItemGroup.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/SourceItemGroup.kt
@@ -31,9 +31,9 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.va
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validatePageItemSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateSourceItemSection
 import mathlingua.chalktalk.phase2.ast.group.toplevel.topLevelToCode
-import mathlingua.chalktalk.phase2.ast.section.neoEnsureNonNull
-import mathlingua.chalktalk.phase2.ast.section.neoIdentifySections
-import mathlingua.chalktalk.phase2.ast.section.neoIfNonNull
+import mathlingua.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.chalktalk.phase2.ast.section.identifySections
+import mathlingua.chalktalk.phase2.ast.section.ifNonNull
 import mathlingua.chalktalk.phase2.ast.validateGroup
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -79,24 +79,24 @@ fun validateSourceItemGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
     validateGroup(node, errors, "source", DEFAULT_SOURCE_ITEM_GROUP) { group ->
-        neoIdentifySections(
+        identifySections(
             group,
             errors,
             DEFAULT_SOURCE_ITEM_GROUP,
             listOf("source", "page?", "offset?", "content?")) { sections ->
             SourceItemGroup(
                 sourceSection =
-                    neoEnsureNonNull(sections["source"], DEFAULT_SOURCE_ITEM_SECTION) {
+                    ensureNonNull(sections["source"], DEFAULT_SOURCE_ITEM_SECTION) {
                         validateSourceItemSection(it, errors, tracker)
                     },
                 pageSection =
-                    neoIfNonNull(sections["page"]) { validatePageItemSection(it, errors, tracker) },
+                    ifNonNull(sections["page"]) { validatePageItemSection(it, errors, tracker) },
                 offsetSection =
-                    neoIfNonNull(sections["offset"]) {
+                    ifNonNull(sections["offset"]) {
                         validateOffsetItemSection(it, errors, tracker)
                     },
                 contentSection =
-                    neoIfNonNull(sections["content"]) {
+                    ifNonNull(sections["content"]) {
                         validateContentItemSection(it, errors, tracker)
                     })
         }

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/ContentItemSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/ContentItemSection.kt
@@ -25,7 +25,7 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_CONTENT_ITEM_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.indentedStringSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -45,7 +45,7 @@ data class ContentItemSection(val content: String) : Phase2Node {
 fun validateContentItemSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node, errors, "content", DEFAULT_CONTENT_ITEM_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_CONTENT_ITEM_SECTION, "string") { arg ->
                 if (arg !is Phase1Token || arg.type != ChalkTalkTokenType.String) {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/MetaDataSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/MetaDataSection.kt
@@ -31,7 +31,7 @@ import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.MetaD
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.StringSectionGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.isReferenceGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.validateReferenceGroup
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.support.Location
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -71,7 +71,7 @@ fun isMetadataSection(sec: Section) = sec.name.text == "Metadata"
 fun validateMetaDataSection(
     section: Section, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(section, tracker) {
+    track(section, tracker) {
         val items = mutableListOf<MetaDataItem>()
         for (arg in section.args) {
             if (isReferenceGroup(arg.chalkTalkTarget)) {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/OffsetItemSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/OffsetItemSection.kt
@@ -25,7 +25,7 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_OFFSET_ITEM_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.indentedStringSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -45,7 +45,7 @@ data class OffsetItemSection(val offset: String) : Phase2Node {
 fun validateOffsetItemSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node, errors, "offset", DEFAULT_OFFSET_ITEM_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_OFFSET_ITEM_SECTION, "string") { arg ->
                 if (arg !is Phase1Token || arg.type != ChalkTalkTokenType.String) {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/PageItemSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/PageItemSection.kt
@@ -25,7 +25,7 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_PAGE_ITEM_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.indentedStringSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -45,7 +45,7 @@ data class PageItemSection(val page: String) : Phase2Node {
 fun validatePageItemSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node, errors, "page", DEFAULT_PAGE_ITEM_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_PAGE_ITEM_SECTION, "string") { arg ->
                 if (arg !is Phase1Token || arg.type != ChalkTalkTokenType.String) {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/ReferenceSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/ReferenceSection.kt
@@ -22,7 +22,7 @@ import mathlingua.chalktalk.phase2.ast.DEFAULT_REFERENCE_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.SourceItemGroup
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.validateSourceItemGroup
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -49,7 +49,7 @@ data class ReferenceSection(val sourceItems: List<SourceItemGroup>) : Phase2Node
 fun validateReferenceSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node, errors, "reference", DEFAULT_REFERENCE_SECTION) { section ->
             ReferenceSection(
                 sourceItems = section.args.map { validateSourceItemGroup(it, errors, tracker) })

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/SourceItemSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/SourceItemSection.kt
@@ -25,7 +25,7 @@ import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_SOURCE_ITEM_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.chalktalk.phase2.ast.group.toplevel.shared.metadata.indentedStringSection
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.support.MutableLocationTracker
@@ -45,7 +45,7 @@ data class SourceItemSection(val sourceReference: String) : Phase2Node {
 fun validateSourceItemSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node, errors, "source", DEFAULT_SOURCE_ITEM_SECTION) { section ->
             validateSingleArg(section, errors, DEFAULT_SOURCE_ITEM_SECTION, "string") { arg ->
                 if (arg !is Phase1Token || arg.type != ChalkTalkTokenType.String) {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/StringSection.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/StringSection.kt
@@ -24,7 +24,7 @@ import mathlingua.chalktalk.phase1.ast.getRow
 import mathlingua.chalktalk.phase2.CodeWriter
 import mathlingua.chalktalk.phase2.ast.DEFAULT_STRING_SECTION
 import mathlingua.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.chalktalk.phase2.ast.neoTrack
+import mathlingua.chalktalk.phase2.ast.track
 import mathlingua.chalktalk.phase2.ast.validateSection
 import mathlingua.support.MutableLocationTracker
 import mathlingua.support.ParseError
@@ -55,7 +55,7 @@ class StringSection(val name: String, val values: List<String>) : Phase2Node {
 fun validateStringSection(
     name: String, node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
-    neoTrack(node, tracker) {
+    track(node, tracker) {
         validateSection(node, errors, name, DEFAULT_STRING_SECTION) { section ->
             if (section.args.isNotEmpty() &&
                 !section.args.all {

--- a/src/main/kotlin/mathlingua/chalktalk/phase2/ast/section/SectionIdentification.kt
+++ b/src/main/kotlin/mathlingua/chalktalk/phase2/ast/section/SectionIdentification.kt
@@ -24,21 +24,21 @@ import mathlingua.chalktalk.phase1.ast.getColumn
 import mathlingua.chalktalk.phase1.ast.getRow
 import mathlingua.support.ParseError
 
-fun <T, U> neoEnsureNonNull(value: T?, default: U, builder: (value: T) -> U) =
+fun <T, U> ensureNonNull(value: T?, default: U, builder: (value: T) -> U) =
     if (value == null) {
         default
     } else {
         builder(value)
     }
 
-fun <T, U> neoIfNonNull(value: T?, builder: (value: T) -> U) =
+fun <T, U> ifNonNull(value: T?, builder: (value: T) -> U) =
     if (value == null) {
         null
     } else {
         builder(value)
     }
 
-fun <T> neoIdentifySections(
+fun <T> identifySections(
     group: Group,
     errors: MutableList<ParseError>,
     default: T,

--- a/src/test/resources/goldens/messages/invalid_phase1/Unrecognized_token/messages.txt
+++ b/src/test/resources/goldens/messages/invalid_phase1/Unrecognized_token/messages.txt
@@ -1,4 +1,11 @@
 Row: 9
+Column: 10
+Message:
+Unrecognized character ;
+EndMessage:
+
+
+Row: 9
 Column: 4
 Message:
 Unrecognized token 'Result


### PR DESCRIPTION
In addition, the ChalkTalkLexer initialization code was
simplified.
