### PR TITLE
chore: introduce the `VirtualFileSystem`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ group = 'mathlingua'
 version = '0.13'
 sourceCompatibility = '1.8'
 
-mainClassName = 'mathlingua.MainKt'
+mainClassName = 'mathlingua.cli.MainKt'
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/mathlingua/cli/Logger.kt
+++ b/src/main/kotlin/mathlingua/cli/Logger.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.cli
+
+import com.github.ajalt.clikt.output.TermUi
+
+interface Logger {
+    fun log(message: String)
+    fun error(message: String)
+}
+
+class TermUiLogger(private val termUi: TermUi) : Logger {
+    override fun log(message: String) = termUi.echo(message = message, err = false)
+
+    override fun error(message: String) = termUi.echo(message = message, err = true)
+}
+
+class MemoryLogger : Logger {
+    private val logs = mutableListOf<String>()
+    private val errors = mutableListOf<String>()
+
+    override fun log(message: String) {
+        logs.add(message)
+    }
+
+    override fun error(message: String) {
+        errors.add(message)
+    }
+
+    fun getLogs(): List<String> {
+        return logs
+    }
+
+    fun getErrors(): List<String> {
+        return errors
+    }
+}

--- a/src/main/kotlin/mathlingua/cli/Main.kt
+++ b/src/main/kotlin/mathlingua/cli/Main.kt
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.output.TermUi
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.arguments.optional
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import java.io.File
+import java.nio.file.FileSystems
+import java.nio.file.Paths
+import java.nio.file.StandardWatchEventKinds
+import java.nio.file.WatchService
+import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
+
+private fun getCwd() = Paths.get(".").toAbsolutePath().normalize().toFile()
+
+private fun cwdParts() = getCwd().absolutePath.split(File.separator)
+
+private fun toVirtualFile(fs: VirtualFileSystem, path: String): VirtualFile {
+    val file = File(path).normalize().absoluteFile
+    val relPath = file.toRelativeString(getCwd()).split(File.separator)
+    return if (file.isDirectory) {
+        fs.getDirectory(relPath)
+    } else {
+        fs.getFile(relPath)
+    }
+}
+
+private class Mlg : CliktCommand() {
+    override fun run() = Unit
+}
+
+private class Check : CliktCommand(help = "Check input files for errors.") {
+    private val file: List<String> by argument(
+            help = "The *.math files and/or directories to process")
+        .multiple(required = false)
+    private val json: Boolean by option(help = "Output the results in JSON format.").flag()
+
+    override fun run(): Unit =
+        runBlocking {
+            val fs = newDiskFileSystem(cwdParts())
+            exitProcess(
+                Mathlingua.check(
+                    fs = fs,
+                    logger = TermUiLogger(termUi = TermUi),
+                    files = file.toList().map { toVirtualFile(fs, it) },
+                    json = json))
+        }
+}
+
+private class Version : CliktCommand(help = "Prints the tool and MathLingua language version.") {
+    override fun run() {
+        exitProcess(Mathlingua.version(logger = TermUiLogger(termUi = TermUi)))
+    }
+}
+
+private class Watch :
+    CliktCommand("Watches the working directory for changes and renders the code on file changes") {
+
+    private fun isHidden(file: File): Boolean {
+        if (file.name.startsWith(".")) {
+            return true
+        }
+
+        val parent = file.parentFile ?: return false
+        return isHidden(parent)
+    }
+
+    override fun run(): Unit =
+        runBlocking {
+            val fs = newDiskFileSystem(cwdParts())
+            val logger = TermUiLogger(termUi = TermUi)
+
+            fun registerAll(file: File, watchService: WatchService) {
+                if (file.isDirectory) {
+                    file.walk().forEach {
+                        val path = it.toPath()
+                        if (it.isDirectory && !isHidden(it)) {
+                            path.register(
+                                watchService,
+                                StandardWatchEventKinds.ENTRY_CREATE,
+                                StandardWatchEventKinds.ENTRY_DELETE,
+                                StandardWatchEventKinds.ENTRY_MODIFY)
+                        }
+                    }
+                }
+            }
+
+            var watchService = FileSystems.getDefault().newWatchService()
+            val cwd = Paths.get(".").toAbsolutePath().normalize().toFile()
+            registerAll(cwd, watchService)
+
+            // do an initial render to ensure the docs directory is up-to-date
+            // even before any changes occur
+            Mathlingua.render(
+                fs = fs,
+                logger = logger,
+                file = null,
+                noexpand = false,
+                stdout = false,
+                raw = false)
+            logger.log("")
+
+            logger.log("Waiting for changes...")
+            logger.log("")
+
+            while (true) {
+                var doRender = false
+                val watchKey = watchService.take()
+                for (event in watchKey.pollEvents()) {
+                    val filename = event.context().toString()
+                    if (!filename.endsWith(".html") || filename == "docs-home.html") {
+                        doRender = true
+                    }
+                    if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE ||
+                        event.kind() == StandardWatchEventKinds.ENTRY_DELETE) {
+                        watchService.close()
+                        watchService = FileSystems.getDefault().newWatchService()
+                        registerAll(cwd, watchService)
+                    }
+                }
+
+                if (doRender) {
+                    logger.log("Change detected...")
+                    Mathlingua.render(
+                        fs = fs,
+                        logger = logger,
+                        file = null,
+                        noexpand = false,
+                        stdout = false,
+                        raw = false)
+                    logger.log("")
+                }
+
+                watchKey.reset()
+            }
+        }
+}
+
+private class Render : CliktCommand("Generates HTML code with definitions expanded.") {
+    private val file: String? by argument(
+            help =
+                "If specified, the .math file to render as an HTML document.  Otherwise, all .math files " +
+                    "in the 'contents' directory will be rendered into a single dynamic HTML document.")
+        .optional()
+    private val noexpand: Boolean by option(
+            help =
+                "Specifies to not expand the contents of entries using the 'written' form of definitions.")
+        .flag()
+    private val stdout: Boolean by option(
+            help =
+                "If specified, the rendered content will be printed to standard " +
+                    "out.  Otherwise, it is written to a file in the `docs` directory with the same path as the " +
+                    "input file except for a '.html' extension if the FILE argument is specified.  Otherwise, the " +
+                    "content is written to an `index.html` file in the `docs` directory.")
+        .flag()
+    private val raw: Boolean by option(
+            help =
+                "If specified with a single file, the raw HTML will be rendered excluding any " +
+                    "script or style tages.  It is an error to specify this flag without specify a specific " +
+                    "file to render.")
+        .flag()
+
+    override fun run(): Unit =
+        runBlocking {
+            val fs = newDiskFileSystem(cwdParts())
+            exitProcess(
+                Mathlingua.render(
+                    fs = fs,
+                    logger = TermUiLogger(termUi = TermUi),
+                    file =
+                        if (file == null) {
+                            null
+                        } else {
+                            toVirtualFile(fs, file!!)
+                        },
+                    noexpand = noexpand,
+                    stdout = stdout,
+                    raw = raw))
+        }
+}
+
+// this value will be populated in main()
+var helpText = ""
+
+class Help : CliktCommand(help = "Show this message and exit") {
+    override fun run() {
+        val logger = TermUiLogger(termUi = TermUi)
+        logger.log(helpText)
+        exitProcess(0)
+    }
+}
+
+class Clean : CliktCommand(help = "Delete the docs directory") {
+    override fun run() {
+        val fs = newDiskFileSystem(cwdParts())
+        val logger = TermUiLogger(termUi = TermUi)
+        exitProcess(Mathlingua.clean(fs, logger))
+    }
+}
+
+fun main(args: Array<String>) {
+    val mlg = Mlg().subcommands(Help(), Check(), Clean(), Render(), Watch(), Version())
+    helpText = mlg.getFormattedHelp()
+    mlg.main(args)
+}

