### PR TITLE
feat: `mlg render` creates a dynamic webpage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.4.31'
     repositories {
         mavenCentral()
     }
@@ -54,9 +54,9 @@ dependencies {
     compile 'com.fifesoft:rsyntaxtextarea:3.0.3'
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile group: 'com.github.ajalt', name: 'clikt', version: '2.6.0'
-    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.3.7'
+    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.4.2'
     testImplementation 'com.willowtreeapps.assertk:assertk-jvm:0.19'
-    testImplementation 'org.jetbrains.kotlin:kotlin-reflect:1.3.41'
+    testImplementation 'org.jetbrains.kotlin:kotlin-reflect:1.4.31'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
     testImplementation "com.tylerthrailkill.helpers:pretty-print:2.0.2"
     testImplementation 'com.beust:klaxon:5.4'

--- a/src/main/kotlin/mathlingua/Main.kt
+++ b/src/main/kotlin/mathlingua/Main.kt
@@ -754,7 +754,49 @@ fun getIndexHtml(
                 mathlinguaToggleDropdown(id);
                 const path = SIGNATURE_TO_PATH.get(signature);
                 if (path) {
-                    window.open(path, '_blank');
+                    const bottom = document.getElementById('__bottom_panel__');
+                    if (bottom) {
+                        const key = path.replace(/\?.*/g, '')
+                                        .replace(/\.html/g, '.math')
+                                        .replace(/\.\.\//g, '');
+                        const index = path.replace(/.*\?show=/g, '');
+                        const entHtml = PATH_TO_ENTITY_LIST.get(key)[index];
+
+                        const ent = document.createElement('div');
+                        ent.className = 'mathlingua-top-level';
+                        ent.innerHTML = entHtml;
+
+                        const div = document.createElement('div');
+                        div.style.margin = '1em';
+                        div.style.display = 'inline-block';
+                        div.style.backgroundColor = '#ffffff';
+
+                        const closeButton = document.createElement('a');
+                        closeButton.text = '✕';
+                        closeButton.style.fontSize = '80%';
+                        closeButton.style.padding = '1ex';
+                        closeButton.style.float = 'right';
+                        closeButton.onclick = () => {
+                            bottom.removeChild(div);
+                            if (bottom.childElementCount === 0) {
+                                const content = document.getElementById('__main_content__');
+                                if (content) {
+                                    content.style.marginBottom = '1em';
+                                }
+                            }
+                        };
+
+                        div.appendChild(closeButton);
+                        div.appendChild(ent);
+
+                        bottom.appendChild(div);
+                        render(div);
+
+                        const content = document.getElementById('__main_content__');
+                        if (content) {
+                            content.style.marginBottom = bottom.clientHeight + 'px';
+                        }
+                    }
                 }
             }
 
@@ -1420,6 +1462,23 @@ fun getIndexHtml(
                     margin-left: 0;
                 }
             }
+
+            .bottom-panel {
+                background-color: #ffffff;
+                overflow-x: scroll;
+                overflow-y: hidden;
+                white-space: nowrap;
+                width: 100%;
+                max-width: max-content;
+                border-width: 1px;
+                border-color: #555555;
+                border-bottom-style: solid;
+                box-shadow: rgba(0, 0, 0, 0.3) 0px 3px 10px,
+                            inset 0  0 10px 0 rgba(200, 200, 200, 0.25);
+                z-index: 1;
+                bottom: 0;
+                position: fixed;
+            }
         </style>
     </head>
     <body id="main" onload="initPage()">
@@ -1438,8 +1497,8 @@ fun getIndexHtml(
             $fileListHtml
         </div>
 
-        <div class="content" id="__main_content__">
-        </div>
+        <div class='bottom-panel' id='__bottom_panel__'></div>
+        <div class="content" id="__main_content__"></div>
     </body>
 </html>
 """

--- a/src/test/kotlin/mathlingua/playground/MathLinguaPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/MathLinguaPlayground.kt
@@ -100,12 +100,11 @@ fun main() {
             val expand = expandButton.isSelected
 
             val htmlPair =
-                collection.prettyPrint(
-                    input = inputArea.text, html = true, js = "", doExpand = expand)
+                collection.prettyPrint(input = inputArea.text, html = true, doExpand = expand)
 
             val homeDir = File(System.getProperty("user.home"))
             val outputFile = File(homeDir, "mathlingua-playground.html")
-            outputFile.writeText(htmlPair.first)
+            outputFile.writeText(htmlPair.first.joinToString("\n"))
             Runtime.getRuntime().exec("open --background ${outputFile.absolutePath}")
 
             for (err in htmlPair.second) {
@@ -113,9 +112,8 @@ fun main() {
             }
 
             val inputPair =
-                collection.prettyPrint(
-                    input = inputArea.text, html = false, js = "", doExpand = expand)
-            outputArea.text = inputPair.first
+                collection.prettyPrint(input = inputArea.text, html = false, doExpand = expand)
+            outputArea.text = inputPair.first.joinToString("\n")
             for (err in inputPair.second) {
                 builder.append("${err.message} (${err.row+1}, ${err.column+1})\n")
             }

--- a/src/test/kotlin/mathlingua/playground/WrittenAsPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/WrittenAsPlayground.kt
@@ -156,8 +156,7 @@ private fun printExpanded(input: String, supplemental: String, html: Boolean): V
             is ValidationSuccess -> {
                 val collection = newSourceCollectionFromContent(listOf(input, supplemental))
                 result.append(
-                    collection.prettyPrint(
-                        node = validation.value, html = html, js = "", doExpand = true))
+                    collection.prettyPrint(node = validation.value, html = html, doExpand = true))
             }
         }
     }


### PR DESCRIPTION
Previously, `iframes` were used to hold subpages, and each
`.math` file had its own `.html` file.  Now, there is only a
single `index.html` that lists entities dynamically using
JavaScript.
