### PR TITLE
chore: don't always print index.html generated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ apply plugin: 'application'
 apply plugin: 'jacoco'
 
 group = 'mathlingua'
-version = '0.7'
+version = '0.13'
 sourceCompatibility = '1.8'
 
 mainClassName = 'mathlingua.MainKt'

--- a/src/main/kotlin/mathlingua/Main.kt
+++ b/src/main/kotlin/mathlingua/Main.kt
@@ -38,7 +38,7 @@ import mathlingua.backend.newSourceCollectionFromFiles
 import mathlingua.frontend.support.ParseError
 import mathlingua.frontend.support.validationFailure
 
-const val TOOL_VERSION = "0.12"
+const val TOOL_VERSION = "0.13"
 
 const val MATHLINGUA_VERSION = "0.8"
 
@@ -146,7 +146,7 @@ private class Render :
             docsDir.mkdirs()
 
             val html = format == "html"
-            if (html) {
+            if (html && !stdout) {
                 val indexFile = writeIndexFile(cwd, docsDir)
                 log("Wrote ${indexFile.relativeTo(cwd)}")
             }


### PR DESCRIPTION
If the `--stdout` option is given to `mlg render` then don't
print that `index.html` was generated.  This is consistent with
the other status messages printed by `mlg render`.
