### PR TITLE
fix: variables in `given:` are recognized

### DIFF
--- a/src/main/kotlin/mathlingua/backend/SourceCollection.kt
+++ b/src/main/kotlin/mathlingua/backend/SourceCollection.kt
@@ -509,21 +509,24 @@ class SourceCollectionImpl(sources: List<SourceFile>) : SourceCollection {
 
                     val allDefines = mutableListOf<DefinesGroup>()
                     allDefines.addAll(doc.defines())
-                    allDefines.addAll(foundations.map {
-                        it.foundationSection.content
-                    }.filterIsInstance<DefinesGroup>())
+                    allDefines.addAll(
+                        foundations
+                            .map { it.foundationSection.content }
+                            .filterIsInstance<DefinesGroup>())
 
                     val allViews = mutableListOf<ViewsGroup>()
                     allViews.addAll(doc.views())
-                    allViews.addAll(foundations.map {
-                        it.foundationSection.content
-                    }.filterIsInstance<ViewsGroup>())
+                    allViews.addAll(
+                        foundations
+                            .map { it.foundationSection.content }
+                            .filterIsInstance<ViewsGroup>())
 
                     val allStates = mutableListOf<StatesGroup>()
                     allStates.addAll(doc.states())
-                    allStates.addAll(foundations.map {
-                        it.foundationSection.content
-                    }.filterIsInstance<StatesGroup>())
+                    allStates.addAll(
+                        foundations
+                            .map { it.foundationSection.content }
+                            .filterIsInstance<StatesGroup>())
 
                     val allSigRoot = mutableListOf<Validation<TexTalkNode>>()
                     allSigRoot.addAll(allDefines.map { it.id.texTalkRoot })
@@ -534,7 +537,8 @@ class SourceCollectionImpl(sources: List<SourceFile>) : SourceCollection {
                         if (vald is ValidationFailure) {
                             result.addAll(
                                 vald.errors.map {
-                                    ValueSourceTracker(source = sf.value, tracker = null, value = it)
+                                    ValueSourceTracker(
+                                        source = sf.value, tracker = null, value = it)
                                 })
                         }
                     }

--- a/src/main/kotlin/mathlingua/backend/SourceCollection.kt
+++ b/src/main/kotlin/mathlingua/backend/SourceCollection.kt
@@ -503,6 +503,42 @@ class SourceCollectionImpl(sources: List<SourceFile>) : SourceCollection {
                             ValueSourceTracker(source = sf.value, tracker = null, value = it)
                         })
                 }
+                is ValidationSuccess -> {
+                    val doc = validation.value.document
+                    val foundations = doc.foundations()
+
+                    val allDefines = mutableListOf<DefinesGroup>()
+                    allDefines.addAll(doc.defines())
+                    allDefines.addAll(foundations.map {
+                        it.foundationSection.content
+                    }.filterIsInstance<DefinesGroup>())
+
+                    val allViews = mutableListOf<ViewsGroup>()
+                    allViews.addAll(doc.views())
+                    allViews.addAll(foundations.map {
+                        it.foundationSection.content
+                    }.filterIsInstance<ViewsGroup>())
+
+                    val allStates = mutableListOf<StatesGroup>()
+                    allStates.addAll(doc.states())
+                    allStates.addAll(foundations.map {
+                        it.foundationSection.content
+                    }.filterIsInstance<StatesGroup>())
+
+                    val allSigRoot = mutableListOf<Validation<TexTalkNode>>()
+                    allSigRoot.addAll(allDefines.map { it.id.texTalkRoot })
+                    allSigRoot.addAll(allViews.map { it.id.texTalkRoot })
+                    allSigRoot.addAll(allStates.map { it.id.texTalkRoot })
+
+                    for (vald in allSigRoot) {
+                        if (vald is ValidationFailure) {
+                            result.addAll(
+                                vald.errors.map {
+                                    ValueSourceTracker(source = sf.value, tracker = null, value = it)
+                                })
+                        }
+                    }
+                }
             }
         }
         return result

--- a/src/main/kotlin/mathlingua/backend/transform/VarUtil.kt
+++ b/src/main/kotlin/mathlingua/backend/transform/VarUtil.kt
@@ -28,6 +28,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.clause.TupleNode
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.exists.ExistsGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.forAll.ForAllGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.clause.given.GivenGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.HasUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.DefinesGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.DefinesSection
@@ -309,6 +310,20 @@ private fun checkVarsImpl(
                 vars.add(v)
             }
             varsToRemove.addAll(existsVars)
+        }
+        is GivenGroup -> {
+            val givenVars = node.givenSection.targets.map { getVars(it) }.flatten()
+            for (v in givenVars) {
+                if (vars.contains(v)) {
+                    errors.add(
+                        ParseError(
+                            message = "Duplicate defined symbol '$v'",
+                            row = location.row,
+                            column = location.column))
+                }
+                vars.add(v)
+            }
+            varsToRemove.addAll(givenVars)
         }
         is Statement -> {
             varsToRemove.addAll(checkVarsImpl(node, vars, tracker, errors))


### PR DESCRIPTION
If a variable is introduced in a `given:`, it is now recognized.
Previously, usage of any such variable was marked as undefined.

In addition, parse errors in ids are reported to the user.
