### PR TITLE
fix: another fix for LaTeX rendering

### DIFF
--- a/src/main/kotlin/mathlingua/cli/Mathlingua.kt
+++ b/src/main/kotlin/mathlingua/cli/Mathlingua.kt
@@ -693,7 +693,36 @@ const val KATEX_RENDERING_JS =
         var buffer = '';
         var i = 0;
         while (i < text.length) {
-            if (text[i] === '\\' && text[i+1] === '[') {
+            if (text[i] === '${'$'}' && text[i+1] === '${'$'}' && text[i+2] === '${'$'}') {
+                i += 3; // skip over the ${'$'}s
+                fragment.appendChild(document.createTextNode(buffer));
+                buffer = '';
+
+                const span = document.createElement('span');
+                var math = '';
+                while (i < text.length &&
+                    !(text[i] === '${'$'}' && text[i+1] === '${'$'}' && text[i+2] === '${'$'}')) {
+                    math += text[i++];
+                }
+                if (text[i] === '${'$'}') {
+                    i++; // move past the ${'$'}
+                }
+                if (text[i] === '${'$'}') {
+                    i++; // move past the second ${'$'}
+                }
+                if (text[i] === '${'$'}') {
+                    i++; // move past the third ${'$'}
+                }
+                try {
+                    katex.render(math, span, {
+                        throwOnError: true,
+                        displayMode: false
+                    });
+                } catch {
+                    span.appendChild(document.createTextNode(math));
+                }
+                fragment.appendChild(span);
+            } else if (text[i] === '\\' && text[i+1] === '[') {
                 i += 2; // skip over \ and [
                 fragment.appendChild(document.createTextNode(buffer));
                 buffer = '';
@@ -740,7 +769,7 @@ const val KATEX_RENDERING_JS =
                 try {
                     katex.render(math, span, {
                         throwOnError: true,
-                        displayMode: true
+                        displayMode: false
                     });
                 } catch {
                     span.appendChild(document.createTextNode(math));
@@ -790,7 +819,7 @@ const val KATEX_RENDERING_JS =
                 try {
                     katex.render(math, span, {
                         throwOnError: true,
-                        displayMode: true
+                        displayMode: false
                     });
                 } catch {
                     span.appendChild(document.createTextNode(math));
@@ -838,7 +867,7 @@ const val KATEX_RENDERING_JS =
                 if (text.trim()) {
                     if (isInWritten) {
                         // if the text is in a written: section
-                        // turn "some text" to \[some text\]
+                        // turn "some text" to ${'$'}${'$'}${'$'}some text${'$'}${'$'}${'$'}
                         // so the text is in math mode
                         if (text[0] === '"') {
                             text = text.substring(1);
@@ -846,7 +875,7 @@ const val KATEX_RENDERING_JS =
                         if (text[text.length - 1] === '"') {
                             text = text.substring(0, text.length - 1);
                         }
-                        text = '\\[' + text + '\\]';
+                        text = '${'$'}${'$'}${'$'}' + text + '${'$'}${'$'}${'$'}';
                     }
                     const fragment = buildMathFragment(text);
                     i += fragment.childNodes.length - 1;

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
@@ -136,13 +136,13 @@ open class HtmlCodeWriter(
             builder.append("<span class='mathlingua-argument'>")
             val code = prettyPrintIdentifier(phase1Node.toCode())
             builder.append(
-                "\\[${code
+                "$$$${code
                     .replace("{", "\\{")
                     .replace("}", "\\}")
                     // replace _\{...\} with _{...}
                     // because that is required to support things
                     // like M_{i, j}
-                    .replace(Regex("_\\\\\\{(.*?)\\\\\\}"), "_{$1}")}\\]")
+                    .replace(Regex("_\\\\\\{(.*?)\\\\\\}"), "_{$1}")}$$$")
             builder.append("</span>")
         } else {
             builder.append("<span class='mathlingua-argument-no-render'>")
@@ -308,30 +308,30 @@ open class HtmlCodeWriter(
             if (stmtText.contains(IS)) {
                 val index = stmtText.indexOf(IS)
                 val lhs = stmtText.substring(0, index)
-                builder.append("\\[${prettyPrintTexTalk(lhs)}\\]")
+                builder.append("$$$${prettyPrintTexTalk(lhs)}$$$")
                 writeSpace()
                 writeDirect("<span class='mathlingua-is'>is</span>")
                 writeSpace()
                 val rhs = stmtText.substring(index + IS.length).trim()
-                builder.append("\\[${prettyPrintTexTalk(rhs)}\\]")
+                builder.append("$$$${prettyPrintTexTalk(rhs)}$$$")
             } else if (stmtText.contains(IN)) {
                 val index = stmtText.indexOf(IN)
                 val lhs = stmtText.substring(0, index)
-                builder.append("\\[")
+                builder.append("$$$")
                 builder.append(prettyPrintTexTalk(lhs))
                 writeDirect(" \\in ")
                 val rhs = stmtText.substring(index + IN.length).trim()
                 builder.append(prettyPrintTexTalk(rhs))
-                builder.append("\\]")
+                builder.append("$$$")
             } else {
                 if (root is ValidationSuccess &&
                     (defines.isNotEmpty() ||
                         states.isNotEmpty() ||
                         foundations.isNotEmpty() ||
                         mutuallyGroups.isNotEmpty())) {
-                    builder.append("\\[$fullExpansion\\]")
+                    builder.append("$$$$fullExpansion$$$")
                 } else {
-                    builder.append("\\[$stmtText\\]")
+                    builder.append("$$$$stmtText$$$")
                 }
             }
             builder.append("</span>")
@@ -360,12 +360,12 @@ open class HtmlCodeWriter(
     }
 
     override fun writeIdentifier(name: String, isVarArgs: Boolean) {
-        builder.append("<span class='mathlingua-identifier'>\\[")
+        builder.append("<span class='mathlingua-identifier'>$$$")
         builder.append(prettyPrintIdentifier(name))
         if (isVarArgs) {
             builder.append("...")
         }
-        builder.append("\\]</span>")
+        builder.append("$$$</span>")
     }
 
     override fun writeDirect(text: String) {


### PR DESCRIPTION
The previous commit made changes to allow `$`, `\(`, `$$`, and
`\[` to be rendered correctly.  However, this caused rendering
issues for statements.  With this commit, the special `$$$`
token is used for text in statements to allow JavaScript to
render statements correctly.
