### PR TITLE
fix: infix ops defined in `using:` are recognized

### DIFF
--- a/src/main/kotlin/mathlingua/backend/SourceCollection.kt
+++ b/src/main/kotlin/mathlingua/backend/SourceCollection.kt
@@ -356,6 +356,20 @@ class SourceCollectionImpl(sources: List<SourceFile>) : SourceCollection {
                         .children[0] as OperatorTexTalkNode)
                     .command as TextTexTalkNode)
                 .text
+        } else if (node.children.isNotEmpty() &&
+            node.children[0] is ColonEqualsTexTalkNode &&
+            (node.children[0] as ColonEqualsTexTalkNode).lhs.items.isNotEmpty() &&
+            (node.children[0] as ColonEqualsTexTalkNode).lhs.items[0].children.isNotEmpty() &&
+            (node.children[0] as ColonEqualsTexTalkNode).lhs.items[0].children[
+                0] is OperatorTexTalkNode &&
+            ((node.children[0] as ColonEqualsTexTalkNode).lhs.items[0].children[
+                    0] as OperatorTexTalkNode)
+                .command is TextTexTalkNode) {
+            // match `a + b := ...`
+            (((node.children[0] as ColonEqualsTexTalkNode).lhs.items[0].children[
+                        0] as OperatorTexTalkNode)
+                    .command as TextTexTalkNode)
+                .text
         } else {
             null
         }


### PR DESCRIPTION
Prior to this change, if a binary operator was defined in a
`using:` section, it would not be counted as defined and would be
marked in an entry as undefined.
