### PR TITLE
chore: bound max width of top-level groups

### DIFF
--- a/src/main/kotlin/mathlingua/backend/SourceCollection.kt
+++ b/src/main/kotlin/mathlingua/backend/SourceCollection.kt
@@ -958,6 +958,7 @@ private fun getHtml(body: String) =
                 padding-left: 1em;
                 padding-right: 1em;
                 width: max-content;
+                max-width: 90%;
                 margin-left: auto; /* for centering content */
                 margin-right: auto; /* for centering content */
             }


### PR DESCRIPTION
When the html code writer renders top-level groups, the max-width
is specified in css as 90%.  This is needed so that long text
entries are wrapped instead scrolling off of the page.
