### PR TITLE
feat!: `Defines` uses the new `satisfying` section

### DIFF
--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
@@ -97,7 +97,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defin
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.MeansSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.ProvidedSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.RequiringSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.SpecifiesSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.SatisfyingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.evaluates.EvaluatesGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.evaluates.EvaluatesSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.FoundationGroup
@@ -388,7 +388,7 @@ val DEFAULT_WHEN_SECTION = WhenSection(clauses = DEFAULT_CLAUSE_LIST_NODE)
 
 val DEFAULT_WHERE_SECTION = WhereSection(clauses = DEFAULT_CLAUSE_LIST_NODE)
 
-val DEFAULT_SPECIFIES_SECTION = SpecifiesSection(clauses = DEFAULT_CLAUSE_LIST_NODE)
+val DEFAULT_SATISFYING_SECTION = SatisfyingSection(clauses = DEFAULT_CLAUSE_LIST_NODE)
 
 val DEFAULT_ALL_SECTION = AllSection(statement = DEFAULT_STATEMENT)
 
@@ -644,7 +644,7 @@ val DEFAULT_DEFINES_MEANS_GROUP =
         definesSection = DEFAULT_DEFINES_SECTION,
         requiringSection = DEFAULT_REQUIRING_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
-        specifiesSection = DEFAULT_SPECIFIES_SECTION,
+        satisfyingSection = DEFAULT_SATISFYING_SECTION,
         meansSection = DEFAULT_MEANS_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
@@ -669,7 +669,7 @@ val DEFAULT_DEFINES_EVALUATED_GROUP =
         definesSection = DEFAULT_DEFINES_SECTION,
         requiringSection = DEFAULT_REQUIRING_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
-        specifiesSection = DEFAULT_SPECIFIES_SECTION,
+        meansSection = DEFAULT_MEANS_SECTION,
         evaluatedSection = DEFAULT_EVALUATED_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
@@ -682,7 +682,7 @@ val DEFAULT_DEFINES_COLLECTS_GROUP =
         definesSection = DEFAULT_DEFINES_SECTION,
         requiringSection = DEFAULT_REQUIRING_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
-        specifiesSection = DEFAULT_SPECIFIES_SECTION,
+        meansSection = DEFAULT_MEANS_SECTION,
         collectsSection = DEFAULT_COLLECTS_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
@@ -695,7 +695,7 @@ val DEFAULT_DEFINES_MAPS_GROUP =
         definesSection = DEFAULT_DEFINES_SECTION,
         requiringSection = DEFAULT_REQUIRING_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
-        specifiesSection = DEFAULT_SPECIFIES_SECTION,
+        meansSection = DEFAULT_MEANS_SECTION,
         mapsSection = DEFAULT_MAPS_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
@@ -708,7 +708,7 @@ val DEFAULT_DEFINES_GENERATED_GROUP =
         definesSection = DEFAULT_DEFINES_SECTION,
         requiringSection = DEFAULT_REQUIRING_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
-        specifiesSection = DEFAULT_SPECIFIES_SECTION,
+        meansSection = DEFAULT_MEANS_SECTION,
         generatedSection = DEFAULT_GENERATED_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
