### PR TITLE
chore: adjust html rendering

### DIFF
--- a/src/main/kotlin/mathlingua/backend/SourceCollection.kt
+++ b/src/main/kotlin/mathlingua/backend/SourceCollection.kt
@@ -107,7 +107,7 @@ interface SourceCollection {
     fun prettyPrint(node: Phase2Node, html: Boolean, doExpand: Boolean): String
 }
 
-fun newSourceCollectionFromFiles(filesOrDirs: List<VirtualFile>): SourceCollection {
+fun newSourceCollection(filesOrDirs: List<VirtualFile>): SourceCollection {
     val sources = mutableListOf<SourceFile>()
     for (file in filesOrDirs) {
         findVirtualFiles(file, sources)

--- a/src/main/kotlin/mathlingua/cli/Mathlingua.kt
+++ b/src/main/kotlin/mathlingua/cli/Mathlingua.kt
@@ -22,7 +22,7 @@ import mathlingua.backend.SourceCollection
 import mathlingua.backend.SourceFile
 import mathlingua.backend.ValueSourceTracker
 import mathlingua.backend.isMathLinguaFile
-import mathlingua.backend.newSourceCollectionFromFiles
+import mathlingua.backend.newSourceCollection
 import mathlingua.frontend.FrontEnd
 import mathlingua.frontend.chalktalk.phase2.ast.clause.Identifier
 import mathlingua.frontend.chalktalk.phase2.ast.clause.Statement
@@ -53,7 +53,7 @@ private fun yellow(text: String) = "\u001B[33m$text\u001B[0m"
 object Mathlingua {
     fun check(fs: VirtualFileSystem, logger: Logger, files: List<VirtualFile>, json: Boolean): Int {
         val sourceCollection =
-            newSourceCollectionFromFiles(
+            newSourceCollection(
                 if (files.isEmpty()) {
                     listOf(fs.cwd())
                 } else {
@@ -241,7 +241,7 @@ private fun renderFile(
                 tracker = null))
     }
 
-    val sourceCollection = newSourceCollectionFromFiles(listOf(fs.cwd()))
+    val sourceCollection = newSourceCollection(listOf(fs.cwd()))
 
     val pair = sourceCollection.prettyPrint(file = target, html = true, doExpand = !noExpand)
 
@@ -303,7 +303,7 @@ private fun renderFile(
 private fun renderAll(
     fs: VirtualFileSystem, logger: Logger, stdout: Boolean, noExpand: Boolean
 ): List<ValueSourceTracker<ParseError>> {
-    val sourceCollection = newSourceCollectionFromFiles(listOf(fs.cwd()))
+    val sourceCollection = newSourceCollection(listOf(fs.cwd()))
 
     val docsDir = getDocsDirectory(fs)
     docsDir.mkdirs()
@@ -383,7 +383,7 @@ private fun getIndexFileText(
 
     val sigToPathCode = generateSignatureToPathJsCode(fs)
 
-    val sourceCollection = newSourceCollectionFromFiles(listOf(cwd))
+    val sourceCollection = newSourceCollection(listOf(cwd))
     val filesToProcess = mutableListOf<VirtualFile>()
     findMathlinguaFiles(cwd, filesToProcess)
 
@@ -884,6 +884,7 @@ const val SHARED_CSS =
     }
 
     .mathlingua-top-level {
+        overflow: auto;
         background-color: white;
         border: solid;
         border-width: 1px;
@@ -931,7 +932,7 @@ const val SHARED_CSS =
     .mathlingua-text {
         color: #000000;
         display: block;
-        margin: 0 0 -1em 0;
+        margin: 0 0 -0.75em 0;
         padding: 0 0 0 2.5em;
         font-size: 80%;
         font-family: Georgia, 'Times New Roman', Times, serif;

--- a/src/test/kotlin/mathlingua/MathLinguaTest.kt
+++ b/src/test/kotlin/mathlingua/MathLinguaTest.kt
@@ -5,7 +5,7 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import mathlingua.backend.SourceCollection
 import mathlingua.backend.getPatternsToWrittenAs
-import mathlingua.backend.newSourceCollectionFromFiles
+import mathlingua.backend.newSourceCollection
 import mathlingua.backend.transform.Signature
 import mathlingua.cli.newMemoryFileSystem
 import mathlingua.frontend.FrontEnd
@@ -32,7 +32,7 @@ internal class MathLinguaTest {
                 file.writeText(inputs[it])
                 file
             }
-        return newSourceCollectionFromFiles(filesOrDirs = files)
+        return newSourceCollection(filesOrDirs = files)
     }
 
     @Test

--- a/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/ChalkTalkPlayground.kt
@@ -26,7 +26,7 @@ import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeModel
 import javax.swing.tree.TreePath
 import mathlingua.backend.SourceCollection
-import mathlingua.backend.newSourceCollectionFromFiles
+import mathlingua.backend.newSourceCollection
 import mathlingua.cli.newMemoryFileSystem
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase1.ast.getColumn
@@ -96,7 +96,7 @@ private fun newSourceCollectionFromContent(input: String): SourceCollection {
     val fs = newMemoryFileSystem(listOf(""))
     val file = fs.getFile(listOf("input.math"))
     file.writeText(input)
-    return newSourceCollectionFromFiles(filesOrDirs = listOf(file))
+    return newSourceCollection(filesOrDirs = listOf(file))
 }
 
 fun main() {

--- a/src/test/kotlin/mathlingua/playground/MathLinguaPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/MathLinguaPlayground.kt
@@ -36,7 +36,7 @@ import javax.swing.UIManager
 import javax.swing.WindowConstants
 import mathlingua.backend.BackEnd
 import mathlingua.backend.SourceCollection
-import mathlingua.backend.newSourceCollectionFromFiles
+import mathlingua.backend.newSourceCollection
 import mathlingua.cli.newMemoryFileSystem
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants
@@ -59,7 +59,7 @@ private fun newSourceCollectionFromContent(input: String): SourceCollection {
     val fs = newMemoryFileSystem(listOf(""))
     val file = fs.getFile(listOf("input.math"))
     file.writeText(input)
-    return newSourceCollectionFromFiles(filesOrDirs = listOf(file))
+    return newSourceCollection(filesOrDirs = listOf(file))
 }
 
 fun main() {

--- a/src/test/kotlin/mathlingua/playground/WrittenAsPlayground.kt
+++ b/src/test/kotlin/mathlingua/playground/WrittenAsPlayground.kt
@@ -27,7 +27,7 @@ import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import javax.swing.WindowConstants
 import mathlingua.backend.SourceCollection
-import mathlingua.backend.newSourceCollectionFromFiles
+import mathlingua.backend.newSourceCollection
 import mathlingua.cli.newMemoryFileSystem
 import mathlingua.frontend.FrontEnd
 import mathlingua.frontend.support.ParseError
@@ -46,7 +46,7 @@ private fun newSourceCollectionFromContent(input: String, supplemental: String):
     inputFile.writeText(input)
     val suppFile = fs.getFile(listOf("supplemental.math"))
     suppFile.writeText(supplemental)
-    return newSourceCollectionFromFiles(filesOrDirs = listOf(inputFile, suppFile))
+    return newSourceCollection(filesOrDirs = listOf(inputFile, suppFile))
 }
 
 fun main() {


### PR DESCRIPTION
There is a larger margin at the bottom of TopLevelGroup entries
and a scrollbar exists when text overflows.
