### PR TITLE
chore: `Defines:` uses `specifies:` section

### DIFF
--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
@@ -97,6 +97,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defin
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.MeansSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.ProvidedSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.RequiringSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.SpecifiesSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.evaluates.EvaluatesGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.evaluates.EvaluatesSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.FoundationGroup
@@ -387,6 +388,8 @@ val DEFAULT_WHEN_SECTION = WhenSection(clauses = DEFAULT_CLAUSE_LIST_NODE)
 
 val DEFAULT_WHERE_SECTION = WhereSection(clauses = DEFAULT_CLAUSE_LIST_NODE)
 
+val DEFAULT_SPECIFIES_SECTION = SpecifiesSection(clauses = DEFAULT_CLAUSE_LIST_NODE)
+
 val DEFAULT_ALL_SECTION = AllSection(statement = DEFAULT_STATEMENT)
 
 val DEFAULT_OF_SECTION = OfSection(statement = DEFAULT_STATEMENT)
@@ -640,8 +643,8 @@ val DEFAULT_DEFINES_MEANS_GROUP =
         id = DEFAULT_ID_STATEMENT,
         definesSection = DEFAULT_DEFINES_SECTION,
         requiringSection = DEFAULT_REQUIRING_SECTION,
-        whereSection = DEFAULT_WHERE_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
+        specifiesSection = DEFAULT_SPECIFIES_SECTION,
         meansSection = DEFAULT_MEANS_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
@@ -665,8 +668,8 @@ val DEFAULT_DEFINES_EVALUATED_GROUP =
         id = DEFAULT_ID_STATEMENT,
         definesSection = DEFAULT_DEFINES_SECTION,
         requiringSection = DEFAULT_REQUIRING_SECTION,
-        whereSection = DEFAULT_WHERE_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
+        specifiesSection = DEFAULT_SPECIFIES_SECTION,
         evaluatedSection = DEFAULT_EVALUATED_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
@@ -678,8 +681,8 @@ val DEFAULT_DEFINES_COLLECTS_GROUP =
         id = DEFAULT_ID_STATEMENT,
         definesSection = DEFAULT_DEFINES_SECTION,
         requiringSection = DEFAULT_REQUIRING_SECTION,
-        whereSection = DEFAULT_WHERE_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
+        specifiesSection = DEFAULT_SPECIFIES_SECTION,
         collectsSection = DEFAULT_COLLECTS_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
@@ -691,8 +694,8 @@ val DEFAULT_DEFINES_MAPS_GROUP =
         id = DEFAULT_ID_STATEMENT,
         definesSection = DEFAULT_DEFINES_SECTION,
         requiringSection = DEFAULT_REQUIRING_SECTION,
-        whereSection = DEFAULT_WHERE_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
+        specifiesSection = DEFAULT_SPECIFIES_SECTION,
         mapsSection = DEFAULT_MAPS_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
@@ -704,8 +707,8 @@ val DEFAULT_DEFINES_GENERATED_GROUP =
         id = DEFAULT_ID_STATEMENT,
         definesSection = DEFAULT_DEFINES_SECTION,
         requiringSection = DEFAULT_REQUIRING_SECTION,
-        whereSection = DEFAULT_WHERE_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
+        specifiesSection = DEFAULT_SPECIFIES_SECTION,
         generatedSection = DEFAULT_GENERATED_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
@@ -32,12 +32,10 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.Writt
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.topLevelToCode
 import mathlingua.frontend.chalktalk.phase2.ast.section.ensureNonNull
 import mathlingua.frontend.chalktalk.phase2.ast.section.identifySections