@@ -51,7 +51,7 @@ data class DefinesCollectsGroup(
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
     val whenSection: WhenSection?,
-    val specifiesSection: SpecifiesSection?,
+    val meansSection: MeansSection?,
     val collectsSection: CollectsSection,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
@@ -67,8 +67,8 @@ data class DefinesCollectsGroup(
         if (whenSection != null) {
             fn(whenSection)
         }
-        if (specifiesSection != null) {
-            fn(specifiesSection)
+        if (meansSection != null) {
+            fn(meansSection)
         }
         fn(collectsSection)
         if (usingSection != null) {
@@ -86,7 +86,7 @@ data class DefinesCollectsGroup(
                 definesSection,
                 requiringSection,
                 whenSection,
-                specifiesSection,
+                meansSection,
                 collectsSection,
                 writtenSection,
                 metaDataSection)
@@ -102,8 +102,7 @@ data class DefinesCollectsGroup(
                 requiringSection =
                     requiringSection?.transform(chalkTransformer) as RequiringSection?,
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
-                specifiesSection =
-                    specifiesSection?.transform(chalkTransformer) as SpecifiesSection?,
+                meansSection = meansSection?.transform(chalkTransformer) as MeansSection?,
                 collectsSection = collectsSection.transform(chalkTransformer) as CollectsSection,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
@@ -125,7 +124,7 @@ fun validateDefinesCollectsGroup(
                     "Defines",
                     "requiring?",
                     "when?",
-                    "specifies?",
+                    "means?",
                     "collects",
                     "using?",
                     "written",
@@ -144,10 +143,8 @@ fun validateDefinesCollectsGroup(
                         },
                     whenSection =
                         ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
-                    specifiesSection =
-                        ifNonNull(sections["specifies"]) {
-                            validateSpecifiesSection(it, errors, tracker)
-                        },
+                    meansSection =
+                        ifNonNull(sections["means"]) { validateMeansSection(it, errors, tracker) },
                     collectsSection =
                         ensureNonNull(sections["collects"], DEFAULT_COLLECTS_SECTION) {
                             validateCollectsSection(it, errors, tracker)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
@@ -51,7 +51,7 @@ data class DefinesEvaluatedGroup(
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
     val whenSection: WhenSection?,
-    val specifiesSection: SpecifiesSection?,
+    val meansSection: MeansSection?,
     val evaluatedSection: EvaluatedSection,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
@@ -67,8 +67,8 @@ data class DefinesEvaluatedGroup(
         if (whenSection != null) {
             fn(whenSection)
         }
-        if (specifiesSection != null) {
-            fn(specifiesSection)
+        if (meansSection != null) {
+            fn(meansSection)
         }
         fn(evaluatedSection)
         if (usingSection != null) {
@@ -86,7 +86,7 @@ data class DefinesEvaluatedGroup(
                 definesSection,
                 requiringSection,
                 whenSection,
-                specifiesSection,
+                meansSection,
                 evaluatedSection,
                 writtenSection,
                 metaDataSection)
@@ -102,8 +102,7 @@ data class DefinesEvaluatedGroup(
                 requiringSection =
                     requiringSection?.transform(chalkTransformer) as RequiringSection?,
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
-                specifiesSection =
-                    specifiesSection?.transform(chalkTransformer) as SpecifiesSection?,
+                meansSection = meansSection?.transform(chalkTransformer) as MeansSection?,
                 evaluatedSection = evaluatedSection.transform(chalkTransformer) as EvaluatedSection,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
@@ -125,7 +124,7 @@ fun validateDefinesEvaluatedGroup(
                     "Defines",
                     "requiring?",
                     "when?",
-                    "specifies?",
+                    "means?",
                     "evaluated",
                     "using?",
                     "written",
@@ -144,10 +143,8 @@ fun validateDefinesEvaluatedGroup(
                         },
                     whenSection =
                         ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
-                    specifiesSection =
-                        ifNonNull(sections["specifies"]) {
-                            validateSpecifiesSection(it, errors, tracker)
-                        },
+                    meansSection =
+                        ifNonNull(sections["means"]) { validateMeansSection(it, errors, tracker) },
                     evaluatedSection =
                         ensureNonNull(sections["evaluated"], DEFAULT_EVALUATED_SECTION) {
                             validateEvaluatedSection(it, errors, tracker)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
@@ -51,7 +51,7 @@ data class DefinesGeneratedGroup(
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
     val whenSection: WhenSection?,
-    val specifiesSection: SpecifiesSection?,
+    val meansSection: MeansSection?,
     val generatedSection: GeneratedSection,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
@@ -67,8 +67,8 @@ data class DefinesGeneratedGroup(
         if (whenSection != null) {
             fn(whenSection)
         }
-        if (specifiesSection != null) {
-            fn(specifiesSection)
+        if (meansSection != null) {
+            fn(meansSection)
         }
         fn(generatedSection)
         if (usingSection != null) {
@@ -86,7 +86,7 @@ data class DefinesGeneratedGroup(
                 definesSection,
                 requiringSection,
                 whenSection,
-                specifiesSection,
+                meansSection,
                 generatedSection,
                 writtenSection,
                 metaDataSection)
@@ -102,8 +102,7 @@ data class DefinesGeneratedGroup(
                 requiringSection =
                     requiringSection?.transform(chalkTransformer) as RequiringSection?,
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
-                specifiesSection =
-                    specifiesSection?.transform(chalkTransformer) as SpecifiesSection?,
+                meansSection = meansSection?.transform(chalkTransformer) as MeansSection?,
                 generatedSection = generatedSection.transform(chalkTransformer) as GeneratedSection,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
@@ -125,7 +124,7 @@ fun validateDefinesGeneratedGroup(
                     "Defines",
                     "requiring?",
                     "when?",
-                    "specifies?",
+                    "means?",
                     "generated",
                     "using?",
                     "written",
@@ -144,10 +143,8 @@ fun validateDefinesGeneratedGroup(
                         },
                     whenSection =
                         ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
-                    specifiesSection =
-                        ifNonNull(sections["specifies"]) {
-                            validateSpecifiesSection(it, errors, tracker)
-                        },
+                    meansSection =
+                        ifNonNull(sections["means"]) { validateMeansSection(it, errors, tracker) },
                     generatedSection =
                         ensureNonNull(sections["generated"], DEFAULT_GENERATED_SECTION) {
                             validateGeneratedSection(it, errors, tracker)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
@@ -51,7 +51,7 @@ data class DefinesMapsGroup(
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
     val whenSection: WhenSection?,
-    val specifiesSection: SpecifiesSection?,
+    val meansSection: MeansSection?,
     val mapsSection: MapsSection,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
@@ -67,8 +67,8 @@ data class DefinesMapsGroup(
         if (whenSection != null) {
             fn(whenSection)
         }
-        if (specifiesSection != null) {
-            fn(specifiesSection)
+        if (meansSection != null) {
+            fn(meansSection)
         }
         fn(mapsSection)
         if (usingSection != null) {
@@ -86,7 +86,7 @@ data class DefinesMapsGroup(
                 definesSection,
                 requiringSection,
                 whenSection,
-                specifiesSection,
+                meansSection,
                 mapsSection,
                 writtenSection,
                 metaDataSection)
@@ -102,8 +102,7 @@ data class DefinesMapsGroup(
                 requiringSection =
                     requiringSection?.transform(chalkTransformer) as RequiringSection?,
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
-                specifiesSection =
-                    specifiesSection?.transform(chalkTransformer) as SpecifiesSection?,
+                meansSection = meansSection?.transform(chalkTransformer) as MeansSection?,
                 mapsSection = mapsSection.transform(chalkTransformer) as MapsSection,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
@@ -125,7 +124,7 @@ fun validateDefinesMapsGroup(
                     "Defines",
                     "requiring?",
                     "when?",
-                    "specifies?",
+                    "means?",
                     "maps",
                     "using?",
                     "written",
@@ -144,10 +143,8 @@ fun validateDefinesMapsGroup(
                         },
                     whenSection =
                         ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
-                    specifiesSection =
-                        ifNonNull(sections["specifies"]) {
-                            validateSpecifiesSection(it, errors, tracker)
-                        },
+                    meansSection =
+                        ifNonNull(sections["means"]) { validateMeansSection(it, errors, tracker) },
                     mapsSection =
                         ensureNonNull(sections["maps"], DEFAULT_MAPS_SECTION) {
                             validateMapsSection(it, errors, tracker)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
@@ -51,8 +51,8 @@ data class DefinesMeansGroup(
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
     val whenSection: WhenSection?,
-    val specifiesSection: SpecifiesSection?,
     val meansSection: MeansSection,
+    val satisfyingSection: SatisfyingSection?,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
@@ -67,10 +67,10 @@ data class DefinesMeansGroup(
         if (whenSection != null) {
             fn(whenSection)
         }
-        if (specifiesSection != null) {
-            fn(specifiesSection)
-        }
         fn(meansSection)
+        if (satisfyingSection != null) {
+            fn(satisfyingSection)
+        }
         if (usingSection != null) {
             fn(usingSection)
         }
@@ -86,8 +86,8 @@ data class DefinesMeansGroup(
                 definesSection,
                 requiringSection,
                 whenSection,
-                specifiesSection,
                 meansSection,
+                satisfyingSection,
                 writtenSection,
                 metaDataSection)
         return topLevelToCode(writer, isArg, indent, id, *sections.toTypedArray())
@@ -102,9 +102,9 @@ data class DefinesMeansGroup(
                 requiringSection =
                     requiringSection?.transform(chalkTransformer) as RequiringSection?,
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
-                specifiesSection =
-                    specifiesSection?.transform(chalkTransformer) as SpecifiesSection?,
                 meansSection = meansSection.transform(chalkTransformer) as MeansSection,
+                satisfyingSection =
+                    satisfyingSection?.transform(chalkTransformer) as SatisfyingSection?,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
                 metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?))
@@ -125,8 +125,8 @@ fun validateDefinesMeansGroup(
                     "Defines",
                     "requiring?",
                     "when?",
-                    "specifies?",
                     "means",
+                    "satisfying?",
                     "using?",
                     "written",
                     "Metadata?")) { sections ->
@@ -144,13 +144,13 @@ fun validateDefinesMeansGroup(
                         },
                     whenSection =
                         ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
-                    specifiesSection =
-                        ifNonNull(sections["specifies"]) {
-                            validateSpecifiesSection(it, errors, tracker)
-                        },
                     meansSection =
                         ensureNonNull(sections["means"], DEFAULT_MEANS_SECTION) {
                             validateMeansSection(it, errors, tracker)
+                        },
+                    satisfyingSection =
+                        ifNonNull(sections["satisfying"]) {
+                            validateSpecifiesSection(it, errors, tracker)
                         },
                     usingSection =
                         ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/MeansSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/MeansSection.kt
@@ -17,6 +17,8 @@
 package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines
 
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
+import mathlingua.frontend.chalktalk.phase1.ast.getColumn
+import mathlingua.frontend.chalktalk.phase1.ast.getRow
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_MEANS_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.clause.ClauseListNode
@@ -50,6 +52,17 @@ fun validateMeansSection(
 ) =
     track(node, tracker) {
         validateSection(node.resolve(), errors, "means", DEFAULT_MEANS_SECTION) {
-            MeansSection(clauses = validateClauseListNode(it, errors, tracker))
+            if (it.args.size != 1) {
+                errors.add(
+                    ParseError(
+                        message =
+                            "A 'means:' section must have exactly one " +
+                                "statement but found ${it.args.size}",
+                        row = getRow(node),
+                        column = getColumn(node)))
+                DEFAULT_MEANS_SECTION
+            } else {
+                MeansSection(clauses = validateClauseListNode(it, errors, tracker))
+            }
         }
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/SatisfyingSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/SatisfyingSection.kt
@@ -18,7 +18,7 @@ package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defi
 
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
-import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_SPECIFIES_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_SATISFYING_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.frontend.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
@@ -27,12 +27,12 @@ import mathlingua.frontend.chalktalk.phase2.ast.validateSection
 import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
 
-data class SpecifiesSection(val clauses: ClauseListNode) : Phase2Node {
+data class SatisfyingSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
-        writer.writeHeader("specifies")
+        writer.writeHeader("satisfying")
         if (clauses.clauses.isNotEmpty()) {
             writer.writeNewline()
         }
@@ -42,14 +42,14 @@ data class SpecifiesSection(val clauses: ClauseListNode) : Phase2Node {
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
         chalkTransformer(
-            SpecifiesSection(clauses = clauses.transform(chalkTransformer) as ClauseListNode))
+            SatisfyingSection(clauses = clauses.transform(chalkTransformer) as ClauseListNode))
 }
 
 fun validateSpecifiesSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
     track(node, tracker) {
-        validateSection(node.resolve(), errors, "specifies", DEFAULT_SPECIFIES_SECTION) {
-            SpecifiesSection(clauses = validateClauseListNode(it, errors, tracker))
+        validateSection(node.resolve(), errors, "satisfying", DEFAULT_SATISFYING_SECTION) {
+            SatisfyingSection(clauses = validateClauseListNode(it, errors, tracker))
         }
     }

--- a/src/test/kotlin/mathlingua/MathLinguaTest.kt
+++ b/src/test/kotlin/mathlingua/MathLinguaTest.kt
@@ -114,27 +114,27 @@ internal class MathLinguaTest {
                 """
             [\finite.set]
             Defines: X
-            specifies: 'X is \something'
-            means: '\something'
+            means: 'X is \something'
+            satisfying: '\something'
             written: "something"
 
             [\infinite.set]
             Defines: X
-            specifies: 'X is \something'
-            means: '\something.else'
+            means: 'X is \something'
+            satisfying: '\something.else'
             written: "something"
 
             [\finite.set]
             Defines: Y
-            specifies: 'X is \something'
-            means: '\yet.something.else'
+            means: 'X is \something'
+            satisfying: '\yet.something.else'
             written: "something"
         """.trimIndent(),
                 """
             [\set]
             Defines: X
-            specifies: 'X is \something'
-            means:
+            means: 'X is \something'
+            satisfying:
             . if: X
               then: '\something.else'
             written: "something"
@@ -259,21 +259,21 @@ internal class MathLinguaTest {
                 """
             [\finite.set]
             Defines: X
-            specifies: 'X is \something'
-            means: '\something'
+            means: 'X is \something'
+            satisfying: '\something'
             written: "something"
 
             [\infinite.set]
             Defines: X
-            specifies: 'X is \something'
-            means: '\something.else'
+            means: 'X is \something'
+            satisfying: '\something.else'
             written: "something"
         """.trimIndent(),
                 """
             [\set]
             Defines: X
-            specifies: 'X is \something'
-            means:
+            means: 'X is \something'
+            satisfying:
             . if: X
               then: '\something.else'
             written: "something"
@@ -307,21 +307,21 @@ internal class MathLinguaTest {
                 """
             [\finite.set]
             Defines: X
-            specifies: 'X is \something'
-            means: '\something'
+            means: 'X is \something'
+            satisfying: '\something'
             written: "something"
 
             [\infinite.set]
             Defines: X
-            specifies: 'X is \something'
-            means: '\something.else'
+            means: 'X is \something'
+            satisfying: '\something.else'
             written: "something"
         """.trimIndent(),
                 """
             [\set]
             Defines: X
-            specifies: 'X is \something'
-            means:
+            means: 'X is \something'
+            satisfying:
             . if: X
               then: '\something.else'
             written: "something"
@@ -333,8 +333,8 @@ internal class MathLinguaTest {
 
             [\set]
             Defines: Y
-            specifies: 'X is \something'
-            means: '\yet.something.else'
+            means: 'X is \something'
+            satisfying: '\yet.something.else'
             written: "something"
         """.trimIndent())
 

--- a/src/test/kotlin/mathlingua/backend/transform/SignatureUtilKtTest.kt
+++ b/src/test/kotlin/mathlingua/backend/transform/SignatureUtilKtTest.kt
@@ -33,7 +33,7 @@ internal class SignatureUtilKtTest {
     fun findAllStatementSignaturesNonGluedTest() {
         val validation =
             FrontEnd.parse(
-                "[\\xyz{x}]\nDefines: y\nspecifies: 'something'\nmeans: 'something'\nwritten: \"something\"")
+                "[\\xyz{x}]\nDefines: y\nmeans: 'something'\nsatisfying: 'something'\nwritten: \"something\"")
         val doc = (validation as ValidationSuccess).value
         val defines = doc.defines()
         assertThat(defines.size).isEqualTo(1)
@@ -48,7 +48,7 @@ internal class SignatureUtilKtTest {
     fun statementSignaturesNotAllowedToBeGluedTest() {
         val validation =
             FrontEnd.parse(
-                "[\\abc \\xyz{x}]\nDefines: y\nspecifies: 'something'\nmeans: 'something'\n" +
+                "[\\abc \\xyz{x}]\nDefines: y\nmeans: 'something'\nsatisfying: 'something'\n" +
                     "written: \"something\"")
         assertThat(validation is ValidationFailure)
         assertThat((validation as ValidationFailure).errors)
@@ -64,7 +64,7 @@ internal class SignatureUtilKtTest {
     fun findAllStatementSignaturesInfixTest() {
         val validation =
             FrontEnd.parse(
-                "[x \\abc/ y]\nDefines: y\nspecifies: 'something'\nmeans: 'something'\n" +
+                "[x \\abc/ y]\nDefines: y\nmeans: 'something'\nsatisfying: 'something'\n" +
                     "written: \"something\"")
         val doc = (validation as ValidationSuccess).value
         val defines = doc.defines()

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/input.math
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/input.math
@@ -1,5 +1,5 @@
 [\f{x...}]
 Defines: X...#x...
-specifies: 'X is \something'
-means: "something for X...#x..."
+means: 'X is \something'
+satisfying: "something for X...#x..."
 written: "something"

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-output.math
@@ -1,9 +1,9 @@
 [\f{x...}]
 Defines:
 . X...#x...
-specifies:
-. 'X is \something'
 means:
+. 'X is \something'
+satisfying:
 . "something for X...#x..."
 written:
 . "something"

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-structure.txt
@@ -34,7 +34,7 @@ Root(
                             ),
                             Section(
                               name = Phase1Token(
-                                text = "specifies"
+                                text = "means"
                                 type = ChalkTalkTokenType.Name
                                 row = 2
                                 column = 1
@@ -45,14 +45,14 @@ Root(
                                            text = "'X is \something'"
                                            type = ChalkTalkTokenType.Statement
                                            row = 2
-                                           column = 12
+                                           column = 8
                                          )
                                        )
                                      ]
                             ),
                             Section(
                               name = Phase1Token(
-                                text = "means"
+                                text = "satisfying"
                                 type = ChalkTalkTokenType.Name
                                 row = 3
                                 column = 1
@@ -63,7 +63,7 @@ Root(
                                            text = ""something for X...#x...""
                                            type = ChalkTalkTokenType.String
                                            row = 3
-                                           column = 8
+                                           column = 13
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-output.math
@@ -1,8 +1,8 @@
 [\f{x...}]
 Defines: X...#x...
-specifies:
-. 'X is \something'
 means:
+. 'X is \something'
+satisfying:
 . "something for X...#x..."
 written:
 . "something"

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-structure.txt
@@ -75,7 +75,7 @@ Document(
                )
                requiringSection = null
                whenSection = null
-               specifiesSection = SpecifiesSection(
+               meansSection = MeansSection(
                  clauses = ClauseListNode(
                    clauses = [
                                Statement(
@@ -134,7 +134,7 @@ Document(
                              ]
                  )
                )
-               meansSection = MeansSection(
+               satisfyingSection = SatisfyingSection(
                  clauses = ClauseListNode(
                    clauses = [
                                Text(

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/input.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/input.math
@@ -1,6 +1,6 @@
 [\evens]
 Defines: X
-specifies: 'X is \set'
+means: 'X is \set'
 collects:
 . given: k
   where: 'k is \integer'

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-output.math
@@ -1,7 +1,7 @@
 [\evens]
 Defines:
 . X
-specifies:
+means:
 . 'X is \set'
 collects:
 . given:

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-structure.txt
@@ -34,7 +34,7 @@ Root(
                             ),
                             Section(
                               name = Phase1Token(
-                                text = "specifies"
+                                text = "means"
                                 type = ChalkTalkTokenType.Name
                                 row = 2
                                 column = 1
@@ -45,7 +45,7 @@ Root(
                                            text = "'X is \set'"
                                            type = ChalkTalkTokenType.Statement
                                            row = 2
-                                           column = 12
+                                           column = 8
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-output.math
@@ -1,6 +1,6 @@
 [\evens]
 Defines: X
-specifies:
+means:
 . 'X is \set'
 collects:
 . given: k

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-structure.txt
@@ -57,7 +57,7 @@ Document(
                )
                requiringSection = null
                whenSection = null
-               specifiesSection = SpecifiesSection(
+               meansSection = MeansSection(
                  clauses = ClauseListNode(
                    clauses = [
                                Statement(

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/input.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/input.math
@@ -1,6 +1,6 @@
 [\f(x)]
 Defines: f(x)
-specifies: 'f is \function'
+means: 'f is \function'
 maps:
 . from: 'A'
   to: 'A'

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-output.math
@@ -1,7 +1,7 @@
 [\f(x)]
 Defines:
 . f(x)
-specifies:
+means:
 . 'f is \function'
 maps:
 . from:

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-structure.txt
@@ -41,7 +41,7 @@ Root(
                             ),
                             Section(
                               name = Phase1Token(
-                                text = "specifies"
+                                text = "means"
                                 type = ChalkTalkTokenType.Name
                                 row = 2
                                 column = 1
@@ -52,7 +52,7 @@ Root(
                                            text = "'f is \function'"
                                            type = ChalkTalkTokenType.Statement
                                            row = 2
-                                           column = 12
+                                           column = 8
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-output.math
@@ -1,6 +1,6 @@
 [\f(x)]
 Defines: f(x)
-specifies:
+means:
 . 'f is \function'
 maps:
 . from: 'A'

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
@@ -81,7 +81,7 @@ Document(
                )
                requiringSection = null
                whenSection = null
-               specifiesSection = SpecifiesSection(
+               meansSection = MeansSection(
                  clauses = ClauseListNode(
                    clauses = [
                                Statement(

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/input.math
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/input.math
@@ -1,5 +1,5 @@
 [A]
 Defines: B
-specifies: 'B is \something'
-means: "C"
+means: 'B is \something'
+satisfying: "C"
 written: "something"

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-output.math
@@ -1,9 +1,9 @@
 [A]
 Defines:
 . B
-specifies:
-. 'B is \something'
 means:
+. 'B is \something'
+satisfying:
 . "C"
 written:
 . "something"

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-structure.txt
@@ -34,7 +34,7 @@ Root(
                             ),
                             Section(
                               name = Phase1Token(
-                                text = "specifies"
+                                text = "means"
                                 type = ChalkTalkTokenType.Name
                                 row = 2
                                 column = 1
@@ -45,14 +45,14 @@ Root(
                                            text = "'B is \something'"
                                            type = ChalkTalkTokenType.Statement
                                            row = 2
-                                           column = 12
+                                           column = 8
                                          )
                                        )
                                      ]
                             ),
                             Section(
                               name = Phase1Token(
-                                text = "means"
+                                text = "satisfying"
                                 type = ChalkTalkTokenType.Name
                                 row = 3
                                 column = 1
@@ -63,7 +63,7 @@ Root(
                                            text = ""C""
                                            type = ChalkTalkTokenType.String
                                            row = 3
-                                           column = 8
+                                           column = 13
                                          )
                                        )
                                      ]

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-output.math
@@ -1,8 +1,8 @@
 [A]
 Defines: B
-specifies:
-. 'B is \something'
 means:
+. 'B is \something'
+satisfying:
 . "C"
 written:
 . "something"

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-structure.txt
@@ -43,7 +43,7 @@ Document(
                )
                requiringSection = null
                whenSection = null
-               specifiesSection = SpecifiesSection(
+               meansSection = MeansSection(
                  clauses = ClauseListNode(
                    clauses = [
                                Statement(
@@ -102,7 +102,7 @@ Document(
                              ]
                  )
                )
-               meansSection = MeansSection(
+               satisfyingSection = SatisfyingSection(
                  clauses = ClauseListNode(
                    clauses = [
                                Text(

--- a/src/test/resources/goldens/messages/defines/Defines_assuming_spelled_wrong/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_assuming_spelled_wrong/messages.txt
@@ -6,8 +6,8 @@ For pattern:
 Defines:
 requiring?:
 when?:
-specifies?:
 means:
+satisfying?:
 using?:
 written:
 Metadata?:

--- a/src/test/resources/goldens/messages/defines/Defines_id_paren_must_match_target/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_id_paren_must_match_target/messages.txt
@@ -6,8 +6,8 @@ For pattern:
 Defines:
 requiring?:
 when?:
-specifies?:
 means:
+satisfying?:
 using?:
 written:
 Metadata?:
@@ -24,8 +24,8 @@ For pattern:
 Defines:
 requiring?:
 when?:
-specifies?:
 means:
+satisfying?:
 using?:
 written:
 Metadata?:
@@ -42,8 +42,8 @@ For pattern:
 Defines:
 requiring?:
 when?:
-specifies?:
 means:
+satisfying?:
 using?:
 written:
 Metadata?:
@@ -60,8 +60,8 @@ For pattern:
 Defines:
 requiring?:
 when?:
-specifies?:
 means:
+satisfying?:
 using?:
 written:
 Metadata?:
@@ -78,8 +78,8 @@ For pattern:
 Defines:
 requiring?:
 when?:
-specifies?:
 means:
+satisfying?:
 using?:
 written:
 Metadata?:
@@ -96,8 +96,8 @@ For pattern:
 Defines:
 requiring?:
 when?:
-specifies?:
 means:
+satisfying?:
 using?:
 written:
 Metadata?:

--- a/src/test/resources/goldens/messages/defines/Defines_must_have_id/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_must_have_id/messages.txt
@@ -6,8 +6,8 @@ For pattern:
 Defines:
 requiring?:
 when?:
-specifies?:
 means:
+satisfying?:
 using?:
 written:
 Metadata?:

--- a/src/test/resources/mathlingua.math
+++ b/src/test/resources/mathlingua.math
@@ -2,8 +2,8 @@
 [\something{A}]
 Defines: X
 when: 'A is \something.else'
-specifies: 'X is \something.else'
-means: 'X is \some.other.thing'
+means: 'X is \something.else'
+satisfying: 'X is \some.other.thing'
 written: "\textrm{something} A?"
 
 
@@ -17,7 +17,7 @@ written: "\textrm{something} A?"
 [\some.function{A}(x)]
 Defines: f(x)
 when: 'A is \something'
-specifies: 'f is \function'
+means: 'f is \function'
 maps:
 . from: '\reals'
   to: '\reals'
@@ -26,7 +26,7 @@ written: "\textrm{some.function}(x?)"
 
 [\some.function2{A}(x)]
 Defines: f(x)
-specifies: 'A is \something'
+means: 'A is \something'
 maps:
 . from: '\reals'
   to: '\reals'
@@ -43,7 +43,7 @@ written: "\mathbb{Z}"
 
 [\naturals]
 Defines: N
-specifies: 'N is \type'
+means: 'N is \type'
 generated:
 . inductively:
   from:
@@ -66,7 +66,7 @@ written: "\mathbb{N}"
 
 [\even.primes]
 Defines: X
-specifies: 'X is \set'
+means: 'X is \set'
 collects:
 . given: p
   where: 'p is \prime'
@@ -87,7 +87,7 @@ written: "\textbf{even primes}"
 
 [\f1(x)]
 Defines: f(x)
-specifies: 'f is \function'
+means: 'f is \function'
 evaluated: 'f(x) := x + 1'
 written: "f1(x?)"
 
@@ -100,7 +100,7 @@ written: "f1(x?)"
 
 [\f2(x)]
 Defines: f(x)
-specifies: 'f is \function'
+means: 'f is \function'
 evaluated:
 . matching:
   . 'f(x?) ::= x + 1'
@@ -117,7 +117,7 @@ written: "f2(x?)"
 
 [\f3(x)]
 Defines: f(x)
-specifies: 'f is \function'
+means: 'f is \function'
 evaluated:
 . piecewise:
   when: 'x > 0'
@@ -149,15 +149,15 @@ that: 'A + B - C is \something'
 Foundation:
 . [\X]
   Defines: X
-  specifies: 'X is \something'
-  means: 'X is \something.else'
+  means: 'X is \something'
+  satisfying: 'X is \something.else'
   written: "X?"
 
 
 Foundation:
 . [\X]
   Defines: X
-  specifies: 'X is \set'
+  means: 'X is \set'
   collects:
   . given: x
     where: 'x'
@@ -169,13 +169,13 @@ Foundation:
 Mutually:
 . [\X]
   Defines: X
-  specifies: 'X is \X'
-  means: 'X is \Y'
+  means: 'X is \X'
+  satisfying: 'X is \Y'
   written: "X?"
 . [\Y]
   Defines: Y
-  specifies: 'Y is \Y'
-  means: 'Y is \X'
+  means: 'Y is \Y'
+  satisfying: 'Y is \X'
   written: "Y?"
 
 


### PR DESCRIPTION
Specifically, `Defines:` uses the patterns:
```
Defines:
requiring?:
when?:
means:
satisfying?:
using?:
written:
Metadata?:
```
and
```
Defines:
requiring?:
when?:
means?:
collects:
using?:
written:
Metadata?:
```
and
```
Defines:
requiring?:
when?:
means?:
maps:
using?:
written:
Metadata?:
```
and
```
Defines:
requiring?:
when?:
means?:
generated:
using?:
written:
Metadata?:
```
