### PR TITLE
feat: rename `viewed:` group add `equality:` group

### DIFF
--- a/src/main/kotlin/mathlingua/backend/transform/VarUtil.kt
+++ b/src/main/kotlin/mathlingua/backend/transform/VarUtil.kt
@@ -36,6 +36,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defin
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.RequiringSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.evaluates.EvaluatesGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.states.StatesGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.equality.EqualityGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.resultlike.axiom.AxiomGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.resultlike.conjecture.ConjectureGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.resultlike.theorem.GivenSection
@@ -311,6 +312,20 @@ private fun checkVarsImpl(
                 vars.add(v)
             }
             varsToRemove.addAll(forAllVars)
+        }
+        is EqualityGroup -> {
+            val betweenVars = node.betweenSection.targets.map { getVars(it, ignoreParen) }.flatten()
+            for (v in betweenVars) {
+                if (vars.contains(v)) {
+                    errors.add(
+                        ParseError(
+                            message = "Duplicate defined symbol '$v'",
+                            row = location.row,
+                            column = location.column))
+                }
+                vars.add(v)
+            }
+            varsToRemove.addAll(betweenVars)
         }
         is ExistsGroup -> {
             val existsVars =

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
@@ -107,13 +107,16 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.mutua
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.states.StatesGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.states.StatesSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.states.ThatSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.ViewedSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.membership.MembershipGroup
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.membership.MembershipSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas.ThroughSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas.ViaSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas.ViewedAsGroup
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas.ViewedAsSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.equality.BetweenSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.equality.EqualityGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.equality.EqualitySection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.membership.MembershipGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.membership.MembershipSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas.ThroughSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas.ViaSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas.ViewingAsGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas.ViewingAsSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.entry.ContentSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.entry.EntryGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.entry.EntrySection
@@ -632,7 +635,7 @@ val DEFAULT_MAPS_SECTION = MapsSection(fromGroup = DEFAULT_FROM_GROUP)
 
 val DEFAULT_GENERATED_SECTION = GeneratedSection(inductivelyGroup = DEFAULT_INDUCTIVELY_GROUP)
 
-val DEFAULT_VIEWED_AS_SECTION = ViewedAsSection(statement = DEFAULT_STATEMENT)
+val DEFAULT_VIEWED_AS_SECTION = ViewingAsSection(statement = DEFAULT_STATEMENT)
 
 val DEFAULT_VIA_SECTION = ViaSection(statement = DEFAULT_STATEMENT)
 
@@ -645,9 +648,19 @@ val DEFAULT_MEMBERSHIP_GROUP =
         membershipSection = DEFAULT_MEMBERSHIP_SECTION, throughSection = DEFAULT_THROUGH_SECTION)
 
 val DEFAULT_VIEWED_AS_GROUP =
-    ViewedAsGroup(viewedAsSection = DEFAULT_VIEWED_AS_SECTION, viaSection = DEFAULT_VIA_SECTION)
+    ViewingAsGroup(viewingAsSection = DEFAULT_VIEWED_AS_SECTION, viaSection = DEFAULT_VIA_SECTION)
 
-val DEFAULT_VIEWED_SECTION = ViewedSection(clauses = DEFAULT_CLAUSE_LIST_NODE)
+val DEFAULT_VIEWING_SECTION = ViewingSection(clauses = DEFAULT_CLAUSE_LIST_NODE)
+
+val DEFAULT_EQUALITY_SECTION = EqualitySection()
+
+val DEFAULT_BETWEEN_SECTION = BetweenSection(emptyList())
+
+val DEFAULT_EQUALITY_GROUP =
+    EqualityGroup(
+        equalitySection = DEFAULT_EQUALITY_SECTION,
+        betweenSection = DEFAULT_BETWEEN_SECTION,
+        providedSection = DEFAULT_PROVIDED_SECTION)
 
 val DEFAULT_DEFINES_MEANS_GROUP =
     DefinesMeansGroup(
@@ -657,7 +670,7 @@ val DEFAULT_DEFINES_MEANS_GROUP =
         requiringSection = DEFAULT_REQUIRING_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
         satisfyingSection = DEFAULT_SATISFYING_SECTION,
-        viewedSection = DEFAULT_VIEWED_SECTION,
+        viewingSection = DEFAULT_VIEWING_SECTION,
         meansSection = DEFAULT_MEANS_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
@@ -671,7 +684,7 @@ val DEFAULT_DEFINES_INSTANTIATED_GROUP =
         requiringSection = DEFAULT_REQUIRING_SECTION,
         whenSection = DEFAULT_WHEN_SECTION,
         instantiatedSection = DEFAULT_INSTANTIATED_SECTION,
-        viewedSection = DEFAULT_VIEWED_SECTION,
+        viewingSection = DEFAULT_VIEWING_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)
@@ -685,7 +698,7 @@ val DEFAULT_DEFINES_EVALUATED_GROUP =
         whenSection = DEFAULT_WHEN_SECTION,
         meansSection = DEFAULT_MEANS_SECTION,
         evaluatedSection = DEFAULT_EVALUATED_SECTION,
