### PR TITLE
feat: standalone operators viewed as identifiers

### DIFF
--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
@@ -52,7 +52,7 @@ data class DefinesCollectsGroup(
     override val id: IdStatement,
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
-    val whenSection: WhenSection?,
+    override val whenSection: WhenSection?,
     val meansSection: MeansSection?,
     val collectsSection: CollectsSection,
     override val viewedSection: ViewedSection?,

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
@@ -52,7 +52,7 @@ data class DefinesEvaluatedGroup(
     override val id: IdStatement,
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
-    val whenSection: WhenSection?,
+    override val whenSection: WhenSection?,
     val meansSection: MeansSection?,
     val evaluatedSection: EvaluatedSection,
     override val viewedSection: ViewedSection?,

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
@@ -52,7 +52,7 @@ data class DefinesGeneratedGroup(
     override val id: IdStatement,
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
-    val whenSection: WhenSection?,
+    override val whenSection: WhenSection?,
     val meansSection: MeansSection?,
     val generatedSection: GeneratedSection,
     override val viewedSection: ViewedSection?,

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
@@ -24,6 +24,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.ViewedSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
@@ -34,6 +35,7 @@ abstract class DefinesGroup(override val metaDataSection: MetaDataSection?) :
     abstract val signature: String?
     abstract val definesSection: DefinesSection
     abstract val requiringSection: RequiringSection?
+    abstract val whenSection: WhenSection?
     abstract val viewedSection: ViewedSection?
     abstract val writtenSection: WrittenSection
 }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesInstantiatedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesInstantiatedGroup.kt
@@ -52,7 +52,7 @@ data class DefinesInstantiatedGroup(
     override val id: IdStatement,
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
-    val whenSection: WhenSection?,
+    override val whenSection: WhenSection?,
     val instantiatedSection: InstantiatedSection,
     override val viewedSection: ViewedSection?,
     override val usingSection: UsingSection?,

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
@@ -52,7 +52,7 @@ data class DefinesMapsGroup(
     override val id: IdStatement,
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
-    val whenSection: WhenSection?,
+    override val whenSection: WhenSection?,
     val meansSection: MeansSection?,
     val mapsSection: MapsSection,
     override val viewedSection: ViewedSection?,

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
@@ -52,7 +52,7 @@ data class DefinesMeansGroup(
     override val id: IdStatement,
     override val definesSection: DefinesSection,
     override val requiringSection: RequiringSection?,
-    val whenSection: WhenSection?,
+    override val whenSection: WhenSection?,
     val meansSection: MeansSection,
     val satisfyingSection: SatisfyingSection?,
     override val viewedSection: ViewedSection?,

--- a/src/main/kotlin/mathlingua/frontend/textalk/PostProcessing.kt
+++ b/src/main/kotlin/mathlingua/frontend/textalk/PostProcessing.kt
@@ -179,9 +179,8 @@ import mathlingua.frontend.support.ParseError
 
 internal fun parseOperators(root: ExpressionTexTalkNode): TexTalkParseResult {
     try {
-        val isOpToNameRoot = isLhsOperatorToName(root)
-        val isRhsExpressions = findIsRhsExpressions(isOpToNameRoot)
-        val funcCallRoot = identifyIdentifierFunctionCalls(isOpToNameRoot)
+        val isRhsExpressions = findIsRhsExpressions(root)
+        val funcCallRoot = identifyIdentifierFunctionCalls(root)
         val idPrefixOpRoot = identifySpecialPrefixOperators(funcCallRoot, isRhsExpressions)
         val idPostfixOpRoot = identifySpecialPostfixOperators(idPrefixOpRoot, isRhsExpressions)
         val idInfixOpRoot = identifyInfixCommandOperators(idPostfixOpRoot, isRhsExpressions)

--- a/src/test/kotlin/mathlingua/backend/transform/MatcherKtTest.kt
+++ b/src/test/kotlin/mathlingua/backend/transform/MatcherKtTest.kt
@@ -58,11 +58,11 @@ class MatcherKtTest {
                 OperatorTexTalkNode(
                     lhs = buildText("A"),
                     command = buildCommand("\\set.in/"),
-                    rhs = buildText("B")) to "A? \\in/ B?")
+                    rhs = buildText("B")) to "A? \\in B?")
         val node = buildNode("X \\set.in/ Y")
         val expanded = expandAsWritten(node, patternToExpansion)
         assertThat(expanded.errors).isEmpty()
-        assertThat(expanded.text).isEqualTo("X \\in/ Y")
+        assertThat(expanded.text).isEqualTo("X \\in Y")
     }
 
     @Test


### PR DESCRIPTION
In addition, variables defined in `when:` sections are recorded
as known variables.  That is, in the section:
```
[\function:on{X}]
Defines: ...
when:
. `X := (A, B)`
```
the variables `A` and `B` are recorded as defined variables.
Note, `X` must already be defined as it is in the example above.
