### PR TITLE
feat: support operators as left-hand-side of `is`

### DIFF
--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/MeansSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/MeansSection.kt
@@ -17,8 +17,6 @@
 package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines
 
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
-import mathlingua.frontend.chalktalk.phase1.ast.getColumn
-import mathlingua.frontend.chalktalk.phase1.ast.getRow
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_MEANS_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.clause.ClauseListNode
@@ -52,17 +50,6 @@ fun validateMeansSection(
 ) =
     track(node, tracker) {
         validateSection(node.resolve(), errors, "means", DEFAULT_MEANS_SECTION) {
-            if (it.args.size != 1) {
-                errors.add(
-                    ParseError(
-                        message =
-                            "A 'means:' section must have exactly one " +
-                                "statement but found ${it.args.size}",
-                        row = getRow(node),
-                        column = getColumn(node)))
-                DEFAULT_MEANS_SECTION
-            } else {
-                MeansSection(clauses = validateClauseListNode(it, errors, tracker))
-            }
+            MeansSection(clauses = validateClauseListNode(it, errors, tracker))
         }
     }

--- a/src/test/resources/mathlingua.math
+++ b/src/test/resources/mathlingua.math
@@ -142,7 +142,9 @@ written: "f3(x?)"
 
 [\semigroup]
 Defines: G := (X, *)
-means: 'G is \something'
+means:
+. 'X is \set'
+. '* is \binary.operation:on{X}'
 satisfying:
 . forAll: x, y, z
   where: 'x, y, z in X'


### PR DESCRIPTION
That is, prior to this change, `* is \something` would result in
an error saying that an operator needs to have arguments
specified.  Now the `*` is viewed as an identifier if it is the
left-hand-side of an `is`.
