### PR TITLE
feat: support symbol definitions in `using:`

### DIFF
--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/TopLevelGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/TopLevelGroup.kt
@@ -19,6 +19,7 @@ package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
 import mathlingua.frontend.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 
 abstract class TopLevelGroup(open val metaDataSection: MetaDataSection?) : Phase2Node
@@ -47,4 +48,8 @@ fun topLevelToCode(
     writer.endTopLevel()
 
     return writer
+}
+
+internal interface HasUsingSection {
+    val usingSection: UsingSection?
 }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
@@ -54,7 +54,7 @@ data class DefinesCollectsGroup(
     val whereSection: WhereSection?,
     val whenSection: WhenSection?,
     val collectsSection: CollectsSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
 ) : DefinesGroup(metaDataSection) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
@@ -54,7 +54,7 @@ data class DefinesEvaluatedGroup(
     val whereSection: WhereSection?,
     val whenSection: WhenSection?,
     val evaluatedSection: EvaluatedSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
 ) : DefinesGroup(metaDataSection) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
@@ -54,7 +54,7 @@ data class DefinesGeneratedGroup(
     val whereSection: WhereSection?,
     val whenSection: WhenSection?,
     val generatedSection: GeneratedSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
 ) : DefinesGroup(metaDataSection) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
@@ -19,6 +19,7 @@ package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defi
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.frontend.chalktalk.phase2.ast.clause.firstSectionMatchesName
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.HasUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
@@ -27,7 +28,7 @@ import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
 
 abstract class DefinesGroup(override val metaDataSection: MetaDataSection?) :
-    TopLevelGroup(metaDataSection), DefinesStatesOrViews {
+    TopLevelGroup(metaDataSection), HasUsingSection, DefinesStatesOrViews {
     abstract val signature: String?
     abstract val definesSection: DefinesSection
     abstract val id: IdStatement

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesInstantiatedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesInstantiatedGroup.kt
@@ -51,7 +51,7 @@ data class DefinesInstantiatedGroup(
     override val definesSection: DefinesSection,
     val whenSection: WhenSection?,
     val instantiatedSection: InstantiatedSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
 ) : DefinesGroup(metaDataSection) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
@@ -54,7 +54,7 @@ data class DefinesMapsGroup(
     val whereSection: WhereSection?,
     val whenSection: WhenSection?,
     val mapsSection: MapsSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
 ) : DefinesGroup(metaDataSection) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
@@ -54,7 +54,7 @@ data class DefinesMeansGroup(
     val whereSection: WhereSection?,
     val whenSection: WhenSection?,
     val meansSection: MeansSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
 ) : DefinesGroup(metaDataSection) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/evaluates/EvaluatesGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/evaluates/EvaluatesGroup.kt
@@ -33,6 +33,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.clause.If.isThenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.If.validateElseSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.If.validateThenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.WhenThenPair
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.HasUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
@@ -60,10 +61,10 @@ data class EvaluatesGroup(
     val evaluatesSection: EvaluatesSection,
     val whenThen: List<WhenThenPair>,
     val elseSection: ElseSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     val writtenSection: WrittenSection?,
     override val metaDataSection: MetaDataSection?
-) : TopLevelGroup(metaDataSection), DefinesStatesOrViews {
+) : TopLevelGroup(metaDataSection), HasUsingSection, DefinesStatesOrViews {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(id)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/states/StatesGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/states/StatesGroup.kt
@@ -27,6 +27,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.frontend.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getId
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.HasUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
@@ -52,10 +53,10 @@ data class StatesGroup(
     val statesSection: StatesSection,
     val whenSection: WhenSection?,
     val thatSection: ThatSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     val writtenSection: WrittenSection?,
     override val metaDataSection: MetaDataSection?
-) : TopLevelGroup(metaDataSection), DefinesStatesOrViews {
+) : TopLevelGroup(metaDataSection), HasUsingSection, DefinesStatesOrViews {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(id)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/views/ViewsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/views/ViewsGroup.kt
@@ -29,6 +29,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.frontend.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getId
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.HasUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
@@ -51,9 +52,9 @@ data class ViewsGroup(
     val singleFromSection: SingleFromSection,
     val singleToSection: SingleToSection,
     val asSection: SingleAsSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     override val metaDataSection: MetaDataSection?
-) : TopLevelGroup(metaDataSection), DefinesStatesOrViews {
+) : TopLevelGroup(metaDataSection), HasUsingSection, DefinesStatesOrViews {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(id)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/resultlike/axiom/AxiomGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/resultlike/axiom/AxiomGroup.kt
@@ -28,6 +28,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getOptionalId
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.If.ThenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.If.validateThenSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.HasUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.resultlike.IfOrIffSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.GivenSection
@@ -56,9 +57,9 @@ data class AxiomGroup(
     val whereSection: WhereSection?,
     val ifOrIffSection: IfOrIffSection?,
     val thenSection: ThenSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     override val metaDataSection: MetaDataSection?
-) : TopLevelGroup(metaDataSection) {
+) : TopLevelGroup(metaDataSection), HasUsingSection {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         if (id != null) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/resultlike/conjecture/ConjectureGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/resultlike/conjecture/ConjectureGroup.kt
@@ -28,6 +28,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getOptionalId
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.If.ThenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.If.validateThenSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.HasUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.resultlike.IfOrIffSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.GivenSection
@@ -56,9 +57,9 @@ data class ConjectureGroup(
     val ifOrIffSection: IfOrIffSection?,
     val whereSection: WhereSection?,
     val thenSection: ThenSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     override val metaDataSection: MetaDataSection?
-) : TopLevelGroup(metaDataSection) {
+) : TopLevelGroup(metaDataSection), HasUsingSection {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         if (id != null) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/resultlike/theorem/TheoremGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/resultlike/theorem/TheoremGroup.kt
@@ -28,6 +28,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getOptionalId
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.If.ThenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.If.validateThenSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.HasUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.resultlike.IfOrIffSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.resultlike.validateIfOrIffSection
@@ -54,9 +55,9 @@ data class TheoremGroup(
     val givenWhereSection: WhereSection?,
     val ifOrIffSection: IfOrIffSection?,
     val thenSection: ThenSection,
-    val usingSection: UsingSection?,
+    override val usingSection: UsingSection?,
     override val metaDataSection: MetaDataSection?
-) : TopLevelGroup(metaDataSection) {
+) : TopLevelGroup(metaDataSection), HasUsingSection {
 
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         if (id != null) {


### PR DESCRIPTION
For example, given
```
Theorem:
given: a, b
then:
. 'a *** b = 0'
. 'b = 1'
using:
. 'a *** b := a'
. '0 := \something'
```
then `***` and `0` are understood as being defined while `1` is
marked as an undefined symbol.
