### PR TITLE
fix: make links work better

### DIFF
--- a/src/main/kotlin/mathlingua/Main.kt
+++ b/src/main/kotlin/mathlingua/Main.kt
@@ -47,6 +47,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.DefinesGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.FoundationGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.states.StatesGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.resource.ResourceGroup
 import mathlingua.frontend.support.ParseError
 import mathlingua.frontend.support.ValidationSuccess
 import mathlingua.frontend.support.validationFailure
@@ -182,6 +183,12 @@ fun getAllWords(node: Phase2Node): Set<String> {
 
 private fun getAllWordsImpl(node: Phase2Node, words: MutableSet<String>) {
     when (node) {
+        is ResourceGroup -> {
+            // searching for a reference with or without @ in front
+            // should find the associated reference group
+            words.add(node.id)
+            words.add("@node.id")
+        }
         is DefinesGroup -> {
             when (val validation = node.id.texTalkRoot
             ) {
@@ -289,6 +296,9 @@ private fun generateSignatureToPathImpl(
                     val grp = groups[i]
                     val signature =
                         when (grp) {
+                            is ResourceGroup -> {
+                                grp.id
+                            }
                             is DefinesGroup -> {
                                 grp.signature
                             }
@@ -296,8 +306,8 @@ private fun generateSignatureToPathImpl(
                                 grp.signature
                             }
                             is FoundationGroup -> {
-                                val content = grp.foundationSection.content
-                                when (content) {
+                                when (val content = grp.foundationSection.content
+                                ) {
                                     is DefinesGroup -> {
                                         content.signature
                                     }
@@ -1034,12 +1044,18 @@ const val SHARED_CSS =
     }
 
     .mathlingua-url {
-        color: #000000;
+        color: #0000aa;
+        text-decoration: none;
         display: block;
         margin: 0 0 -1em 0;
         padding: 0 0 0 2.5em;
         font-size: 80%;
         font-family: Georgia, 'Times New Roman', Times, serif;
+    }
+
+    .mathlingua-link {
+        color: #0000aa;
+        text-decoration: none;
     }
 
     .mathlingua-statement-no-render {
@@ -1194,6 +1210,7 @@ fun buildIndexHtml(
                                 const content = document.getElementById('__main_content__');
                                 if (content) {
                                     content.style.marginBottom = '1em';
+                                    bottom.style.display = 'none';
                                 }
                             }
                         };
@@ -1202,6 +1219,7 @@ fun buildIndexHtml(
                         div.appendChild(ent);
 
                         bottom.appendChild(div);
+                        bottom.style.display = 'block';
                         render(div);
 
                         const content = document.getElementById('__main_content__');
@@ -1564,6 +1582,7 @@ fun buildIndexHtml(
             }
 
             .bottom-panel {
+                display: none;
                 background-color: #ffffff;
                 overflow-x: scroll;
                 overflow-y: scroll;

--- a/src/main/kotlin/mathlingua/backend/transform/SignatureUtil.kt
+++ b/src/main/kotlin/mathlingua/backend/transform/SignatureUtil.kt
@@ -30,6 +30,7 @@ import mathlingua.frontend.support.ValidationSuccess
 import mathlingua.frontend.textalk.Command
 import mathlingua.frontend.textalk.CommandPart
 import mathlingua.frontend.textalk.ExpressionTexTalkNode
+import mathlingua.frontend.textalk.InTexTalkNode
 import mathlingua.frontend.textalk.IsTexTalkNode
 import mathlingua.frontend.textalk.TexTalkNode
 
@@ -99,7 +100,13 @@ private fun findAllSignaturesImpl(
                 signatures.add(Signature(form = sig, location = location))
             }
         }
-        return
+    } else if (texTalkNode is InTexTalkNode) {
+        for (expNode in texTalkNode.rhs.items) {
+            val sig = getMergedCommandSignature(expNode)
+            if (sig != null) {
+                signatures.add(Signature(form = sig, location = location))
+            }
+        }
     } else if (texTalkNode is Command) {
         val sig = texTalkNode.signature()
         signatures.add(Signature(form = sig, location = location))

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
@@ -202,10 +202,18 @@ open class HtmlCodeWriter(
                 }
             }
         builder.append(
-            "<span class=\"mathlingua-url\"><a target=\"_blank\" href=\"$urlNoSpace\">$title</a></span>")
+            "<span class=\"mathlingua-url\"><a class=\"mathlingua-link\" target=\"_blank\" href=\"$urlNoSpace\">$title</a></span>")
     }
 
     override fun writeText(text: String) {
+        if (text.startsWith("@") && !text.contains(' ')) {
+            builder.append("<span class='mathlingua-text-no-render'>")
+            builder.append(
+                "<a class=\"mathlingua-link\" onclick=\"mathlinguaViewSignature('${text.removePrefix("@")}')\">$text</a>")
+            builder.append("</span>")
+            return
+        }
+
         val textWithBreaks = newlinesToHtml(text)
         if (shouldExpand()) {
             val expansion =


### PR DESCRIPTION
For example, `\function:on{X \times/ X}:to{X}` previously would
not identify `\times/` as a signature.  It would only find
`\function:on:to`.  Also, references to ReferenceGroups were
not clickable.  These have both been addressed.
