### PR TITLE
fix: address invalid line numbers in text elements

### DIFF
--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase1/ChalkTalkLexer.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase1/ChalkTalkLexer.kt
@@ -286,8 +286,14 @@ private class ChalkTalkLexerImpl(private var text: String) : ChalkTalkLexer {
                 val startColumn = column
                 var str = "" + c
                 while (i < text.length && text[i] != '"') {
-                    str += text[i++]
-                    column++
+                    val cur = text[i++]
+                    str += cur
+                    if (cur == '\n' || cur == '\r') {
+                        line++
+                        column = 0
+                    } else {
+                        column++
+                    }
                 }
                 if (i == text.length) {
                     errors.add(ParseError("Expected a terminating \"", line, column))
@@ -304,8 +310,14 @@ private class ChalkTalkLexerImpl(private var text: String) : ChalkTalkLexer {
                 val startColumn = column
                 var stmt = "" + c
                 while (i < text.length && text[i] != '\'') {
-                    stmt += text[i++]
-                    column++
+                    val cur = text[i++]
+                    stmt += cur
+                    if (cur == '\n' || cur == '\r') {
+                        line++
+                        column = 0
+                    } else {
+                        column++
+                    }
                 }
                 if (i == text.length) {
                     errors.add(ParseError("Expected a terminating '", line, column))


### PR DESCRIPTION
If a statement or text element contains newlines, they were not
counted correctly by the lexer causing line numbers to be
incorrect.  After this change, line numbers are correctly counted.