-        viewedSection = DEFAULT_VIEWED_SECTION,
+        viewingSection = DEFAULT_VIEWING_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)
@@ -699,7 +712,7 @@ val DEFAULT_DEFINES_COLLECTS_GROUP =
         whenSection = DEFAULT_WHEN_SECTION,
         meansSection = DEFAULT_MEANS_SECTION,
         collectsSection = DEFAULT_COLLECTS_SECTION,
-        viewedSection = DEFAULT_VIEWED_SECTION,
+        viewingSection = DEFAULT_VIEWING_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)
@@ -713,7 +726,7 @@ val DEFAULT_DEFINES_MAPS_GROUP =
         whenSection = DEFAULT_WHEN_SECTION,
         meansSection = DEFAULT_MEANS_SECTION,
         mapsSection = DEFAULT_MAPS_SECTION,
-        viewedSection = DEFAULT_VIEWED_SECTION,
+        viewingSection = DEFAULT_VIEWING_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)
@@ -727,7 +740,7 @@ val DEFAULT_DEFINES_GENERATED_GROUP =
         whenSection = DEFAULT_WHEN_SECTION,
         meansSection = DEFAULT_MEANS_SECTION,
         generatedSection = DEFAULT_GENERATED_SECTION,
-        viewedSection = DEFAULT_VIEWED_SECTION,
+        viewingSection = DEFAULT_VIEWING_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/clause/Clause.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/clause/Clause.kt
@@ -59,10 +59,12 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.evalu
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.evaluates.validateEvaluatesGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.states.isStatesGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.states.validateStatesGroup
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.membership.isMembershipGroup
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.membership.validateMembershipGroup
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas.isViewedAsGroup
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas.validateViewedAsGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.equality.isEqualityGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.equality.validateEqualityGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.membership.isMembershipGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.membership.validateMembershipGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas.isViewingAsGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas.validateViewingAsGroup
 import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
 
@@ -153,7 +155,8 @@ private val CLAUSE_VALIDATORS =
         ValidationPair(::isDefinesGroup, ::validateDefinesGroup),
         ValidationPair(::isStatesGroup, ::validateStatesGroup),
         ValidationPair(::isMembershipGroup, ::validateMembershipGroup),