@@ -52,8 +50,8 @@ data class DefinesCollectsGroup(
     override val id: IdStatement,
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
-    val whereSection: WhereSection?,
     val whenSection: WhenSection?,
+    val specifiesSection: SpecifiesSection?,
     val collectsSection: CollectsSection,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
@@ -66,11 +64,11 @@ data class DefinesCollectsGroup(
         if (requiringSection != null) {
             fn(requiringSection)
         }
-        if (whereSection != null) {
-            fn(whereSection)
-        }
         if (whenSection != null) {
             fn(whenSection)
+        }
+        if (specifiesSection != null) {
+            fn(specifiesSection)
         }
         fn(collectsSection)
         if (usingSection != null) {
@@ -87,8 +85,8 @@ data class DefinesCollectsGroup(
             mutableListOf(
                 definesSection,
                 requiringSection,
-                whereSection,
                 whenSection,
+                specifiesSection,
                 collectsSection,
                 writtenSection,
                 metaDataSection)
@@ -103,8 +101,9 @@ data class DefinesCollectsGroup(
                 definesSection = definesSection.transform(chalkTransformer) as DefinesSection,
                 requiringSection =
                     requiringSection?.transform(chalkTransformer) as RequiringSection?,
-                whereSection = whereSection?.transform(chalkTransformer) as WhereSection?,
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
+                specifiesSection =
+                    specifiesSection?.transform(chalkTransformer) as SpecifiesSection?,
                 collectsSection = collectsSection.transform(chalkTransformer) as CollectsSection,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
@@ -125,8 +124,8 @@ fun validateDefinesCollectsGroup(
                 listOf(
                     "Defines",
                     "requiring?",
-                    "where?",
                     "when?",
+                    "specifies?",
                     "collects",
                     "using?",
                     "written",
@@ -143,10 +142,12 @@ fun validateDefinesCollectsGroup(
                         ifNonNull(sections["requiring"]) {
                             validateRequiringSection(it, errors, tracker)
                         },
-                    whereSection =
-                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     whenSection =
                         ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                    specifiesSection =
+                        ifNonNull(sections["specifies"]) {
+                            validateSpecifiesSection(it, errors, tracker)
+                        },
                     collectsSection =
                         ensureNonNull(sections["collects"], DEFAULT_COLLECTS_SECTION) {
                             validateCollectsSection(it, errors, tracker)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
@@ -32,12 +32,10 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.Writt
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.topLevelToCode
 import mathlingua.frontend.chalktalk.phase2.ast.section.ensureNonNull
 import mathlingua.frontend.chalktalk.phase2.ast.section.identifySections
@@ -52,8 +50,8 @@ data class DefinesEvaluatedGroup(
     override val id: IdStatement,
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
-    val whereSection: WhereSection?,
     val whenSection: WhenSection?,
+    val specifiesSection: SpecifiesSection?,
     val evaluatedSection: EvaluatedSection,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
@@ -66,11 +64,11 @@ data class DefinesEvaluatedGroup(
         if (requiringSection != null) {
             fn(requiringSection)
         }
-        if (whereSection != null) {
-            fn(whereSection)
-        }
         if (whenSection != null) {
             fn(whenSection)
+        }
+        if (specifiesSection != null) {
+            fn(specifiesSection)
         }
         fn(evaluatedSection)
         if (usingSection != null) {
@@ -87,8 +85,8 @@ data class DefinesEvaluatedGroup(
             mutableListOf(
                 definesSection,
                 requiringSection,
-                whereSection,
                 whenSection,
+                specifiesSection,
                 evaluatedSection,
                 writtenSection,
                 metaDataSection)
@@ -103,8 +101,9 @@ data class DefinesEvaluatedGroup(
                 definesSection = definesSection.transform(chalkTransformer) as DefinesSection,
                 requiringSection =
                     requiringSection?.transform(chalkTransformer) as RequiringSection?,
-                whereSection = whereSection?.transform(chalkTransformer) as WhereSection?,
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
+                specifiesSection =
+                    specifiesSection?.transform(chalkTransformer) as SpecifiesSection?,
                 evaluatedSection = evaluatedSection.transform(chalkTransformer) as EvaluatedSection,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
@@ -125,8 +124,8 @@ fun validateDefinesEvaluatedGroup(
                 listOf(
                     "Defines",
                     "requiring?",
-                    "where?",
                     "when?",
+                    "specifies?",
                     "evaluated",
                     "using?",
                     "written",
@@ -143,10 +142,12 @@ fun validateDefinesEvaluatedGroup(
                         ifNonNull(sections["requiring"]) {
                             validateRequiringSection(it, errors, tracker)
                         },
-                    whereSection =
-                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     whenSection =
                         ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                    specifiesSection =
+                        ifNonNull(sections["specifies"]) {
+                            validateSpecifiesSection(it, errors, tracker)
+                        },
                     evaluatedSection =
                         ensureNonNull(sections["evaluated"], DEFAULT_EVALUATED_SECTION) {
                             validateEvaluatedSection(it, errors, tracker)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
@@ -32,12 +32,10 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.Writt
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.topLevelToCode
 import mathlingua.frontend.chalktalk.phase2.ast.section.ensureNonNull
 import mathlingua.frontend.chalktalk.phase2.ast.section.identifySections
@@ -52,8 +50,8 @@ data class DefinesGeneratedGroup(
     override val id: IdStatement,
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
-    val whereSection: WhereSection?,
     val whenSection: WhenSection?,
+    val specifiesSection: SpecifiesSection?,
     val generatedSection: GeneratedSection,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
@@ -66,11 +64,11 @@ data class DefinesGeneratedGroup(
         if (requiringSection != null) {
             fn(requiringSection)
         }
-        if (whereSection != null) {
-            fn(whereSection)
-        }
         if (whenSection != null) {
             fn(whenSection)
+        }
+        if (specifiesSection != null) {
+            fn(specifiesSection)
         }
         fn(generatedSection)
         if (usingSection != null) {
@@ -87,8 +85,8 @@ data class DefinesGeneratedGroup(
             mutableListOf(
                 definesSection,
                 requiringSection,
-                whereSection,
                 whenSection,
+                specifiesSection,
                 generatedSection,
                 writtenSection,
                 metaDataSection)
@@ -103,8 +101,9 @@ data class DefinesGeneratedGroup(
                 definesSection = definesSection.transform(chalkTransformer) as DefinesSection,
                 requiringSection =
                     requiringSection?.transform(chalkTransformer) as RequiringSection?,
-                whereSection = whereSection?.transform(chalkTransformer) as WhereSection?,
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
+                specifiesSection =
+                    specifiesSection?.transform(chalkTransformer) as SpecifiesSection?,
                 generatedSection = generatedSection.transform(chalkTransformer) as GeneratedSection,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
@@ -125,8 +124,8 @@ fun validateDefinesGeneratedGroup(
                 listOf(
                     "Defines",
                     "requiring?",
-                    "where?",
                     "when?",
+                    "specifies?",
                     "generated",
                     "using?",
                     "written",
@@ -143,10 +142,12 @@ fun validateDefinesGeneratedGroup(
                         ifNonNull(sections["requiring"]) {
                             validateRequiringSection(it, errors, tracker)
                         },
-                    whereSection =
-                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     whenSection =
                         ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                    specifiesSection =
+                        ifNonNull(sections["specifies"]) {
+                            validateSpecifiesSection(it, errors, tracker)
+                        },
                     generatedSection =
                         ensureNonNull(sections["generated"], DEFAULT_GENERATED_SECTION) {
                             validateGeneratedSection(it, errors, tracker)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
@@ -29,10 +29,10 @@ import mathlingua.frontend.support.ParseError
 
 abstract class DefinesGroup(override val metaDataSection: MetaDataSection?) :
     TopLevelGroup(metaDataSection), HasUsingSection, DefinesStatesOrViews {
+    abstract val id: IdStatement
     abstract val signature: String?
     abstract val definesSection: DefinesSection
     abstract val requiringSection: RequiringSection?
-    abstract val id: IdStatement
     abstract val writtenSection: WrittenSection
 }
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
@@ -32,12 +32,10 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.Writt
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.topLevelToCode
 import mathlingua.frontend.chalktalk.phase2.ast.section.ensureNonNull
 import mathlingua.frontend.chalktalk.phase2.ast.section.identifySections
@@ -52,8 +50,8 @@ data class DefinesMapsGroup(
     override val id: IdStatement,
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
-    val whereSection: WhereSection?,
     val whenSection: WhenSection?,
+    val specifiesSection: SpecifiesSection?,
     val mapsSection: MapsSection,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
@@ -66,11 +64,11 @@ data class DefinesMapsGroup(
         if (requiringSection != null) {
             fn(requiringSection)
         }
-        if (whereSection != null) {
-            fn(whereSection)
-        }
         if (whenSection != null) {
             fn(whenSection)
+        }
+        if (specifiesSection != null) {
+            fn(specifiesSection)
         }
         fn(mapsSection)
         if (usingSection != null) {
@@ -87,8 +85,8 @@ data class DefinesMapsGroup(
             mutableListOf(
                 definesSection,
                 requiringSection,
-                whereSection,
                 whenSection,
+                specifiesSection,
                 mapsSection,
                 writtenSection,
                 metaDataSection)
@@ -103,8 +101,9 @@ data class DefinesMapsGroup(
                 definesSection = definesSection.transform(chalkTransformer) as DefinesSection,
                 requiringSection =
                     requiringSection?.transform(chalkTransformer) as RequiringSection?,
-                whereSection = whereSection?.transform(chalkTransformer) as WhereSection?,
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
+                specifiesSection =
+                    specifiesSection?.transform(chalkTransformer) as SpecifiesSection?,
                 mapsSection = mapsSection.transform(chalkTransformer) as MapsSection,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
@@ -125,8 +124,8 @@ fun validateDefinesMapsGroup(
                 listOf(
                     "Defines",
                     "requiring?",
-                    "where?",
                     "when?",
+                    "specifies?",
                     "maps",
                     "using?",
                     "written",
@@ -143,10 +142,12 @@ fun validateDefinesMapsGroup(
                         ifNonNull(sections["requiring"]) {
                             validateRequiringSection(it, errors, tracker)
                         },
-                    whereSection =
-                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     whenSection =
                         ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                    specifiesSection =
+                        ifNonNull(sections["specifies"]) {
+                            validateSpecifiesSection(it, errors, tracker)
+                        },
                     mapsSection =
                         ensureNonNull(sections["maps"], DEFAULT_MAPS_SECTION) {
                             validateMapsSection(it, errors, tracker)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
@@ -32,12 +32,10 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.Writt
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateMetaDataSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateWhenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.topLevelToCode
 import mathlingua.frontend.chalktalk.phase2.ast.section.ensureNonNull
 import mathlingua.frontend.chalktalk.phase2.ast.section.identifySections
@@ -52,8 +50,8 @@ data class DefinesMeansGroup(
     override val id: IdStatement,
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
-    val whereSection: WhereSection?,
     val whenSection: WhenSection?,
+    val specifiesSection: SpecifiesSection?,
     val meansSection: MeansSection,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
@@ -66,11 +64,11 @@ data class DefinesMeansGroup(
         if (requiringSection != null) {
             fn(requiringSection)
         }
-        if (whereSection != null) {
-            fn(whereSection)
-        }
         if (whenSection != null) {
             fn(whenSection)
+        }
+        if (specifiesSection != null) {
+            fn(specifiesSection)
         }
         fn(meansSection)
         if (usingSection != null) {
@@ -87,8 +85,8 @@ data class DefinesMeansGroup(
             mutableListOf(
                 definesSection,
                 requiringSection,
-                whereSection,
                 whenSection,
+                specifiesSection,
                 meansSection,
                 writtenSection,
                 metaDataSection)
@@ -103,8 +101,9 @@ data class DefinesMeansGroup(
                 definesSection = definesSection.transform(chalkTransformer) as DefinesSection,
                 requiringSection =
                     requiringSection?.transform(chalkTransformer) as RequiringSection?,
-                whereSection = whereSection?.transform(chalkTransformer) as WhereSection?,
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
+                specifiesSection =
+                    specifiesSection?.transform(chalkTransformer) as SpecifiesSection?,
                 meansSection = meansSection.transform(chalkTransformer) as MeansSection,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
@@ -125,8 +124,8 @@ fun validateDefinesMeansGroup(
                 listOf(
                     "Defines",
                     "requiring?",
-                    "where?",
                     "when?",
+                    "specifies?",
                     "means",
                     "using?",
                     "written",
@@ -143,10 +142,12 @@ fun validateDefinesMeansGroup(
                         ifNonNull(sections["requiring"]) {
                             validateRequiringSection(it, errors, tracker)
                         },
-                    whereSection =
-                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
                     whenSection =
                         ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
+                    specifiesSection =
+                        ifNonNull(sections["specifies"]) {
+                            validateSpecifiesSection(it, errors, tracker)
+                        },
                     meansSection =
                         ensureNonNull(sections["means"], DEFAULT_MEANS_SECTION) {
                             validateMeansSection(it, errors, tracker)

--- a/src/test/kotlin/mathlingua/MathLinguaTest.kt
+++ b/src/test/kotlin/mathlingua/MathLinguaTest.kt
@@ -114,26 +114,26 @@ internal class MathLinguaTest {
                 """
             [\finite.set]
             Defines: X
-            where: 'X is \something'
+            specifies: 'X is \something'
             means: '\something'
             written: "something"
 
             [\infinite.set]
             Defines: X
-            where: 'X is \something'
+            specifies: 'X is \something'
             means: '\something.else'
             written: "something"
 
             [\finite.set]
             Defines: Y
-            where: 'X is \something'
+            specifies: 'X is \something'
             means: '\yet.something.else'
             written: "something"
         """.trimIndent(),
                 """
             [\set]
             Defines: X
-            where: 'X is \something'
+            specifies: 'X is \something'
             means:
             . if: X
               then: '\something.else'
@@ -259,20 +259,20 @@ internal class MathLinguaTest {
                 """
             [\finite.set]
             Defines: X
-            where: 'X is \something'
+            specifies: 'X is \something'
             means: '\something'
             written: "something"
 
             [\infinite.set]
             Defines: X
-            where: 'X is \something'
+            specifies: 'X is \something'
             means: '\something.else'
             written: "something"
         """.trimIndent(),
                 """
             [\set]
             Defines: X
-            where: 'X is \something'
+            specifies: 'X is \something'
             means:
             . if: X
               then: '\something.else'
@@ -307,20 +307,20 @@ internal class MathLinguaTest {
                 """
             [\finite.set]
             Defines: X
-            where: 'X is \something'
+            specifies: 'X is \something'
             means: '\something'
             written: "something"
 
             [\infinite.set]
             Defines: X
-            where: 'X is \something'
+            specifies: 'X is \something'
             means: '\something.else'
             written: "something"
         """.trimIndent(),
                 """
             [\set]
             Defines: X
-            where: 'X is \something'
+            specifies: 'X is \something'
             means:
             . if: X
               then: '\something.else'
@@ -333,7 +333,7 @@ internal class MathLinguaTest {
 
             [\set]
             Defines: Y
-            where: 'X is \something'
+            specifies: 'X is \something'
             means: '\yet.something.else'
             written: "something"
         """.trimIndent())

--- a/src/test/kotlin/mathlingua/backend/transform/SignatureUtilKtTest.kt
+++ b/src/test/kotlin/mathlingua/backend/transform/SignatureUtilKtTest.kt
@@ -33,7 +33,7 @@ internal class SignatureUtilKtTest {
     fun findAllStatementSignaturesNonGluedTest() {
         val validation =
             FrontEnd.parse(
-                "[\\xyz{x}]\nDefines: y\nwhere: 'something'\nmeans: 'something'\nwritten: \"something\"")
+                "[\\xyz{x}]\nDefines: y\nspecifies: 'something'\nmeans: 'something'\nwritten: \"something\"")
         val doc = (validation as ValidationSuccess).value
         val defines = doc.defines()
         assertThat(defines.size).isEqualTo(1)
@@ -48,7 +48,7 @@ internal class SignatureUtilKtTest {
     fun statementSignaturesNotAllowedToBeGluedTest() {
         val validation =
             FrontEnd.parse(
-                "[\\abc \\xyz{x}]\nDefines: y\nwhere: 'something'\nmeans: 'something'\n" +
+                "[\\abc \\xyz{x}]\nDefines: y\nspecifies: 'something'\nmeans: 'something'\n" +
                     "written: \"something\"")
         assertThat(validation is ValidationFailure)
         assertThat((validation as ValidationFailure).errors)
@@ -64,7 +64,7 @@ internal class SignatureUtilKtTest {
     fun findAllStatementSignaturesInfixTest() {
         val validation =
             FrontEnd.parse(
-                "[x \\abc/ y]\nDefines: y\nwhere: 'something'\nmeans: 'something'\n" +
+                "[x \\abc/ y]\nDefines: y\nspecifies: 'something'\nmeans: 'something'\n" +
                     "written: \"something\"")
         val doc = (validation as ValidationSuccess).value
         val defines = doc.defines()

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/input.math
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/input.math
@@ -1,5 +1,5 @@
 [\f{x...}]
 Defines: X...#x...
-where: 'X is \something'
+specifies: 'X is \something'
 means: "something for X...#x..."
 written: "something"

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-output.math
@@ -1,7 +1,7 @@
 [\f{x...}]
 Defines:
 . X...#x...
-where:
+specifies:
 . 'X is \something'
 means:
 . "something for X...#x..."

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-structure.txt
@@ -34,7 +34,7 @@ Root(
                             ),
                             Section(
                               name = Phase1Token(
-                                text = "where"
+                                text = "specifies"
                                 type = ChalkTalkTokenType.Name
                                 row = 2
                                 column = 1
@@ -45,7 +45,7 @@ Root(
                                            text = "'X is \something'"
                                            type = ChalkTalkTokenType.Statement
                                            row = 2
-                                           column = 8
+                                           column = 12
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-output.math
@@ -1,6 +1,6 @@
 [\f{x...}]
 Defines: X...#x...
-where:
+specifies:
 . 'X is \something'
 means:
 . "something for X...#x..."

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-structure.txt
@@ -74,7 +74,8 @@ Document(
                            ]
                )
                requiringSection = null
-               whereSection = WhereSection(
+               whenSection = null
+               specifiesSection = SpecifiesSection(
                  clauses = ClauseListNode(
                    clauses = [
                                Statement(
@@ -133,7 +134,6 @@ Document(
                              ]
                  )
                )
-               whenSection = null
                meansSection = MeansSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/input.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/input.math
@@ -1,6 +1,6 @@
 [\evens]
 Defines: X
-where: 'X is \set'
+specifies: 'X is \set'
 collects:
 . given: k
   where: 'k is \integer'

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-output.math
@@ -1,7 +1,7 @@
 [\evens]
 Defines:
 . X
-where:
+specifies:
 . 'X is \set'
 collects:
 . given:

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-structure.txt
@@ -34,7 +34,7 @@ Root(
                             ),
                             Section(
                               name = Phase1Token(
-                                text = "where"
+                                text = "specifies"
                                 type = ChalkTalkTokenType.Name
                                 row = 2
                                 column = 1
@@ -45,7 +45,7 @@ Root(
                                            text = "'X is \set'"
                                            type = ChalkTalkTokenType.Statement
                                            row = 2
-                                           column = 8
+                                           column = 12
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-output.math
@@ -1,6 +1,6 @@
 [\evens]
 Defines: X
-where:
+specifies:
 . 'X is \set'
 collects:
 . given: k

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-structure.txt
@@ -56,7 +56,8 @@ Document(
                            ]
                )
                requiringSection = null
-               whereSection = WhereSection(
+               whenSection = null
+               specifiesSection = SpecifiesSection(
                  clauses = ClauseListNode(
                    clauses = [
                                Statement(
@@ -115,7 +116,6 @@ Document(
                              ]
                  )
                )
-               whenSection = null
                collectsSection = CollectsSection(
                  givenGroup = GivenGroup(
                    givenSection = GivenSection(

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/input.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/input.math
@@ -1,6 +1,6 @@
 [\f(x)]
 Defines: f(x)
-where: 'f is \function'
+specifies: 'f is \function'
 maps:
 . from: 'A'
   to: 'A'

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-output.math
@@ -1,7 +1,7 @@
 [\f(x)]
 Defines:
 . f(x)
-where:
+specifies:
 . 'f is \function'
 maps:
 . from:

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-structure.txt
@@ -41,7 +41,7 @@ Root(
                             ),
                             Section(
                               name = Phase1Token(
-                                text = "where"
+                                text = "specifies"
                                 type = ChalkTalkTokenType.Name
                                 row = 2
                                 column = 1
@@ -52,7 +52,7 @@ Root(
                                            text = "'f is \function'"
                                            type = ChalkTalkTokenType.Statement
                                            row = 2
-                                           column = 8
+                                           column = 12
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-output.math
@@ -1,6 +1,6 @@
 [\f(x)]
 Defines: f(x)
-where:
+specifies:
 . 'f is \function'
 maps:
 . from: 'A'

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
@@ -80,7 +80,8 @@ Document(
                            ]
                )
                requiringSection = null
-               whereSection = WhereSection(
+               whenSection = null
+               specifiesSection = SpecifiesSection(
                  clauses = ClauseListNode(
                    clauses = [
                                Statement(
@@ -139,7 +140,6 @@ Document(
                              ]
                  )
                )
-               whenSection = null
                mapsSection = MapsSection(
                  fromGroup = FromGroup(
                    fromSection = FromSection(

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/input.math
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/input.math
@@ -1,5 +1,5 @@
 [A]
 Defines: B
-where: 'B is \something'
+specifies: 'B is \something'
 means: "C"
 written: "something"

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-output.math
@@ -1,7 +1,7 @@
 [A]
 Defines:
 . B
-where:
+specifies:
 . 'B is \something'
 means:
 . "C"

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-structure.txt
@@ -34,7 +34,7 @@ Root(
                             ),
                             Section(
                               name = Phase1Token(
-                                text = "where"
+                                text = "specifies"
                                 type = ChalkTalkTokenType.Name
                                 row = 2
                                 column = 1
@@ -45,7 +45,7 @@ Root(
                                            text = "'B is \something'"
                                            type = ChalkTalkTokenType.Statement
                                            row = 2
-                                           column = 8
+                                           column = 12
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-output.math
@@ -1,6 +1,6 @@
 [A]
 Defines: B
-where:
+specifies:
 . 'B is \something'
 means:
 . "C"

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-structure.txt
@@ -42,7 +42,8 @@ Document(
                            ]
                )
                requiringSection = null
-               whereSection = WhereSection(
+               whenSection = null
+               specifiesSection = SpecifiesSection(
                  clauses = ClauseListNode(
                    clauses = [
                                Statement(
@@ -101,7 +102,6 @@ Document(
                              ]
                  )
                )
-               whenSection = null
                meansSection = MeansSection(
                  clauses = ClauseListNode(
                    clauses = [

--- a/src/test/resources/goldens/messages/defines/Defines_assuming_spelled_wrong/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_assuming_spelled_wrong/messages.txt
@@ -5,8 +5,8 @@ For pattern:
 
 Defines:
 requiring?:
-where?:
 when?:
+specifies?:
 means:
 using?:
 written:

--- a/src/test/resources/goldens/messages/defines/Defines_id_paren_must_match_target/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_id_paren_must_match_target/messages.txt
@@ -5,8 +5,8 @@ For pattern:
 
 Defines:
 requiring?:
-where?:
 when?:
+specifies?:
 means:
 using?:
 written:
@@ -23,8 +23,8 @@ For pattern:
 
 Defines:
 requiring?:
-where?:
 when?:
+specifies?:
 means:
 using?:
 written:
@@ -41,8 +41,8 @@ For pattern:
 
 Defines:
 requiring?:
-where?:
 when?:
+specifies?:
 means:
 using?:
 written:
@@ -59,8 +59,8 @@ For pattern:
 
 Defines:
 requiring?:
-where?:
 when?:
+specifies?:
 means:
 using?:
 written:
@@ -77,8 +77,8 @@ For pattern:
 
 Defines:
 requiring?:
-where?:
 when?:
+specifies?:
 means:
 using?:
 written:
@@ -95,8 +95,8 @@ For pattern:
 
 Defines:
 requiring?:
-where?:
 when?:
+specifies?:
 means:
 using?:
 written:

--- a/src/test/resources/goldens/messages/defines/Defines_must_have_id/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_must_have_id/messages.txt
@@ -5,8 +5,8 @@ For pattern:
 
 Defines:
 requiring?:
-where?:
 when?:
+specifies?:
 means:
 using?:
 written:

--- a/src/test/resources/mathlingua.math
+++ b/src/test/resources/mathlingua.math
@@ -1,8 +1,8 @@
 
 [\something{A}]
 Defines: X
-where: 'X is \something.else'
 when: 'A is \something.else'
+specifies: 'X is \something.else'
 means: 'X is \some.other.thing'
 written: "\textrm{something} A?"
 
@@ -16,8 +16,8 @@ written: "\textrm{something} A?"
 
 [\some.function{A}(x)]
 Defines: f(x)
-where: 'f is \function'
 when: 'A is \something'
+specifies: 'f is \function'
 maps:
 . from: '\reals'
   to: '\reals'
@@ -26,7 +26,7 @@ written: "\textrm{some.function}(x?)"
 
 [\some.function2{A}(x)]
 Defines: f(x)
-when: 'A is \something'
+specifies: 'A is \something'
 maps:
 . from: '\reals'
   to: '\reals'
@@ -43,7 +43,7 @@ written: "\mathbb{Z}"
 
 [\naturals]
 Defines: N
-where: 'N is \type'
+specifies: 'N is \type'
 generated:
 . inductively:
   from:
@@ -66,7 +66,7 @@ written: "\mathbb{N}"
 
 [\even.primes]
 Defines: X
-where: 'X is \set'
+specifies: 'X is \set'
 collects:
 . given: p
   where: 'p is \prime'
@@ -87,7 +87,7 @@ written: "\textbf{even primes}"
 
 [\f1(x)]
 Defines: f(x)
-where: 'f is \function'
+specifies: 'f is \function'
 evaluated: 'f(x) := x + 1'
 written: "f1(x?)"
 
@@ -100,7 +100,7 @@ written: "f1(x?)"
 
 [\f2(x)]
 Defines: f(x)
-where: 'f is \function'
+specifies: 'f is \function'
 evaluated:
 . matching:
   . 'f(x?) ::= x + 1'
@@ -117,7 +117,7 @@ written: "f2(x?)"
 
 [\f3(x)]
 Defines: f(x)
-where: 'f is \function'
+specifies: 'f is \function'
 evaluated:
 . piecewise:
   when: 'x > 0'
@@ -149,7 +149,7 @@ that: 'A + B - C is \something'
 Foundation:
 . [\X]
   Defines: X
-  where: 'X is \something'
+  specifies: 'X is \something'
   means: 'X is \something.else'
   written: "X?"
 
@@ -157,7 +157,7 @@ Foundation:
 Foundation:
 . [\X]
   Defines: X
-  where: 'X is \set'
+  specifies: 'X is \set'
   collects:
   . given: x
     where: 'x'
@@ -169,12 +169,12 @@ Foundation:
 Mutually:
 . [\X]
   Defines: X
-  where: 'X is \X'
+  specifies: 'X is \X'
   means: 'X is \Y'
   written: "X?"
 . [\Y]
   Defines: Y
-  where: 'Y is \Y'
+  specifies: 'Y is \Y'
   means: 'Y is \X'
   written: "Y?"
 


### PR DESCRIPTION
The `specifies:` section is used instead of `where:`.
