### PR TITLE
feat: support Defines:generated signatures

### DIFF
--- a/src/main/kotlin/mathlingua/backend/SymbolAnalyzer.kt
+++ b/src/main/kotlin/mathlingua/backend/SymbolAnalyzer.kt
@@ -17,6 +17,7 @@
 package mathlingua.backend
 
 import java.lang.StringBuilder
+import mathlingua.backend.transform.Signature
 import mathlingua.backend.transform.normalize
 import mathlingua.backend.transform.signature
 import mathlingua.frontend.chalktalk.phase2.ast.clause.AbstractionNode
@@ -38,17 +39,16 @@ import mathlingua.frontend.textalk.IsTexTalkNode
 import mathlingua.frontend.textalk.TexTalkNode
 import mathlingua.frontend.textalk.TextTexTalkNode
 
-class SymbolAnalyzer(defines: List<ValueSourceTracker<DefinesGroup>>) {
+class SymbolAnalyzer(defines: List<Pair<ValueSourceTracker<Signature>, DefinesGroup>>) {
     private val signatureMap = mutableMapOf<String, Set<String>>()
 
     init {
-        for (vst in defines) {
-            val sig = vst.value.signature
-            if (sig != null) {
-                val name = getTargetName(vst.value.definesSection.targets[0])
-                signatureMap[sig] =
-                    getDefSignatures(vst.value, name, vst.tracker ?: newLocationTracker())
-            }
+        for (pair in defines) {
+            val sig = pair.first.value
+            val def = pair.second
+            val name = getTargetName(def.definesSection.targets[0])
+            signatureMap[sig.form] =
+                getDefSignatures(def, name, pair.first.tracker ?: newLocationTracker())
         }
     }
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Document.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Document.kt
@@ -38,6 +38,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.mutua
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.states.StatesGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.states.isStatesGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.states.validateStatesGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.views.ViewsGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.views.isViewsGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.views.validateViewsGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.entry.isEntryGroup
@@ -66,6 +67,7 @@ data class Document(val groups: List<TopLevelGroup>) : Phase2Node {
 
     fun defines() = groups.filterIsInstance<DefinesGroup>()
     fun states() = groups.filterIsInstance<StatesGroup>()
+    fun views() = groups.filterIsInstance<ViewsGroup>()
     fun foundations() = groups.filterIsInstance<FoundationGroup>()
     fun mutually() = groups.filterIsInstance<MutuallyGroup>()
     fun theorems() = groups.filterIsInstance<TheoremGroup>()


### PR DESCRIPTION
The signatures in `Defines:generated` groups in the `constant`
and `constructor` sections are now understood as being defined.
