### PR TITLE
feat: support signatures defined in `using:`

### DIFF
--- a/src/main/kotlin/mathlingua/backend/transform/Matcher.kt
+++ b/src/main/kotlin/mathlingua/backend/transform/Matcher.kt
@@ -54,7 +54,8 @@ internal fun Command.signature(): String {
 
 internal fun IdStatement.signature(locationTracker: MutableLocationTracker): Signature? {
     val signatures =
-        findAllStatementSignatures(stmt = this.toStatement(), locationTracker = locationTracker)
+        findAllStatementSignatures(
+            stmt = this.toStatement(), ignoreLhsEqual = false, locationTracker = locationTracker)
     val form = signatures.toList().firstOrNull()?.form ?: return null
     return Signature(
         form = form,

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
@@ -340,7 +340,8 @@ open class HtmlCodeWriter(
         builder.append("</div>")
         if (root is ValidationSuccess) {
             val stmt = Statement(text = stmtText, texTalkRoot = root)
-            val signatures = findAllStatementSignatures(stmt, newLocationTracker())
+            val signatures =
+                findAllStatementSignatures(stmt, ignoreLhsEqual = false, newLocationTracker())
             if (signatures.isNotEmpty()) {
                 builder.append(
                     "<div class='mathlingua-dropdown-menu-hidden' id='statement-$dropdownIndex'>")

--- a/src/test/kotlin/mathlingua/backend/transform/SignatureUtilKtTest.kt
+++ b/src/test/kotlin/mathlingua/backend/transform/SignatureUtilKtTest.kt
@@ -39,7 +39,8 @@ internal class SignatureUtilKtTest {
         assertThat(defines.size).isEqualTo(1)
         val def = defines[0]
         val stmt = def.id.toStatement()
-        val signatures = findAllStatementSignatures(stmt, newLocationTracker())
+        val signatures =
+            findAllStatementSignatures(stmt, ignoreLhsEqual = false, newLocationTracker())
         assertThat(signatures)
             .isEqualTo(setOf(Signature(form = "\\xyz", location = Location(row = -1, column = -1))))
     }
@@ -71,7 +72,8 @@ internal class SignatureUtilKtTest {
         assertThat(defines.size).isEqualTo(1)
         val def = defines[0]
         val stmt = def.id.toStatement()
-        val signatures = findAllStatementSignatures(stmt, newLocationTracker())
+        val signatures =
+            findAllStatementSignatures(stmt, ignoreLhsEqual = false, newLocationTracker())
         assertThat(signatures)
             .isEqualTo(setOf(Signature(form = "\\abc", location = Location(row = -1, column = -1))))
     }


### PR DESCRIPTION
Now the following code will check correctly:
```
Theorem:
given: x
then: '@x'
using: '@y := 0'
```
In particular, the fact that `@y` is defined in a `using:` section
the use of `@x` won't be marked as using an undefined signature
`@`.
