### PR TITLE
feat: add `site:name:` group

### DIFF
--- a/src/main/kotlin/mathlingua/Main.kt
+++ b/src/main/kotlin/mathlingua/Main.kt
@@ -562,7 +562,7 @@ fun getIndexHtml(
     """
 <html>
     <head>
-        <meta name="viewport" content="width=100%, initial-scale=1.0">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
         <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
         <meta content="utf-8" http-equiv="encoding">
         <style>
@@ -588,8 +588,11 @@ fun getIndexHtml(
             }
 
             .search-area {
-                margin-left: auto;
-                margin-right: auto;
+                position: absolute;
+                left: 50%;
+                top: 50%;
+                transform: translate(-50%, -50%);
+                width: max-content;
             }
 
             .sidebar {
@@ -654,6 +657,10 @@ fun getIndexHtml(
                 text-decoration: none;
                 color: black;
                 margin-left: 0.75em;
+                position: absolute;
+                left: 0;
+                top: 50%;
+                transform: translate(0, -50%);
             }
 
             #main {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
@@ -47,6 +47,7 @@ interface CodeWriter {
     fun writeStatement(stmtText: String, root: Validation<ExpressionTexTalkNode>)
     fun writeIdentifier(name: String, isVarArgs: Boolean)
     fun writeText(text: String)
+    fun writeUrl(url: String, name: String?)
     fun writeDirect(text: String)
     fun writeHorizontalLine()
     fun beginTopLevel(label: String)
@@ -159,6 +160,44 @@ open class HtmlCodeWriter(
     }
 
     private fun newlinesToHtml(text: String) = text.replace(Regex("[\r\n][\r\n]+"), "<br/></br>")
+
+    override fun writeUrl(url: String, name: String?) {
+        val urlNoSpace = url.replace(Regex("[ \\r\\n\\t]+"), "")
+        val title =
+            if (name != null) {
+                name
+            } else {
+                val rawName =
+                    urlNoSpace
+                        .replace("https://", "")
+                        .replace("http://", "")
+                        .replace("ftp://", "")
+                        .replace("file://", "")
+                if (rawName.length > 30) {
+                    val questionIndex = rawName.indexOf("?")
+                    val withoutQueryString =
+                        if (questionIndex < 0) {
+                            rawName
+                        } else {
+                            rawName.substring(0, questionIndex)
+                        }
+
+                    if (withoutQueryString.length > 30) {
+                        val parts = withoutQueryString.split("/")
+                        if (parts.size == 1) {
+                            withoutQueryString
+                        } else {
+                            "${parts.first()}/.../${parts.last()}"
+                        }
+                    } else {
+                        withoutQueryString
+                    }
+                } else {
+                    rawName
+                }
+            }
+        builder.append("<a href=\"$urlNoSpace\">$title</a>")
+    }
 
     override fun writeText(text: String) {
         val textWithBreaks = newlinesToHtml(text)
@@ -407,6 +446,12 @@ class MathLinguaCodeWriter(
         builder.append(
             expandTextAsWritten(text, true, defines, states, foundations, mutuallyGroups).text
                 ?: text)
+        builder.append('"')
+    }
+
+    override fun writeUrl(url: String, name: String?) {
+        builder.append('"')
+        builder.append(url)
         builder.append('"')
     }
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
@@ -132,13 +132,16 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSecti
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.ReferenceGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.SiteGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.SourceItemGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.StringSectionGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.ContentItemSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.NameItemSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.OffsetItemSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.PageItemSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.ReferenceSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.SiteItemSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.SourceItemSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.StringSection
 import mathlingua.frontend.support.Location
@@ -587,9 +590,17 @@ val DEFAULT_CONTENT_ITEM_SECTION = ContentItemSection(content = "")
 
 val DEFAULT_OFFSET_ITEM_SECTION = OffsetItemSection(offset = "")
 
+val DEFAULT_SITE_ITEM_SECTION = SiteItemSection(url = "")
+
+val DEFAULT_NAME_ITEM_SECTION = NameItemSection(name = "")
+
+val DEFAULT_SITE_GROUP =
+    SiteGroup(
+        siteItemSection = DEFAULT_SITE_ITEM_SECTION, nameItemSection = DEFAULT_NAME_ITEM_SECTION)
+
 val DEFAULT_PAGE_ITEM_SECTION = PageItemSection(page = "")
 
-val DEFAULT_REFERENCE_SECTION = ReferenceSection(sourceItems = emptyList())
+val DEFAULT_REFERENCE_SECTION = ReferenceSection(items = emptyList())
 
 val DEFAULT_REFERENCE_GROUP = ReferenceGroup(referenceSection = DEFAULT_REFERENCE_SECTION)
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/ReferenceItem.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/ReferenceItem.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.item
+
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
+import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.frontend.support.MutableLocationTracker
+import mathlingua.frontend.support.ParseError
+
+interface ReferenceItem : Phase2Node
+
+fun validateReferenceItem(
+    node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
+): ReferenceItem =
+    when {
+        isSiteGroup(node.resolve()) -> {
+            validateSiteGroup(node, errors, tracker)
+        }
+        isSourceItemGroup(node.resolve()) -> {
+            validateSourceItemGroup(node, errors, tracker)
+        }
+        else -> {
+            throw RuntimeException("Unknown ReferenceItem: $node")
+        }
+    }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/SiteGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/SiteGroup.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.item
+
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_SITE_GROUP
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_SITE_ITEM_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.clause.firstSectionMatchesName
+import mathlingua.frontend.chalktalk.phase2.ast.common.TwoPartNode
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.NameItemSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.SiteItemSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateNameItemSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.validateSiteItemSection
+import mathlingua.frontend.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.frontend.chalktalk.phase2.ast.section.identifySections
+import mathlingua.frontend.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.frontend.chalktalk.phase2.ast.track
+import mathlingua.frontend.chalktalk.phase2.ast.validateGroup
+import mathlingua.frontend.support.MutableLocationTracker
+import mathlingua.frontend.support.ParseError
+
+data class SiteGroup(val siteItemSection: SiteItemSection, val nameItemSection: NameItemSection?) :
+    TwoPartNode<SiteItemSection, NameItemSection?>(siteItemSection, nameItemSection, ::SiteGroup),
+    MetaDataItem,
+    ReferenceItem
+
+fun isSiteGroup(node: Phase1Node) = firstSectionMatchesName(node, "site")
+
+fun validateSiteGroup(
+    node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
+) =
+    track(node, tracker) {
+        validateGroup(node.resolve(), errors, "site", DEFAULT_SITE_GROUP) { group ->
+            identifySections(group, errors, DEFAULT_SITE_GROUP, listOf("site", "name?")) {
+            sections ->
+                SiteGroup(
+                    siteItemSection =
+                        ensureNonNull(sections["site"], DEFAULT_SITE_ITEM_SECTION) {
+                            validateSiteItemSection(it, errors, tracker)
+                        },
+                    nameItemSection =
+                        ifNonNull(sections["name"]) {
+                            validateNameItemSection(it, errors, tracker)
+                        })
+            }
+        }
+    }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/SourceItemGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/SourceItemGroup.kt
@@ -43,7 +43,7 @@ data class SourceItemGroup(
     val pageSection: PageItemSection?,
     val offsetSection: OffsetItemSection?,
     val contentSection: ContentItemSection?
-) : MetaDataItem {
+) : MetaDataItem, ReferenceItem {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(sourceSection)
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/NameItemSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/NameItemSection.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section
+
+import mathlingua.frontend.chalktalk.phase1.ast.ChalkTalkTokenType
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Token
+import mathlingua.frontend.chalktalk.phase1.ast.getColumn
+import mathlingua.frontend.chalktalk.phase1.ast.getRow
+import mathlingua.frontend.chalktalk.phase2.CodeWriter
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_NAME_ITEM_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.indentedStringSection
+import mathlingua.frontend.chalktalk.phase2.ast.track
+import mathlingua.frontend.chalktalk.phase2.ast.validateSection
+import mathlingua.frontend.chalktalk.phase2.ast.validateSingleArg
+import mathlingua.frontend.support.MutableLocationTracker
+import mathlingua.frontend.support.ParseError
+
+data class NameItemSection(val name: String) : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) {}
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter) =
+        indentedStringSection(writer, isArg, indent, "name", name)
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node): Phase2Node {
+        return chalkTransformer(this)
+    }
+}
+
+fun validateNameItemSection(
+    node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
+) =
+    track(node, tracker) {
+        validateSection(node, errors, "name", DEFAULT_NAME_ITEM_SECTION) { section ->
+            validateSingleArg(section, errors, DEFAULT_NAME_ITEM_SECTION, "string") { arg ->
+                val resolved = arg.resolve()
+                if (resolved !is Phase1Token || resolved.type != ChalkTalkTokenType.String) {
+                    errors.add(
+                        ParseError(
+                            message = "Expected a string",
+                            row = getRow(node),
+                            column = getColumn(node)))
+                    DEFAULT_NAME_ITEM_SECTION
+                } else {
+                    NameItemSection(name = resolved.text)
+                }
+            }
+        }
+    }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/ReferenceSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/ReferenceSection.kt
@@ -20,30 +20,29 @@ import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_REFERENCE_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.SourceItemGroup
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.validateSourceItemGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.ReferenceItem
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.item.validateReferenceItem
 import mathlingua.frontend.chalktalk.phase2.ast.track
 import mathlingua.frontend.chalktalk.phase2.ast.validateSection
 import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
 
-data class ReferenceSection(val sourceItems: List<SourceItemGroup>) : Phase2Node {
-    override fun forEach(fn: (node: Phase2Node) -> Unit) = sourceItems.forEach(fn)
+data class ReferenceSection(val items: List<ReferenceItem>) : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) = items.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
         writer.writeHeader("reference")
-        for (sourceItem in sourceItems) {
+        for (item in items) {
             writer.writeNewline()
-            writer.append(sourceItem, true, indent + 2)
+            writer.append(item, true, indent + 2)
         }
         return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
         chalkTransformer(
-            ReferenceSection(
-                sourceItems = sourceItems.map { chalkTransformer(it) as SourceItemGroup }))
+            ReferenceSection(items = items.map { chalkTransformer(it) as ReferenceItem }))
 }
 
 fun validateReferenceSection(
@@ -52,6 +51,6 @@ fun validateReferenceSection(
     track(node, tracker) {
         validateSection(node, errors, "reference", DEFAULT_REFERENCE_SECTION) { section ->
             ReferenceSection(
-                sourceItems = section.args.map { validateSourceItemGroup(it, errors, tracker) })
+                items = section.args.map { validateReferenceItem(it, errors, tracker) })
         }
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/SiteItemSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/SiteItemSection.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section
+
+import mathlingua.frontend.chalktalk.phase1.ast.ChalkTalkTokenType
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Token
+import mathlingua.frontend.chalktalk.phase1.ast.getColumn
+import mathlingua.frontend.chalktalk.phase1.ast.getRow
+import mathlingua.frontend.chalktalk.phase2.CodeWriter
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_SITE_ITEM_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.frontend.chalktalk.phase2.ast.track
+import mathlingua.frontend.chalktalk.phase2.ast.validateSection
+import mathlingua.frontend.chalktalk.phase2.ast.validateSingleArg
+import mathlingua.frontend.support.MutableLocationTracker
+import mathlingua.frontend.support.ParseError
+
+data class SiteItemSection(val url: String) : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) {}
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("site")
+        writer.writeSpace()
+        val urlNoSpace = url.removeSurrounding("\"", "\"")
+        writer.writeUrl(urlNoSpace, null)
+        return writer
+    }
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node): Phase2Node {
+        return chalkTransformer(this)
+    }
+}
+
+fun validateSiteItemSection(
+    node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
+) =
+    track(node, tracker) {
+        validateSection(node, errors, "site", DEFAULT_SITE_ITEM_SECTION) { section ->
+            validateSingleArg(section, errors, DEFAULT_SITE_ITEM_SECTION, "string") { arg ->
+                val resolved = arg.resolve()
+                if (resolved !is Phase1Token || resolved.type != ChalkTalkTokenType.String) {
+                    errors.add(
+                        ParseError(
+                            message = "Expected a string",
+                            row = getRow(node),
+                            column = getColumn(node)))
+                    DEFAULT_SITE_ITEM_SECTION
+                } else {
+                    SiteItemSection(url = resolved.text)
+                }
+            }
+        }
+    }


### PR DESCRIPTION
The `site:name:` group can be used as a reference to specify a
website.  The HtmlCodeWriter creates an `<a>` element for a
url and truncates the length if it is too long.

For example,
```
Theorem:
...
Metadata:
. reference:
  . site: "https://en.wikipedia.org/wiki/Magma_(algebra)"
    name: "Magma"
```
will have the anchor's displayed value as
```
en.wikipedia.org/.../Magma_(algebra)
```

In addition, this change include improvements to the rendered
HTML to center the search box and to not zoom in on mobile
devices when entering text.