-        ValidationPair(::isViewedAsGroup, ::validateViewedAsGroup))
+        ValidationPair(::isViewingAsGroup, ::validateViewingAsGroup),
+        ValidationPair(::isEqualityGroup, ::validateEqualityGroup))
 
 fun validateClause(
     rawNode: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
@@ -31,8 +31,8 @@ import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getId
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.ViewedSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.validateViewedSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.validateViewingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
@@ -56,7 +56,7 @@ data class DefinesCollectsGroup(
     override val whenSection: WhenSection?,
     val meansSection: MeansSection?,
     val collectsSection: CollectsSection,
-    override val viewedSection: ViewedSection?,
+    override val viewingSection: ViewingSection?,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
@@ -75,8 +75,8 @@ data class DefinesCollectsGroup(
             fn(meansSection)
         }
         fn(collectsSection)
-        if (viewedSection != null) {
-            fn(viewedSection)
+        if (viewingSection != null) {
+            fn(viewingSection)
         }
         if (usingSection != null) {
             fn(usingSection)
@@ -95,7 +95,7 @@ data class DefinesCollectsGroup(
                 whenSection,
                 meansSection,
                 collectsSection,
-                viewedSection,
+                viewingSection,
                 usingSection,
                 writtenSection,
                 metaDataSection)
@@ -113,7 +113,7 @@ data class DefinesCollectsGroup(
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
                 meansSection = meansSection?.transform(chalkTransformer) as MeansSection?,
                 collectsSection = collectsSection.transform(chalkTransformer) as CollectsSection,
-                viewedSection = viewedSection?.transform(chalkTransformer) as ViewedSection?,
+                viewingSection = viewingSection?.transform(chalkTransformer) as ViewingSection?,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
                 metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?))
@@ -136,7 +136,7 @@ fun validateDefinesCollectsGroup(
                     "when?",
                     "means?",
                     "collects",
-                    "viewed?",
+                    "viewing?",
                     "using?",
                     "written",
                     "Metadata?")) { sections ->
@@ -165,9 +165,9 @@ fun validateDefinesCollectsGroup(
                             ensureNonNull(sections["collects"], DEFAULT_COLLECTS_SECTION) {
                                 validateCollectsSection(it, errors, tracker)
                             },
-                        viewedSection =
-                            ifNonNull(sections["viewed"]) {
-                                validateViewedSection(it, errors, tracker)
+                        viewingSection =
+                            ifNonNull(sections["viewing"]) {
+                                validateViewingSection(it, errors, tracker)
                             },
                         usingSection =
                             ifNonNull(sections["using"]) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
@@ -31,8 +31,8 @@ import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getId
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.ViewedSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.validateViewedSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.validateViewingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
@@ -56,7 +56,7 @@ data class DefinesEvaluatedGroup(
     override val whenSection: WhenSection?,
     val meansSection: MeansSection?,
     val evaluatedSection: EvaluatedSection,
-    override val viewedSection: ViewedSection?,
+    override val viewingSection: ViewingSection?,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
@@ -75,8 +75,8 @@ data class DefinesEvaluatedGroup(
             fn(meansSection)
         }
         fn(evaluatedSection)
-        if (viewedSection != null) {
-            fn(viewedSection)
+        if (viewingSection != null) {
+            fn(viewingSection)
         }
         if (usingSection != null) {
             fn(usingSection)
@@ -95,7 +95,7 @@ data class DefinesEvaluatedGroup(
                 whenSection,
                 meansSection,
                 evaluatedSection,
-                viewedSection,
+                viewingSection,
                 usingSection,
                 writtenSection,
                 metaDataSection)
@@ -113,7 +113,7 @@ data class DefinesEvaluatedGroup(
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
                 meansSection = meansSection?.transform(chalkTransformer) as MeansSection?,
                 evaluatedSection = evaluatedSection.transform(chalkTransformer) as EvaluatedSection,
-                viewedSection = viewedSection?.transform(chalkTransformer) as ViewedSection?,
+                viewingSection = viewingSection?.transform(chalkTransformer) as ViewingSection?,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
                 metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?))
@@ -136,7 +136,7 @@ fun validateDefinesEvaluatedGroup(
                     "when?",
                     "means?",
                     "evaluated",
-                    "viewed?",
+                    "viewing?",
                     "using?",
                     "written",
                     "Metadata?")) { sections ->
@@ -165,9 +165,9 @@ fun validateDefinesEvaluatedGroup(
                             ensureNonNull(sections["evaluated"], DEFAULT_EVALUATED_SECTION) {
                                 validateEvaluatedSection(it, errors, tracker)
                             },
-                        viewedSection =
-                            ifNonNull(sections["viewed"]) {
-                                validateViewedSection(it, errors, tracker)
+                        viewingSection =
+                            ifNonNull(sections["viewing"]) {
+                                validateViewingSection(it, errors, tracker)
                             },
                         usingSection =
                             ifNonNull(sections["using"]) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGeneratedGroup.kt
@@ -31,8 +31,8 @@ import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getId
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.ViewedSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.validateViewedSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.validateViewingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
@@ -56,7 +56,7 @@ data class DefinesGeneratedGroup(
     override val whenSection: WhenSection?,
     val meansSection: MeansSection?,
     val generatedSection: GeneratedSection,
-    override val viewedSection: ViewedSection?,
+    override val viewingSection: ViewingSection?,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
@@ -75,8 +75,8 @@ data class DefinesGeneratedGroup(
             fn(meansSection)
         }
         fn(generatedSection)
-        if (viewedSection != null) {
-            fn(viewedSection)
+        if (viewingSection != null) {
+            fn(viewingSection)
         }
         if (usingSection != null) {
             fn(usingSection)
@@ -95,7 +95,7 @@ data class DefinesGeneratedGroup(
                 whenSection,
                 meansSection,
                 generatedSection,
-                viewedSection,
+                viewingSection,
                 usingSection,
                 writtenSection,
                 metaDataSection)
@@ -113,7 +113,7 @@ data class DefinesGeneratedGroup(
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
                 meansSection = meansSection?.transform(chalkTransformer) as MeansSection?,
                 generatedSection = generatedSection.transform(chalkTransformer) as GeneratedSection,
-                viewedSection = viewedSection?.transform(chalkTransformer) as ViewedSection?,
+                viewingSection = viewingSection?.transform(chalkTransformer) as ViewingSection?,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
                 metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?))
@@ -136,7 +136,7 @@ fun validateDefinesGeneratedGroup(
                     "when?",
                     "means?",
                     "generated",
-                    "viewed?",
+                    "viewing?",
                     "using?",
                     "written",
                     "Metadata?")) { sections ->
@@ -165,9 +165,9 @@ fun validateDefinesGeneratedGroup(
                             ensureNonNull(sections["generated"], DEFAULT_GENERATED_SECTION) {
                                 validateGeneratedSection(it, errors, tracker)
                             },
-                        viewedSection =
-                            ifNonNull(sections["viewed"]) {
-                                validateViewedSection(it, errors, tracker)
+                        viewingSection =
+                            ifNonNull(sections["viewing"]) {
+                                validateViewingSection(it, errors, tracker)
                             },
                         usingSection =
                             ifNonNull(sections["using"]) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
@@ -25,7 +25,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.HasUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.ViewedSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 import mathlingua.frontend.support.Location
@@ -45,7 +45,7 @@ abstract class DefinesGroup(override val metaDataSection: MetaDataSection?) :
     abstract val definesSection: DefinesSection
     abstract val requiringSection: RequiringSection?
     abstract val whenSection: WhenSection?
-    abstract val viewedSection: ViewedSection?
+    abstract val viewingSection: ViewingSection?
     abstract val writtenSection: WrittenSection
 }
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesInstantiatedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesInstantiatedGroup.kt
@@ -31,8 +31,8 @@ import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getId
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.ViewedSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.validateViewedSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.validateViewingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
@@ -55,7 +55,7 @@ data class DefinesInstantiatedGroup(
     override val requiringSection: RequiringSection?,
     override val whenSection: WhenSection?,
     val instantiatedSection: InstantiatedSection,
-    override val viewedSection: ViewedSection?,
+    override val viewingSection: ViewingSection?,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
@@ -71,8 +71,8 @@ data class DefinesInstantiatedGroup(
             fn(whenSection)
         }
         fn(instantiatedSection)
-        if (viewedSection != null) {
-            fn(viewedSection)
+        if (viewingSection != null) {
+            fn(viewingSection)
         }
         if (usingSection != null) {
             fn(usingSection)
@@ -90,7 +90,7 @@ data class DefinesInstantiatedGroup(
                 requiringSection,
                 whenSection,
                 instantiatedSection,
-                viewedSection,
+                viewingSection,
                 usingSection,
                 writtenSection,
                 metaDataSection)
@@ -108,7 +108,7 @@ data class DefinesInstantiatedGroup(
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
                 instantiatedSection =
                     instantiatedSection.transform(chalkTransformer) as InstantiatedSection,
-                viewedSection = viewedSection?.transform(chalkTransformer) as ViewedSection?,
+                viewingSection = viewingSection?.transform(chalkTransformer) as ViewingSection?,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
                 metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?))
@@ -132,7 +132,7 @@ fun validateDefinesInstantiatedGroup(
                     "requiring?",
                     "when?",
                     "instantiated",
-                    "viewed?",
+                    "viewing?",
                     "using?",
                     "written",
                     "Metadata?")) { sections ->
@@ -157,9 +157,9 @@ fun validateDefinesInstantiatedGroup(
                             ensureNonNull(sections["instantiated"], DEFAULT_INSTANTIATED_SECTION) {
                                 validateInstantiatedSection(it, errors, tracker)
                             },
-                        viewedSection =
-                            ifNonNull(sections["viewed"]) {
-                                validateViewedSection(it, errors, tracker)
+                        viewingSection =
+                            ifNonNull(sections["viewing"]) {
+                                validateViewingSection(it, errors, tracker)
                             },
                         usingSection =
                             ifNonNull(sections["using"]) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
@@ -31,8 +31,8 @@ import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getId
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.ViewedSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.validateViewedSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.validateViewingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
@@ -56,7 +56,7 @@ data class DefinesMapsGroup(
     override val whenSection: WhenSection?,
     val meansSection: MeansSection?,
     val mapsSection: MapsSection,
-    override val viewedSection: ViewedSection?,
+    override val viewingSection: ViewingSection?,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
@@ -75,8 +75,8 @@ data class DefinesMapsGroup(
             fn(meansSection)
         }
         fn(mapsSection)
-        if (viewedSection != null) {
-            fn(viewedSection)
+        if (viewingSection != null) {
+            fn(viewingSection)
         }
         if (usingSection != null) {
             fn(usingSection)
@@ -95,7 +95,7 @@ data class DefinesMapsGroup(
                 whenSection,
                 meansSection,
                 mapsSection,
-                viewedSection,
+                viewingSection,
                 usingSection,
                 writtenSection,
                 metaDataSection)
@@ -113,7 +113,7 @@ data class DefinesMapsGroup(
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
                 meansSection = meansSection?.transform(chalkTransformer) as MeansSection?,
                 mapsSection = mapsSection.transform(chalkTransformer) as MapsSection,
-                viewedSection = viewedSection?.transform(chalkTransformer) as ViewedSection?,
+                viewingSection = viewingSection?.transform(chalkTransformer) as ViewingSection?,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
                 metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?))
@@ -136,7 +136,7 @@ fun validateDefinesMapsGroup(
                     "when?",
                     "means?",
                     "maps",
-                    "viewed?",
+                    "viewing?",
                     "using?",
                     "written",
                     "Metadata?")) { sections ->
@@ -165,9 +165,9 @@ fun validateDefinesMapsGroup(
                             ensureNonNull(sections["maps"], DEFAULT_MAPS_SECTION) {
                                 validateMapsSection(it, errors, tracker)
                             },
-                        viewedSection =
-                            ifNonNull(sections["viewed"]) {
-                                validateViewedSection(it, errors, tracker)
+                        viewingSection =
+                            ifNonNull(sections["viewing"]) {
+                                validateViewingSection(it, errors, tracker)
                             },
                         usingSection =
                             ifNonNull(sections["using"]) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
@@ -31,8 +31,8 @@ import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getId
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.ViewedSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.validateViewedSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.validateViewingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
@@ -56,7 +56,7 @@ data class DefinesMeansGroup(
     override val whenSection: WhenSection?,
     val meansSection: MeansSection,
     val satisfyingSection: SatisfyingSection?,
-    override val viewedSection: ViewedSection?,
+    override val viewingSection: ViewingSection?,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
     override val metaDataSection: MetaDataSection?
@@ -75,8 +75,8 @@ data class DefinesMeansGroup(
         if (satisfyingSection != null) {
             fn(satisfyingSection)
         }
-        if (viewedSection != null) {
-            fn(viewedSection)
+        if (viewingSection != null) {
+            fn(viewingSection)
         }
         if (usingSection != null) {
             fn(usingSection)
@@ -95,7 +95,7 @@ data class DefinesMeansGroup(
                 whenSection,
                 meansSection,
                 satisfyingSection,
-                viewedSection,
+                viewingSection,
                 usingSection,
                 writtenSection,
                 metaDataSection)
@@ -114,7 +114,7 @@ data class DefinesMeansGroup(
                 meansSection = meansSection.transform(chalkTransformer) as MeansSection,
                 satisfyingSection =
                     satisfyingSection?.transform(chalkTransformer) as SatisfyingSection?,
-                viewedSection = viewedSection?.transform(chalkTransformer) as ViewedSection?,
+                viewingSection = viewingSection?.transform(chalkTransformer) as ViewingSection?,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
                 metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?))
@@ -137,7 +137,7 @@ fun validateDefinesMeansGroup(
                     "when?",
                     "means",
                     "satisfying?",
-                    "viewed?",
+                    "viewing?",
                     "using?",
                     "written",
                     "Metadata?")) { sections ->
@@ -166,9 +166,9 @@ fun validateDefinesMeansGroup(
                             ifNonNull(sections["satisfying"]) {
                                 validateSpecifiesSection(it, errors, tracker)
                             },
-                        viewedSection =
-                            ifNonNull(sections["viewed"]) {
-                                validateViewedSection(it, errors, tracker)
+                        viewingSection =
+                            ifNonNull(sections["viewing"]) {
+                                validateViewingSection(it, errors, tracker)
                             },
                         usingSection =
                             ifNonNull(sections["using"]) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/ViewingSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/ViewingSection.kt
@@ -14,28 +14,29 @@
  * limitations under the License.
  */
 
-package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing
 
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
-import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_VIEWED_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_VIEWING_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.clause.ClauseListNode
 import mathlingua.frontend.chalktalk.phase2.ast.clause.validateClauseListNode
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.membership.MembershipGroup
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas.ViewedAsGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.equality.EqualityGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.membership.MembershipGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas.ViewingAsGroup
 import mathlingua.frontend.chalktalk.phase2.ast.track
 import mathlingua.frontend.chalktalk.phase2.ast.validateSection
 import mathlingua.frontend.support.Location
 import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
 
-data class ViewedSection(val clauses: ClauseListNode) : Phase2Node {
+data class ViewingSection(val clauses: ClauseListNode) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
-        writer.writeHeader("viewed")
+        writer.writeHeader("viewing")
         if (clauses.clauses.isNotEmpty()) {
             writer.writeNewline()
         }
@@ -45,30 +46,32 @@ data class ViewedSection(val clauses: ClauseListNode) : Phase2Node {
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
         chalkTransformer(
-            ViewedSection(clauses = clauses.transform(chalkTransformer) as ClauseListNode))
+            ViewingSection(clauses = clauses.transform(chalkTransformer) as ClauseListNode))
 }
 
-fun validateViewedSection(
+fun validateViewingSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
     track(node, tracker) {
-        validateSection(node.resolve(), errors, "viewed", DEFAULT_VIEWED_SECTION) {
+        validateSection(node.resolve(), errors, "viewing", DEFAULT_VIEWING_SECTION) {
             val clauses = validateClauseListNode(it, errors, tracker)
             val errorCountBefore = errors.size
             for (clause in clauses.clauses) {
-                if (clause !is MembershipGroup && clause !is ViewedAsGroup) {
+                if (clause !is MembershipGroup &&
+                    clause !is ViewingAsGroup &&
+                    clause !is EqualityGroup) {
                     val location = tracker.getLocationOf(clause) ?: Location(row = -1, column = -1)
                     errors.add(
                         ParseError(
-                            message = "Expected either a membership: or an as: group",
+                            message = "Expected either a membership:, as:, or equality: group",
                             row = location.row,
                             column = location.column))
                 }
             }
             if (errors.size != errorCountBefore) {
-                DEFAULT_VIEWED_SECTION
+                DEFAULT_VIEWING_SECTION
             } else {
-                ViewedSection(clauses = clauses)
+                ViewingSection(clauses = clauses)
             }
         }
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/equality/BetweenSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/equality/BetweenSection.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.equality
+
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
+import mathlingua.frontend.chalktalk.phase1.ast.getColumn
+import mathlingua.frontend.chalktalk.phase1.ast.getRow
+import mathlingua.frontend.chalktalk.phase2.CodeWriter
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_BETWEEN_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.clause.Target
+import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.frontend.chalktalk.phase2.ast.section.appendTargetArgs
+import mathlingua.frontend.chalktalk.phase2.ast.track
+import mathlingua.frontend.chalktalk.phase2.ast.validateTargetSection
+import mathlingua.frontend.support.MutableLocationTracker
+import mathlingua.frontend.support.ParseError
+
+data class BetweenSection(val targets: List<Target>) : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) = targets.forEach(fn)
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("between")
+        appendTargetArgs(writer, targets, indent + 2)
+        return writer
+    }
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
+        chalkTransformer(
+            BetweenSection(targets = targets.map { it.transform(chalkTransformer) as Target }))
+}
+
+fun validateBetweenSection(
+    node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
+) =
+    track(node, tracker) {
+        val result =
+            validateTargetSection(
+                node.resolve(),
+                errors,
+                "between",
+                DEFAULT_BETWEEN_SECTION,
+                tracker,
+                ::BetweenSection)
+        if (result == DEFAULT_BETWEEN_SECTION) {
+            result
+        } else {
+            if (result.targets.size != 2) {
+                errors.add(
+                    ParseError(
+                        message = "A between: section must have exactly two between: sections",
+                        row = getRow(node),
+                        column = getColumn(node)))
+                DEFAULT_BETWEEN_SECTION
+            } else {
+                result
+            }
+        }
+    }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/equality/EqualityGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/equality/EqualityGroup.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.equality
+
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_BETWEEN_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_EQUALITY_GROUP
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_EQUALITY_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_PROVIDED_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.clause.Clause
+import mathlingua.frontend.chalktalk.phase2.ast.clause.firstSectionMatchesName
+import mathlingua.frontend.chalktalk.phase2.ast.common.ThreePartNode
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.ProvidedSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.validateProvidedSection
+import mathlingua.frontend.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.frontend.chalktalk.phase2.ast.section.identifySections
+import mathlingua.frontend.chalktalk.phase2.ast.track
+import mathlingua.frontend.chalktalk.phase2.ast.validateGroup
+import mathlingua.frontend.support.MutableLocationTracker
+import mathlingua.frontend.support.ParseError
+
+data class EqualityGroup(
+    val equalitySection: EqualitySection,
+    val betweenSection: BetweenSection,
+    val providedSection: ProvidedSection
+) :
+    ThreePartNode<EqualitySection, BetweenSection, ProvidedSection>(
+        equalitySection, betweenSection, providedSection, ::EqualityGroup),
+    Clause
+
+fun isEqualityGroup(node: Phase1Node) = firstSectionMatchesName(node, "equality")
+
+fun validateEqualityGroup(
+    node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
+) =
+    track(node, tracker) {
+        validateGroup(node.resolve(), errors, "equality", DEFAULT_EQUALITY_GROUP) { group ->
+            identifySections(
+                group, errors, DEFAULT_EQUALITY_GROUP, listOf("equality", "between", "provided")) {
+            sections ->
+                EqualityGroup(
+                    equalitySection =
+                        ensureNonNull(sections["equality"], DEFAULT_EQUALITY_SECTION) {
+                            validateEqualitySection(it, errors, tracker)
+                        },
+                    betweenSection =
+                        ensureNonNull(sections["between"], DEFAULT_BETWEEN_SECTION) {
+                            validateBetweenSection(it, errors, tracker)
+                        },
+                    providedSection =
+                        ensureNonNull(sections["provided"], DEFAULT_PROVIDED_SECTION) {
+                            validateProvidedSection(it, errors, tracker)
+                        })
+            }
+        }
+    }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/equality/EqualitySection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/equality/EqualitySection.kt
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.membership
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.equality
 
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
-import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_MEMBERSHIP_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_EQUALITY_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.track
 import mathlingua.frontend.chalktalk.phase2.ast.validateSection
 import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
 
-class MembershipSection : Phase2Node {
+class EqualitySection : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
-        writer.writeHeader("membership")
+        writer.writeHeader("equality")
         return writer
     }
 
@@ -38,11 +38,11 @@ class MembershipSection : Phase2Node {
         chalkTransformer(this)
 }
 
-fun validateMembershipSection(
+fun validateEqualitySection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
     track(node, tracker) {
-        validateSection(node.resolve(), errors, "membership", DEFAULT_MEMBERSHIP_SECTION) {
-            MembershipSection()
+        validateSection(node.resolve(), errors, "equality", DEFAULT_EQUALITY_SECTION) {
+            EqualitySection()
         }
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/membership/MembershipGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/membership/MembershipGroup.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.membership
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.membership
 
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_MEMBERSHIP_GROUP
@@ -23,8 +23,8 @@ import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_THROUGH_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.clause.Clause
 import mathlingua.frontend.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.frontend.chalktalk.phase2.ast.common.TwoPartNode
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas.ThroughSection
-import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas.validateThroughSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas.ThroughSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas.validateThroughSection
 import mathlingua.frontend.chalktalk.phase2.ast.section.ensureNonNull
 import mathlingua.frontend.chalktalk.phase2.ast.section.identifySections
 import mathlingua.frontend.chalktalk.phase2.ast.track

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/membership/MembershipSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/membership/MembershipSection.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.membership
+
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
+import mathlingua.frontend.chalktalk.phase2.CodeWriter
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_MEMBERSHIP_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.frontend.chalktalk.phase2.ast.track
+import mathlingua.frontend.chalktalk.phase2.ast.validateSection
+import mathlingua.frontend.support.MutableLocationTracker
+import mathlingua.frontend.support.ParseError
+
+class MembershipSection : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) {}
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("membership")
+        return writer
+    }
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
+        chalkTransformer(this)
+}
+
+fun validateMembershipSection(
+    node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
+) =
+    track(node, tracker) {
+        validateSection(node.resolve(), errors, "membership", DEFAULT_MEMBERSHIP_SECTION) {
+            MembershipSection()
+        }
+    }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/membership/ThroughSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/membership/ThroughSection.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas
 
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/viewingas/ViaSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/viewingas/ViaSection.kt
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas
 
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
-import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_VIEWED_AS_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_VIA_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.clause.Statement
 import mathlingua.frontend.chalktalk.phase2.ast.clause.validateStatement
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
@@ -28,29 +28,29 @@ import mathlingua.frontend.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
 
-data class ViewedAsSection(val statement: Statement) : Phase2Node {
+data class ViaSection(val statement: Statement) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(statement)
     }
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
-        writer.writeHeader("as")
+        writer.writeHeader("via")
         writer.append(statement, false, 1)
         return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
-        chalkTransformer(ViewedAsSection(statement = chalkTransformer(statement) as Statement))
+        chalkTransformer(ViaSection(statement = chalkTransformer(statement) as Statement))
 }
 
-fun validateViewedAsSection(
+fun validateViaSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
     track(node, tracker) {
-        validateSection(node.resolve(), errors, "as", DEFAULT_VIEWED_AS_SECTION) {
-            validateSingleArg(it, errors, DEFAULT_VIEWED_AS_SECTION, "statement") {
-                ViewedAsSection(statement = validateStatement(it, errors, tracker))
+        validateSection(node.resolve(), errors, "via", DEFAULT_VIA_SECTION) {
+            validateSingleArg(it, errors, DEFAULT_VIA_SECTION, "statement") {
+                ViaSection(statement = validateStatement(it, errors, tracker))
             }
         }
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/viewingas/ViewingAsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/viewingas/ViewingAsGroup.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas
 
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_VIA_SECTION
@@ -31,23 +31,24 @@ import mathlingua.frontend.chalktalk.phase2.ast.validateGroup
 import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
 
-data class ViewedAsGroup(val viewedAsSection: ViewedAsSection, val viaSection: ViaSection) :
-    TwoPartNode<ViewedAsSection, ViaSection>(viewedAsSection, viaSection, ::ViewedAsGroup), Clause
+data class ViewingAsGroup(val viewingAsSection: ViewingAsSection, val viaSection: ViaSection) :
+    TwoPartNode<ViewingAsSection, ViaSection>(viewingAsSection, viaSection, ::ViewingAsGroup),
+    Clause
 
-fun isViewedAsGroup(node: Phase1Node) =
+fun isViewingAsGroup(node: Phase1Node) =
     firstSectionMatchesName(node, "as") && secondSectionMatchesName(node, "via")
 
-fun validateViewedAsGroup(
+fun validateViewingAsGroup(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
     track(node, tracker) {
         validateGroup(node.resolve(), errors, "as", DEFAULT_VIEWED_AS_GROUP) { group ->
             identifySections(group, errors, DEFAULT_VIEWED_AS_GROUP, listOf("as", "via")) {
             sections ->
-                ViewedAsGroup(
-                    viewedAsSection =
+                ViewingAsGroup(
+                    viewingAsSection =
                         ensureNonNull(sections["as"], DEFAULT_VIEWED_AS_SECTION) {
-                            validateViewedAsSection(it, errors, tracker)
+                            validateViewingAsSection(it, errors, tracker)
                         },
                     viaSection =
                         ensureNonNull(sections["via"], DEFAULT_VIA_SECTION) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/viewingas/ViewingAsSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/viewing/viewingas/ViewingAsSection.kt
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewed.viewedas
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.viewingas
 
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
-import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_VIA_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_VIEWED_AS_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.clause.Statement
 import mathlingua.frontend.chalktalk.phase2.ast.clause.validateStatement
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
@@ -28,29 +28,29 @@ import mathlingua.frontend.chalktalk.phase2.ast.validateSingleArg
 import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
 
-data class ViaSection(val statement: Statement) : Phase2Node {
+data class ViewingAsSection(val statement: Statement) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {
         fn(statement)
     }
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
-        writer.writeHeader("via")
+        writer.writeHeader("as")
         writer.append(statement, false, 1)
         return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
-        chalkTransformer(ViaSection(statement = chalkTransformer(statement) as Statement))
+        chalkTransformer(ViewingAsSection(statement = chalkTransformer(statement) as Statement))
 }
 
-fun validateViaSection(
+fun validateViewingAsSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
     track(node, tracker) {
-        validateSection(node.resolve(), errors, "via", DEFAULT_VIA_SECTION) {
-            validateSingleArg(it, errors, DEFAULT_VIA_SECTION, "statement") {
-                ViaSection(statement = validateStatement(it, errors, tracker))
+        validateSection(node.resolve(), errors, "as", DEFAULT_VIEWED_AS_SECTION) {
+            validateSingleArg(it, errors, DEFAULT_VIEWED_AS_SECTION, "statement") {
+                ViewingAsSection(statement = validateStatement(it, errors, tracker))
             }
         }
     }

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-structure.txt
@@ -149,7 +149,7 @@ Document(
                              ]
                  )
                )
-               viewedSection = null
+               viewingSection = null
                usingSection = null
                writtenSection = WrittenSection(
                  forms = [

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-structure.txt
@@ -275,7 +275,7 @@ Document(
                    )
                  )
                )
-               viewedSection = null
+               viewingSection = null
                usingSection = null
                writtenSection = WrittenSection(
                  forms = [

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
@@ -188,7 +188,7 @@ Document(
                    )
                  )
                )
-               viewedSection = null
+               viewingSection = null
                usingSection = null
                writtenSection = WrittenSection(
                  forms = [

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-structure.txt
@@ -111,7 +111,7 @@ Document(
                              ]
                  )
                )
-               viewedSection = null
+               viewingSection = null
                usingSection = null
                writtenSection = WrittenSection(
                  forms = [

--- a/src/test/resources/goldens/messages/defines/Defines_assuming_spelled_wrong/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_assuming_spelled_wrong/messages.txt
@@ -8,7 +8,7 @@ requiring?:
 when?:
 means:
 satisfying?:
-viewed?:
+viewing?:
 using?:
 written:
 Metadata?:

--- a/src/test/resources/goldens/messages/defines/Defines_id_paren_must_match_target/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_id_paren_must_match_target/messages.txt
@@ -8,7 +8,7 @@ requiring?:
 when?:
 means:
 satisfying?:
-viewed?:
+viewing?:
 using?:
 written:
 Metadata?:
@@ -27,7 +27,7 @@ requiring?:
 when?:
 means:
 satisfying?:
-viewed?:
+viewing?:
 using?:
 written:
 Metadata?:
@@ -46,7 +46,7 @@ requiring?:
 when?:
 means:
 satisfying?:
-viewed?:
+viewing?:
 using?:
 written:
 Metadata?:
@@ -65,7 +65,7 @@ requiring?:
 when?:
 means:
 satisfying?:
-viewed?:
+viewing?:
 using?:
 written:
 Metadata?:
@@ -84,7 +84,7 @@ requiring?:
 when?:
 means:
 satisfying?:
-viewed?:
+viewing?:
 using?:
 written:
 Metadata?:
@@ -103,7 +103,7 @@ requiring?:
 when?:
 means:
 satisfying?:
-viewed?:
+viewing?:
 using?:
 written:
 Metadata?:

--- a/src/test/resources/goldens/messages/defines/Defines_must_have_id/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_must_have_id/messages.txt
@@ -8,7 +8,7 @@ requiring?:
 when?:
 means:
 satisfying?:
-viewed?:
+viewing?:
 using?:
 written:
 Metadata?:

--- a/src/test/resources/mathlingua.math
+++ b/src/test/resources/mathlingua.math
@@ -149,7 +149,7 @@ satisfying:
 . forAll: x, y, z
   where: 'x, y, z in X'
   then: '(x*y)*z = x*(y*z)'
-viewed:
+viewing:
 . as: '\set'
   via: 'X'
 . membership:


### PR DESCRIPTION
The `viewed:` section has been renamed to `viewing:`.  Also, the
new `equality:` group has been added to specify in a definition
when two items are equal.
