### PR TITLE
feat: command operators sometimes treated as ops

### DIFF
--- a/src/main/kotlin/mathlingua/frontend/textalk/TexTalkLexer.kt
+++ b/src/main/kotlin/mathlingua/frontend/textalk/TexTalkLexer.kt
@@ -207,19 +207,19 @@ private class TexTalkLexerImpl(text: String) : TexTalkLexer {
         return builder.toString()
     }
 
-    private fun isOpChar(c: Char) =
-        (c == '!' ||
-            c == '@' ||
-            c == '%' ||
-            c == '&' ||
-            c == '*' ||
-            c == '-' ||
-            c == '+' ||
-            c == '=' ||
-            c == '|' ||
-            c == '/' ||
-            c == '<' ||
-            c == '>')
-
     private fun isIdentifierChar(c: Char) = Regex("[$#a-zA-Z0-9]+").matches("$c")
 }
+
+fun isOpChar(c: Char) =
+    (c == '!' ||
+        c == '@' ||
+        c == '%' ||
+        c == '&' ||
+        c == '*' ||
+        c == '-' ||
+        c == '+' ||
+        c == '=' ||
+        c == '|' ||
+        c == '/' ||
+        c == '<' ||
+        c == '>')


### PR DESCRIPTION
Now the operator `\op.+/` is treated as `+` for example.  In
particular, if a command operator ends with an operator then
it is treated as an operator.

That is, the code
```
x \op.+/ y \op.*/ z
```
is parsed as
```
x \op.+/ (y \op.*/ z)
```