--- a/src/main/kotlin/mathlingua/cli/VirtualFileSystem.kt
+++ b/src/main/kotlin/mathlingua/cli/VirtualFileSystem.kt
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.cli
+
+import java.io.File
+import java.io.IOException
+
+interface VirtualFile {
+    fun absolutePath(): List<String>
+    fun relativePathTo(dir: VirtualFile): List<String>
+    fun isDirectory(): Boolean
+    fun exists(): Boolean
+    fun readText(): String
+    fun writeText(text: String)
+    fun mkdirs(): Boolean
+    fun listFiles(): List<VirtualFile>
+    fun delete(): Boolean
+}
+
+interface VirtualFileSystem {
+    fun getFile(relativePath: List<String>): VirtualFile
+    fun getDirectory(relativePath: List<String>): VirtualFile
+    fun cwd(): VirtualFile
+    fun relativePathTo(vf: VirtualFile, dir: VirtualFile): List<String>
+    fun exists(vf: VirtualFile): Boolean
+    fun mkdirs(vf: VirtualFile): Boolean
+    fun readText(vf: VirtualFile): String
+    fun writeText(vf: VirtualFile, content: String)
+    fun listFiles(vf: VirtualFile): List<VirtualFile>
+    // deletes the virtual file if it is a file and recursively
+    // if it is a directory
+    fun delete(vf: VirtualFile): Boolean
+}
+
+fun newDiskFileSystem(cwd: List<String>): VirtualFileSystem {
+    return DiskFileSystem(cwd)
+}
+
+fun newMemoryFileSystem(cwd: List<String>): VirtualFileSystem {
+    return MemoryFileSystem(cwd)
+}
+
+data class VirtualFileImpl(
+    private val absolutePathParts: List<String>,
+    private val directory: Boolean,
+    private val fs: VirtualFileSystem
+) : VirtualFile {
+
+    override fun absolutePath() = absolutePathParts
+
+    override fun relativePathTo(dir: VirtualFile) = fs.relativePathTo(this, dir)
+
+    override fun isDirectory() = directory
+
+    override fun exists() = fs.exists(this)
+
+    override fun readText() = fs.readText(this)
+
+    override fun writeText(text: String) = fs.writeText(this, text)
+
+    override fun mkdirs() = fs.mkdirs(this)
+
+    override fun listFiles() = fs.listFiles(this)
+
+    override fun delete() = fs.delete(this)
+}
+
+private class DiskFileSystem(private val cwd: List<String>) : VirtualFileSystem {
+    private val cwdFile = VirtualFileImpl(absolutePathParts = cwd, directory = true, this)
+
+    private fun getAbsolutePath(relativePath: List<String>): List<String> {
+        val absolutePath = mutableListOf<String>()
+        absolutePath.addAll(cwd)
+        absolutePath.addAll(relativePath)
+        return absolutePath
+    }
+
+    override fun getFile(relativePath: List<String>): VirtualFile {
+        return VirtualFileImpl(
+            absolutePathParts = getAbsolutePath(relativePath), directory = false, fs = this)
+    }
+
+    override fun getDirectory(relativePath: List<String>): VirtualFile {
+        return VirtualFileImpl(
+            absolutePathParts = getAbsolutePath(relativePath), directory = true, fs = this)
+    }
+
+    override fun cwd() = cwdFile
+
+    private fun VirtualFile.toFile() =
+        File(this.absolutePath().joinToString(File.separator)).normalize()
+
+    override fun relativePathTo(vf: VirtualFile, dir: VirtualFile) =
+        vf.toFile().toRelativeString(dir.toFile()).split(File.separator)
+
+    override fun exists(vf: VirtualFile) = vf.toFile().exists()
+
+    override fun mkdirs(vf: VirtualFile) = vf.toFile().mkdirs()
+
+    override fun readText(vf: VirtualFile) = vf.toFile().readText()
+
+    override fun writeText(vf: VirtualFile, content: String) = vf.toFile().writeText(content)
+
+    override fun listFiles(vf: VirtualFile) =
+        (vf.toFile().listFiles() ?: arrayOf()).map {
+            VirtualFileImpl(
+                absolutePathParts = it.absolutePath.split(File.separator),
+                directory = it.isDirectory,
+                this)
+        }
+
+    override fun delete(vf: VirtualFile): Boolean {
+        val file = vf.toFile()
+        return if (file.isDirectory) {
+            file.deleteRecursively()
+        } else {
+            file.delete()
+        }
+    }
+}
+
+private class MemoryFileNode(
+    val name: String,
+    val isDirectory: Boolean,
+    var content: String,
+    val children: MutableMap<String, MemoryFileNode>)
+
+private class MemoryFileSystem(private val cwd: List<String>) : VirtualFileSystem {
+
+    private val root =
+        MemoryFileNode(name = "", isDirectory = true, content = "", children = mutableMapOf())
+
+    private val cwdFile = VirtualFileImpl(absolutePathParts = cwd, directory = true, fs = this)
+
+    init {
+        var tail = root
+        for (part in cwd) {
+            val child =
+                MemoryFileNode(
+                    name = part, isDirectory = true, content = "", children = mutableMapOf())
+            tail.children[part] = child
+            tail = child
+        }
+    }
+
+    private fun getAbsolutePath(relativePath: List<String>): List<String> {
+        val absolutePath = mutableListOf<String>()
+        absolutePath.addAll(cwd)
+        absolutePath.addAll(relativePath)
+        return absolutePath
+    }
+
+    override fun getFile(relativePath: List<String>): VirtualFile {
+        return VirtualFileImpl(
+            absolutePathParts = getAbsolutePath(relativePath), directory = false, fs = this)
+    }
+
+    override fun getDirectory(relativePath: List<String>): VirtualFile {
+        return VirtualFileImpl(
+            absolutePathParts = getAbsolutePath(relativePath), directory = true, fs = this)
+    }
+
+    override fun cwd() = cwdFile
+
+    override fun relativePathTo(vf: VirtualFile, dir: VirtualFile): List<String> {
+        val vfParts = vf.absolutePath()
+        val dirParts = dir.absolutePath()
+        var i = 0
+        while (i < dirParts.size && i < vfParts.size && dirParts[i] == vfParts[i]) {
+            i++
+        }
+        val relParts = mutableListOf<String>()
+        while (i < vfParts.size) {
+            relParts.add(vfParts[i])
+        }
+        return relParts
+    }
+
+    override fun exists(vf: VirtualFile): Boolean {
+        var tail = root
+        for (part in vf.absolutePath()) {
+            if (!tail.children.containsKey(part)) {
+                return false
+            }
+            tail = tail.children[part]!!
+        }
+        return true
+    }
+
+    override fun mkdirs(vf: VirtualFile): Boolean {
+        var tail = root
+        for (part in vf.absolutePath()) {
+            if (!tail.children.containsKey(part)) {
+                val child =
+                    MemoryFileNode(
+                        name = part, isDirectory = true, content = "", children = mutableMapOf())
+                tail.children[part] = child
+                tail = child
+            } else {
+                val child = tail.children[part]!!
+                if (!child.isDirectory) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    private fun getMemoryNode(absolutePath: List<String>, createAsFile: Boolean): MemoryFileNode {
+        var tail = root
+        for (part in absolutePath) {
+            if (!tail.children.containsKey(part)) {
+                if (createAsFile) {
+                    val newFile =
+                        MemoryFileNode(
+                            name = part,
+                            isDirectory = false,
+                            content = "",
+                            children = mutableMapOf())
+                    tail.children[part] = newFile
+                    tail = newFile
+                } else {
+                    throw IOException(
+                        "File not found: ${absolutePath.joinToString(File.separator)}")
+                }
+            } else {
+                tail = tail.children[part]!!
+            }
+        }
+        return tail
+    }
+
+    override fun readText(vf: VirtualFile) =
+        getMemoryNode(vf.absolutePath(), createAsFile = false).content
+
+    override fun writeText(vf: VirtualFile, content: String) {
+        getMemoryNode(vf.absolutePath(), createAsFile = true).content = content
+    }
+
+    override fun listFiles(vf: VirtualFile): List<VirtualFile> {
+        val node = getMemoryNode(vf.absolutePath(), createAsFile = false)
+        return node.children.values.map {
+            val parts = mutableListOf<String>()
+            parts.addAll(vf.absolutePath())
+            parts.add(it.name)
+            VirtualFileImpl(absolutePathParts = parts, directory = it.isDirectory, fs = this)
+        }
+    }
+
+    override fun delete(vf: VirtualFile): Boolean {
+        val path = vf.absolutePath()
+        val parentPath = path.filterIndexed { index, _ -> index < path.size - 1 }
+        val parent = getMemoryNode(parentPath, createAsFile = true)
+        val name = path.last()
+        parent.children.remove(name)
+        return true
+    }
+}

--- a/src/test/kotlin/mathlingua/MathLinguaTest.kt
+++ b/src/test/kotlin/mathlingua/MathLinguaTest.kt
@@ -3,9 +3,11 @@ package mathlingua.mathlingua
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import mathlingua.backend.SourceCollection
 import mathlingua.backend.getPatternsToWrittenAs
-import mathlingua.backend.newSourceCollectionFromContent
+import mathlingua.backend.newSourceCollectionFromFiles
 import mathlingua.backend.transform.Signature
+import mathlingua.cli.newMemoryFileSystem
 import mathlingua.frontend.FrontEnd
 import mathlingua.frontend.support.Location
 import mathlingua.frontend.support.ValidationSuccess
@@ -21,6 +23,17 @@ import mathlingua.frontend.textalk.TextTexTalkNode
 import org.junit.jupiter.api.Test
 
 internal class MathLinguaTest {
+
+    private fun newSourceCollectionFromContent(inputs: List<String>): SourceCollection {
+        val fs = newMemoryFileSystem(listOf(""))
+        val files =
+            inputs.indices.map {
+                val file = fs.getFile(listOf("input$it.math"))
+                file.writeText(inputs[it])
+                file
+            }
+        return newSourceCollectionFromFiles(filesOrDirs = files)
+    }
 
     @Test
     fun findDuplicateContentNoDuplicates() {

--- a/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
@@ -25,7 +25,9 @@ import javax.swing.*
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeModel
 import javax.swing.tree.TreePath
-import mathlingua.backend.newSourceCollectionFromContent
+import mathlingua.backend.SourceCollection
+import mathlingua.backend.newSourceCollectionFromFiles
+import mathlingua.cli.newMemoryFileSystem
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase1.ast.getColumn
 import mathlingua.frontend.chalktalk.phase1.ast.getRow
@@ -88,6 +90,13 @@ enum class Normalization(
     ): Document {
         return fn(parent?.transform(doc, defines, states, tracker) ?: doc, defines, states, tracker)
     }
+}
+
+private fun newSourceCollectionFromContent(input: String): SourceCollection {
+    val fs = newMemoryFileSystem(listOf(""))
+    val file = fs.getFile(listOf("input.math"))
+    file.writeText(input)
+    return newSourceCollectionFromFiles(filesOrDirs = listOf(file))
 }
 
 fun main() {
@@ -178,9 +187,7 @@ fun main() {
                 }
 
                 val invalidTypesErrors =
-                    newSourceCollectionFromContent(listOf(input)).findInvalidTypes().map {
-                        it.value
-                    }
+                    newSourceCollectionFromContent(input).findInvalidTypes().map { it.value }
 
                 for (err in invalidTypesErrors) {
                     errorBuilder.append("ERROR: ${err.message} (${err.row+1}, ${err.column})")
@@ -226,9 +233,9 @@ fun main() {
                 phase2Tree.model = DefaultTreeModel(DefaultMutableTreeNode())
             } else {
                 val signatures =
-                    newSourceCollectionFromContent(listOf(inputArea.text))
-                        .getDefinedSignatures()
-                        .map { it.value }
+                    newSourceCollectionFromContent(inputArea.text).getDefinedSignatures().map {
+                        it.value
+                    }
                 val sigBuilder = StringBuilder()
                 for (sig in signatures) {
                     sigBuilder.append(sig.form)

--- a/src/test/kotlin/mathlingua/playground/MathLinguaPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/MathLinguaPlayground.kt
@@ -35,7 +35,9 @@ import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import javax.swing.WindowConstants
 import mathlingua.backend.BackEnd
-import mathlingua.backend.newSourceCollectionFromContent
+import mathlingua.backend.SourceCollection
+import mathlingua.backend.newSourceCollectionFromFiles
+import mathlingua.cli.newMemoryFileSystem
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants
 import org.fife.ui.rtextarea.RTextScrollPane
@@ -52,6 +54,13 @@ fun readState() =
     } catch (e: IOException) {
         ""
     }
+
+private fun newSourceCollectionFromContent(input: String): SourceCollection {
+    val fs = newMemoryFileSystem(listOf(""))
+    val file = fs.getFile(listOf("input.math"))
+    file.writeText(input)
+    return newSourceCollectionFromFiles(filesOrDirs = listOf(file))
+}
 
 fun main() {
     // enable sub-pixel antialiasing
@@ -90,7 +99,7 @@ fun main() {
 
     fun processInput() {
         SwingUtilities.invokeLater {
-            val collection = newSourceCollectionFromContent(listOf(inputArea.text))
+            val collection = newSourceCollectionFromContent(inputArea.text)
             val errors = BackEnd.check(collection)
             val builder = StringBuilder()
             for (err in errors) {

--- a/src/test/kotlin/mathlingua/playground/WrittenAsPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/WrittenAsPlayground.kt
@@ -26,7 +26,9 @@ import javax.swing.JTextArea
 import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import javax.swing.WindowConstants
-import mathlingua.backend.newSourceCollectionFromContent
+import mathlingua.backend.SourceCollection
+import mathlingua.backend.newSourceCollectionFromFiles
+import mathlingua.cli.newMemoryFileSystem
 import mathlingua.frontend.FrontEnd
 import mathlingua.frontend.support.ParseError
 import mathlingua.frontend.support.Validation
@@ -37,6 +39,15 @@ import mathlingua.frontend.support.validationSuccess
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants
 import org.fife.ui.rtextarea.RTextScrollPane
+
+private fun newSourceCollectionFromContent(input: String, supplemental: String): SourceCollection {
+    val fs = newMemoryFileSystem(listOf(""))
+    val inputFile = fs.getFile(listOf("input.math"))
+    inputFile.writeText(input)
+    val suppFile = fs.getFile(listOf("supplemental.math"))
+    suppFile.writeText(supplemental)
+    return newSourceCollectionFromFiles(filesOrDirs = listOf(inputFile, suppFile))
+}
 
 fun main() {
     // enable sub-pixel antialiasing
@@ -154,7 +165,7 @@ private fun printExpanded(input: String, supplemental: String, html: Boolean): V
                 errors.addAll(validation.errors)
             }
             is ValidationSuccess -> {
-                val collection = newSourceCollectionFromContent(listOf(input, supplemental))
+                val collection = newSourceCollectionFromContent(input, supplemental)
                 result.append(
                     collection.prettyPrint(node = validation.value, html = html, doExpand = true))
             }


### PR DESCRIPTION
The `VirtualFileSystem` represents a filesystem that could either
be an in-memory system or the regular disk based system.  In
addition, a new `Logger` interface represents something that can
create logs and abstracts away the use of `println`.

With these, a new `Mathlingua` object exists that can do the
operations of the `mlg` cli (check, render, clean, etc.) using
a `VirtualFileSystem` and a `Logger` without being tightly
coupled to using the underlying real filesystem or standard out.

As a result, it is now easy to have an entire MathLingua collection
of content completely in memory or on disk and perform the actions
that can be performed by the cli.

This allows for a better API to interact with a MathLingua
collection since it does not require physically writing any files
to disk.
