### PR TITLE
feat: check function signature arg count

### DIFF
--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
@@ -141,39 +141,54 @@ fun validateDefinesCollectsGroup(
                     "written",
                     "Metadata?")) { sections ->
                 val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
-                DefinesCollectsGroup(
-                    signature = id.signature(tracker),
-                    id = id,
-                    definesSection =
-                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
-                            validateDefinesSection(it, errors, tracker)
-                        },
-                    requiringSection =
-                        ifNonNull(sections["requiring"]) {
-                            validateRequiringSection(it, errors, tracker)
-                        },
-                    whenSection =
-                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
-                    meansSection =
-                        ifNonNull(sections["means"]) { validateMeansSection(it, errors, tracker) },
-                    collectsSection =
-                        ensureNonNull(sections["collects"], DEFAULT_COLLECTS_SECTION) {
-                            validateCollectsSection(it, errors, tracker)
-                        },
-                    viewedSection =
-                        ifNonNull(sections["viewed"]) {
-                            validateViewedSection(it, errors, tracker)
-                        },
-                    usingSection =
-                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
-                    writtenSection =
-                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
-                            validateWrittenSection(it, errors, tracker)
-                        },
-                    metaDataSection =
-                        ifNonNull(sections["Metadata"]) {
-                            validateMetaDataSection(it, errors, tracker)
-                        })
+                val def =
+                    DefinesCollectsGroup(
+                        signature = id.signature(tracker),
+                        id = id,
+                        definesSection =
+                            ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                                validateDefinesSection(it, errors, tracker)
+                            },
+                        requiringSection =
+                            ifNonNull(sections["requiring"]) {
+                                validateRequiringSection(it, errors, tracker)
+                            },
+                        whenSection =
+                            ifNonNull(sections["when"]) {
+                                validateWhenSection(it, errors, tracker)
+                            },
+                        meansSection =
+                            ifNonNull(sections["means"]) {
+                                validateMeansSection(it, errors, tracker)
+                            },
+                        collectsSection =
+                            ensureNonNull(sections["collects"], DEFAULT_COLLECTS_SECTION) {
+                                validateCollectsSection(it, errors, tracker)
+                            },
+                        viewedSection =
+                            ifNonNull(sections["viewed"]) {
+                                validateViewedSection(it, errors, tracker)
+                            },
+                        usingSection =
+                            ifNonNull(sections["using"]) {
+                                validateUsingSection(it, errors, tracker)
+                            },
+                        writtenSection =
+                            ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                                validateWrittenSection(it, errors, tracker)
+                            },
+                        metaDataSection =
+                            ifNonNull(sections["Metadata"]) {
+                                validateMetaDataSection(it, errors, tracker)
+                            })
+
+                val funcArgsError = checkIfFunctionSignatureMatchDefines(def, tracker)
+                if (funcArgsError != null) {
+                    errors.add(funcArgsError)
+                    DEFAULT_DEFINES_COLLECTS_GROUP
+                } else {
+                    def
+                }
             }
         }
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
@@ -141,39 +141,54 @@ fun validateDefinesEvaluatedGroup(
                     "written",
                     "Metadata?")) { sections ->
                 val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
-                DefinesEvaluatedGroup(
-                    signature = id.signature(tracker),
-                    id = id,
-                    definesSection =
-                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
-                            validateDefinesSection(it, errors, tracker)
-                        },
-                    requiringSection =
-                        ifNonNull(sections["requiring"]) {
-                            validateRequiringSection(it, errors, tracker)
-                        },
-                    whenSection =
-                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
-                    meansSection =
-                        ifNonNull(sections["means"]) { validateMeansSection(it, errors, tracker) },
-                    evaluatedSection =
-                        ensureNonNull(sections["evaluated"], DEFAULT_EVALUATED_SECTION) {
-                            validateEvaluatedSection(it, errors, tracker)
-                        },
-                    viewedSection =
-                        ifNonNull(sections["viewed"]) {
-                            validateViewedSection(it, errors, tracker)
-                        },
-                    usingSection =
-                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
-                    writtenSection =
-                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
-                            validateWrittenSection(it, errors, tracker)
-                        },
-                    metaDataSection =
-                        ifNonNull(sections["Metadata"]) {
-                            validateMetaDataSection(it, errors, tracker)
-                        })
+                val def =
+                    DefinesEvaluatedGroup(
+                        signature = id.signature(tracker),
+                        id = id,
+                        definesSection =
+                            ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                                validateDefinesSection(it, errors, tracker)
+                            },
+                        requiringSection =
+                            ifNonNull(sections["requiring"]) {
+                                validateRequiringSection(it, errors, tracker)
+                            },
+                        whenSection =
+                            ifNonNull(sections["when"]) {
+                                validateWhenSection(it, errors, tracker)
+                            },
+                        meansSection =
+                            ifNonNull(sections["means"]) {
+                                validateMeansSection(it, errors, tracker)
+                            },
+                        evaluatedSection =
+                            ensureNonNull(sections["evaluated"], DEFAULT_EVALUATED_SECTION) {
+                                validateEvaluatedSection(it, errors, tracker)
+                            },
+                        viewedSection =
+                            ifNonNull(sections["viewed"]) {
+                                validateViewedSection(it, errors, tracker)
+                            },
+                        usingSection =
+                            ifNonNull(sections["using"]) {
+                                validateUsingSection(it, errors, tracker)
+                            },
+                        writtenSection =
+                            ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                                validateWrittenSection(it, errors, tracker)
+                            },
+                        metaDataSection =
+                            ifNonNull(sections["Metadata"]) {
+                                validateMetaDataSection(it, errors, tracker)
+                            })
+
+                val funcArgsError = checkIfFunctionSignatureMatchDefines(def, tracker)
+                if (funcArgsError != null) {
+                    errors.add(funcArgsError)
+                    DEFAULT_DEFINES_EVALUATED_GROUP
+                } else {
+                    def
+                }
             }
         }
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
@@ -141,39 +141,54 @@ fun validateDefinesGeneratedGroup(
                     "written",
                     "Metadata?")) { sections ->
                 val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
-                DefinesGeneratedGroup(
-                    signature = id.signature(tracker),
-                    id = id,
-                    definesSection =
-                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
-                            validateDefinesSection(it, errors, tracker)
-                        },
-                    requiringSection =
-                        ifNonNull(sections["requiring"]) {
-                            validateRequiringSection(it, errors, tracker)
-                        },
-                    whenSection =
-                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
-                    meansSection =
-                        ifNonNull(sections["means"]) { validateMeansSection(it, errors, tracker) },
-                    generatedSection =
-                        ensureNonNull(sections["generated"], DEFAULT_GENERATED_SECTION) {
-                            validateGeneratedSection(it, errors, tracker)
-                        },
-                    viewedSection =
-                        ifNonNull(sections["viewed"]) {
-                            validateViewedSection(it, errors, tracker)
-                        },
-                    usingSection =
-                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
-                    writtenSection =
-                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
-                            validateWrittenSection(it, errors, tracker)
-                        },
-                    metaDataSection =
-                        ifNonNull(sections["Metadata"]) {
-                            validateMetaDataSection(it, errors, tracker)
-                        })
+                val def =
+                    DefinesGeneratedGroup(
+                        signature = id.signature(tracker),
+                        id = id,
+                        definesSection =
+                            ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                                validateDefinesSection(it, errors, tracker)
+                            },
+                        requiringSection =
+                            ifNonNull(sections["requiring"]) {
+                                validateRequiringSection(it, errors, tracker)
+                            },
+                        whenSection =
+                            ifNonNull(sections["when"]) {
+                                validateWhenSection(it, errors, tracker)
+                            },
+                        meansSection =
+                            ifNonNull(sections["means"]) {
+                                validateMeansSection(it, errors, tracker)
+                            },
+                        generatedSection =
+                            ensureNonNull(sections["generated"], DEFAULT_GENERATED_SECTION) {
+                                validateGeneratedSection(it, errors, tracker)
+                            },
+                        viewedSection =
+                            ifNonNull(sections["viewed"]) {
+                                validateViewedSection(it, errors, tracker)
+                            },
+                        usingSection =
+                            ifNonNull(sections["using"]) {
+                                validateUsingSection(it, errors, tracker)
+                            },
+                        writtenSection =
+                            ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                                validateWrittenSection(it, errors, tracker)
+                            },
+                        metaDataSection =
+                            ifNonNull(sections["Metadata"]) {
+                                validateMetaDataSection(it, errors, tracker)
+                            })
+
+                val funcArgsError = checkIfFunctionSignatureMatchDefines(def, tracker)
+                if (funcArgsError != null) {
+                    errors.add(funcArgsError)
+                    DEFAULT_DEFINES_GENERATED_GROUP
+                } else {
+                    def
+                }
             }
         }
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesInstantiatedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesInstantiatedGroup.kt
@@ -137,37 +137,50 @@ fun validateDefinesInstantiatedGroup(
                     "written",
                     "Metadata?")) { sections ->
                 val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
-                DefinesInstantiatedGroup(
-                    signature = id.signature(tracker),
-                    id = id,
-                    definesSection =
-                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
-                            validateDefinesSection(it, errors, tracker)
-                        },
-                    requiringSection =
-                        ifNonNull(sections["requiring"]) {
-                            validateRequiringSection(it, errors, tracker)
-                        },
-                    whenSection =
-                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
-                    instantiatedSection =
-                        ensureNonNull(sections["instantiated"], DEFAULT_INSTANTIATED_SECTION) {
-                            validateInstantiatedSection(it, errors, tracker)
-                        },
-                    viewedSection =
-                        ifNonNull(sections["viewed"]) {
-                            validateViewedSection(it, errors, tracker)
-                        },
-                    usingSection =
-                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
-                    writtenSection =
-                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
-                            validateWrittenSection(it, errors, tracker)
-                        },
-                    metaDataSection =
-                        ifNonNull(sections["Metadata"]) {
-                            validateMetaDataSection(it, errors, tracker)
-                        })
+                val def =
+                    DefinesInstantiatedGroup(
+                        signature = id.signature(tracker),
+                        id = id,
+                        definesSection =
+                            ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                                validateDefinesSection(it, errors, tracker)
+                            },
+                        requiringSection =
+                            ifNonNull(sections["requiring"]) {
+                                validateRequiringSection(it, errors, tracker)
+                            },
+                        whenSection =
+                            ifNonNull(sections["when"]) {
+                                validateWhenSection(it, errors, tracker)
+                            },
+                        instantiatedSection =
+                            ensureNonNull(sections["instantiated"], DEFAULT_INSTANTIATED_SECTION) {
+                                validateInstantiatedSection(it, errors, tracker)
+                            },
+                        viewedSection =
+                            ifNonNull(sections["viewed"]) {
+                                validateViewedSection(it, errors, tracker)
+                            },
+                        usingSection =
+                            ifNonNull(sections["using"]) {
+                                validateUsingSection(it, errors, tracker)
+                            },
+                        writtenSection =
+                            ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                                validateWrittenSection(it, errors, tracker)
+                            },
+                        metaDataSection =
+                            ifNonNull(sections["Metadata"]) {
+                                validateMetaDataSection(it, errors, tracker)
+                            })
+
+                val funcArgsError = checkIfFunctionSignatureMatchDefines(def, tracker)
+                if (funcArgsError != null) {
+                    errors.add(funcArgsError)
+                    DEFAULT_DEFINES_INSTANTIATED_GROUP
+                } else {
+                    def
+                }
             }
         }
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
@@ -141,39 +141,54 @@ fun validateDefinesMapsGroup(
                     "written",
                     "Metadata?")) { sections ->
                 val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
-                DefinesMapsGroup(
-                    signature = id.signature(tracker),
-                    id = id,
-                    definesSection =
-                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
-                            validateDefinesSection(it, errors, tracker)
-                        },
-                    requiringSection =
-                        ifNonNull(sections["requiring"]) {
-                            validateRequiringSection(it, errors, tracker)
-                        },
-                    whenSection =
-                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
-                    meansSection =
-                        ifNonNull(sections["means"]) { validateMeansSection(it, errors, tracker) },
-                    mapsSection =
-                        ensureNonNull(sections["maps"], DEFAULT_MAPS_SECTION) {
-                            validateMapsSection(it, errors, tracker)
-                        },
-                    viewedSection =
-                        ifNonNull(sections["viewed"]) {
-                            validateViewedSection(it, errors, tracker)
-                        },
-                    usingSection =
-                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
-                    writtenSection =
-                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
-                            validateWrittenSection(it, errors, tracker)
-                        },
-                    metaDataSection =
-                        ifNonNull(sections["Metadata"]) {
-                            validateMetaDataSection(it, errors, tracker)
-                        })
+                val def =
+                    DefinesMapsGroup(
+                        signature = id.signature(tracker),
+                        id = id,
+                        definesSection =
+                            ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                                validateDefinesSection(it, errors, tracker)
+                            },
+                        requiringSection =
+                            ifNonNull(sections["requiring"]) {
+                                validateRequiringSection(it, errors, tracker)
+                            },
+                        whenSection =
+                            ifNonNull(sections["when"]) {
+                                validateWhenSection(it, errors, tracker)
+                            },
+                        meansSection =
+                            ifNonNull(sections["means"]) {
+                                validateMeansSection(it, errors, tracker)
+                            },
+                        mapsSection =
+                            ensureNonNull(sections["maps"], DEFAULT_MAPS_SECTION) {
+                                validateMapsSection(it, errors, tracker)
+                            },
+                        viewedSection =
+                            ifNonNull(sections["viewed"]) {
+                                validateViewedSection(it, errors, tracker)
+                            },
+                        usingSection =
+                            ifNonNull(sections["using"]) {
+                                validateUsingSection(it, errors, tracker)
+                            },
+                        writtenSection =
+                            ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                                validateWrittenSection(it, errors, tracker)
+                            },
+                        metaDataSection =
+                            ifNonNull(sections["Metadata"]) {
+                                validateMetaDataSection(it, errors, tracker)
+                            })
+
+                val funcArgsError = checkIfFunctionSignatureMatchDefines(def, tracker)
+                if (funcArgsError != null) {
+                    errors.add(funcArgsError)
+                    DEFAULT_DEFINES_MAPS_GROUP
+                } else {
+                    def
+                }
             }
         }
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
@@ -142,41 +142,54 @@ fun validateDefinesMeansGroup(
                     "written",
                     "Metadata?")) { sections ->
                 val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
-                DefinesMeansGroup(
-                    signature = id.signature(tracker),
-                    id = id,
-                    definesSection =
-                        ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
-                            validateDefinesSection(it, errors, tracker)
-                        },
-                    requiringSection =
-                        ifNonNull(sections["requiring"]) {
-                            validateRequiringSection(it, errors, tracker)
-                        },
-                    whenSection =
-                        ifNonNull(sections["when"]) { validateWhenSection(it, errors, tracker) },
-                    meansSection =
-                        ensureNonNull(sections["means"], DEFAULT_MEANS_SECTION) {
-                            validateMeansSection(it, errors, tracker)
-                        },
-                    satisfyingSection =
-                        ifNonNull(sections["satisfying"]) {
-                            validateSpecifiesSection(it, errors, tracker)
-                        },
-                    viewedSection =
-                        ifNonNull(sections["viewed"]) {
-                            validateViewedSection(it, errors, tracker)
-                        },
-                    usingSection =
-                        ifNonNull(sections["using"]) { validateUsingSection(it, errors, tracker) },
-                    writtenSection =
-                        ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
-                            validateWrittenSection(it, errors, tracker)
-                        },
-                    metaDataSection =
-                        ifNonNull(sections["Metadata"]) {
-                            validateMetaDataSection(it, errors, tracker)
-                        })
+                val def =
+                    DefinesMeansGroup(
+                        signature = id.signature(tracker),
+                        id = id,
+                        definesSection =
+                            ensureNonNull(sections["Defines"], DEFAULT_DEFINES_SECTION) {
+                                validateDefinesSection(it, errors, tracker)
+                            },
+                        requiringSection =
+                            ifNonNull(sections["requiring"]) {
+                                validateRequiringSection(it, errors, tracker)
+                            },
+                        whenSection =
+                            ifNonNull(sections["when"]) {
+                                validateWhenSection(it, errors, tracker)
+                            },
+                        meansSection =
+                            ensureNonNull(sections["means"], DEFAULT_MEANS_SECTION) {
+                                validateMeansSection(it, errors, tracker)
+                            },
+                        satisfyingSection =
+                            ifNonNull(sections["satisfying"]) {
+                                validateSpecifiesSection(it, errors, tracker)
+                            },
+                        viewedSection =
+                            ifNonNull(sections["viewed"]) {
+                                validateViewedSection(it, errors, tracker)
+                            },
+                        usingSection =
+                            ifNonNull(sections["using"]) {
+                                validateUsingSection(it, errors, tracker)
+                            },
+                        writtenSection =
+                            ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
+                                validateWrittenSection(it, errors, tracker)
+                            },
+                        metaDataSection =
+                            ifNonNull(sections["Metadata"]) {
+                                validateMetaDataSection(it, errors, tracker)
+                            })
+
+                val funcArgsError = checkIfFunctionSignatureMatchDefines(def, tracker)
+                if (funcArgsError != null) {
+                    errors.add(funcArgsError)
+                    DEFAULT_DEFINES_MEANS_GROUP
+                } else {
+                    def
+                }
             }
         }
     }


### PR DESCRIPTION
Now if the signature of the `Defines:` group specifies a function
(specifically if the signature contains a parens) then a check
is done to make sure the defines specifies a function.

That is, if the signature is `\something(x, y)` then the
defines must define a function `f(x, y)` that has exactly the
two arguments `x` and `y`.  That is, the count and name of the
arguments must match.

Note that if the signature doesn't have parens, then the
defines can still define a function.  For example, a defines
`\bounded.function` that specifies a function `f(x)` with certain
properties is still valid.
