### PR TITLE
feat: add support for text blocks

### DIFF
--- a/src/main/kotlin/mathlingua/cli/Mathlingua.kt
+++ b/src/main/kotlin/mathlingua/cli/Mathlingua.kt
@@ -261,9 +261,13 @@ private fun renderFile(
 
     val contentBuilder = StringBuilder()
     for (item in pair.first) {
-        contentBuilder.append("<div class='mathlingua-top-level'>")
-        contentBuilder.append(item)
-        contentBuilder.append("</div><br/><br/>")
+        if (item.trim().startsWith("::")) {
+            contentBuilder.append(item)
+        } else {
+            contentBuilder.append("<div class='mathlingua-top-level'>")
+            contentBuilder.append(item)
+            contentBuilder.append("</div><br/><br/>")
+        }
     }
 
     val text =
@@ -916,6 +920,7 @@ const val SHARED_CSS =
 
     h1, h2, h3, h4 {
         color: #0055bb;
+        text-align: center;
     }
 
     .mathlingua-top-level {
@@ -935,6 +940,34 @@ const val SHARED_CSS =
         width: max-content;
         margin-left: auto; /* for centering content */
         margin-right: auto; /* for centering content */
+    }
+
+    .mathlingua-block-comment {
+        font-family: Georgia, 'Times New Roman', Times, serif;
+        padding-top: 1.1em;
+        padding-bottom: 1em;
+        padding-left: 1.1em;
+        padding-right: 1.1em;
+    }
+
+    .mathlingua-block-comment-top-level {
+        font-family: Georgia, 'Times New Roman', Times, serif;
+        font-size: 80%;
+        line-height: 1.3;
+        text-indent: -2.5ex !important;
+        padding-top: 1.5em;
+        padding-bottom: 1.5em;
+        padding-left: 1.5em;
+        padding-right: 1.5em;
+        background-color: #ffffff;
+        max-width: 90%;
+        width: max-content;
+        margin-left: auto; /* for centering content */
+        margin-right: auto; /* for centering content */
+        border: solid;
+        border-width: 1px;
+        border-color: rgba(230, 230, 230);
+        border-radius: 2px;
     }
 
     .end-mathlingua-top-level {
@@ -971,6 +1004,7 @@ const val SHARED_CSS =
         padding: 0 0 0 2.5em;
         font-size: 80%;
         font-family: Georgia, 'Times New Roman', Times, serif;
+        line-height: 1.3;
     }
 
     .mathlingua-text-no-render {
@@ -980,6 +1014,7 @@ const val SHARED_CSS =
         padding: 0 0 0 2.5em;
         font-size: 80%;
         font-family: Georgia, 'Times New Roman', Times, serif;
+        line-height: 1.3;
     }
 
     .mathlingua-url {
@@ -1036,6 +1071,8 @@ const val SHARED_CSS =
         margin-right: auto;
         width: max-content;
         display: block;
+        padding-top: 1ex;
+        padding-bottom: 1ex;
     }
 
     .katex {
@@ -1270,7 +1307,11 @@ fun buildIndexHtml(
                             }
 
                             const el = document.createElement('div');
-                            el.className = 'mathlingua-top-level';
+                            if (entityList[i].indexOf('class=\'mathlingua-block-comment\'') >= 0) {
+                                el.className = 'mathlingua-block-comment-top-level';
+                            } else {
+                                el.className = 'mathlingua-top-level';
+                            }
                             el.innerHTML = entityList[i];
                             content.appendChild(el);
                             content.appendChild(document.createElement('br'));

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase1/ChalkTalkLexer.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase1/ChalkTalkLexer.kt
@@ -99,16 +99,6 @@ private class ChalkTalkLexerImpl(private var text: String) : ChalkTalkLexer {
                 this.chalkTalkTokens.add(Phase1Token("{", ChalkTalkTokenType.LCurly, line, column))
             } else if (c == '}') {
                 this.chalkTalkTokens.add(Phase1Token("}", ChalkTalkTokenType.RCurly, line, column))
-            } else if (c == ':') {
-                if (i < text.length && text[i] == '=') {
-                    this.chalkTalkTokens.add(
-                        Phase1Token(":=", ChalkTalkTokenType.ColonEquals, line, column))
-                    i++ // move past the =
-                    column++
-                } else {
-                    this.chalkTalkTokens.add(
-                        Phase1Token(":", ChalkTalkTokenType.Colon, line, column))
-                }
             } else if (c == ',') {
                 this.chalkTalkTokens.add(Phase1Token(",", ChalkTalkTokenType.Comma, line, column))
             } else if (c == '.' && i < text.length && text[i] == ' ') {
@@ -362,6 +352,52 @@ private class ChalkTalkLexerImpl(private var text: String) : ChalkTalkLexer {
                 }
                 this.chalkTalkTokens.add(
                     Phase1Token(id, ChalkTalkTokenType.Id, startLine, startColumn))
+            } else if (c == ':' && i < text.length && text[i] == ':') {
+                val startLine = line
+                val startColumn = column
+                // move past the ::
+                i++
+                column++
+                val builder = StringBuilder("::")
+                while (i < text.length &&
+                    !(text[i] == ':' && i + 1 < text.length && text[i + 1] == ':')) {
+                    val tmp = text[i++]
+                    builder.append(tmp)
+                    if (tmp == '\n' || tmp == '\r') {
+                        line++
+                        column = -1
+                    }
+                }
+                if (i < text.length &&
+                    text[i] == ':' &&
+                    i + 1 < text.length &&
+                    text[i + 1] == ':') {
+                    // move past the ::
+                    i += 2
+                    builder.append("::")
+                }
+                if (i < text.length && text[i] == '\n') {
+                    // address the trailing newline
+                    i++
+                    line++
+                    column = -1
+                }
+                this.chalkTalkTokens.add(
+                    Phase1Token(
+                        builder.toString(),
+                        ChalkTalkTokenType.BlockComment,
+                        startLine,
+                        startColumn))
+            } else if (c == ':') {
+                if (i < text.length && text[i] == '=') {
+                    this.chalkTalkTokens.add(
+                        Phase1Token(":=", ChalkTalkTokenType.ColonEquals, line, column))
+                    i++ // move past the =
+                    column++
+                } else {
+                    this.chalkTalkTokens.add(
+                        Phase1Token(":", ChalkTalkTokenType.Colon, line, column))
+                }
             } else if (c != ' ') { // spaces are ignored
                 errors.add(ParseError("Unrecognized character $c", line, column))
             }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase1/ast/Ast.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase1/ast/Ast.kt
@@ -23,13 +23,17 @@ interface Phase1Node {
     fun transform(transformer: (node: Phase1Node) -> Phase1Node): Phase1Node
 }
 
-data class Root(val groups: List<Group>) : Phase1Node {
+data class Root(val groups: List<GroupOrBlockComment>) : Phase1Node {
 
     override fun forEach(fn: (node: Phase1Node) -> Unit) = groups.forEach(fn)
 
     private fun print(buffer: StringBuilder) {
         for (grp in groups) {
-            grp.print(buffer, 0, false)
+            if (grp is Group) {
+                grp.print(buffer, 0, false)
+            } else if (grp is BlockComment) {
+                grp.print(buffer)
+            }
         }
     }
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase1/ast/Phase1Target.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase1/ast/Phase1Target.kt
@@ -35,10 +35,13 @@ enum class ChalkTalkTokenType {
     LCurly,
     RCurly,
     Underscore,
-    DotDotDot
+    DotDotDot,
+    BlockComment
 }
 
 sealed class Phase1Target : Phase1Node
+
+interface GroupOrBlockComment : Phase1Node
 
 data class Mapping(val lhs: Phase1Token, val rhs: Phase1Token) : Phase1Target() {
 
@@ -58,7 +61,22 @@ data class Mapping(val lhs: Phase1Token, val rhs: Phase1Token) : Phase1Target() 
                 rhs = rhs.transform(transformer) as Phase1Token))
 }
 
-data class Group(val sections: List<Section>, val id: Phase1Token?) : Phase1Target() {
+data class BlockComment(val text: String) : GroupOrBlockComment {
+    override fun forEach(fn: (node: Phase1Node) -> Unit) {}
+
+    override fun toCode() = text
+
+    override fun resolve() = this
+
+    override fun transform(transformer: (node: Phase1Node) -> Phase1Node) = transformer(this)
+
+    fun print(buffer: StringBuilder) {
+        buffer.append(toCode())
+    }
+}
+
+data class Group(val sections: List<Section>, val id: Phase1Token?) :
+    Phase1Target(), GroupOrBlockComment {
 
     override fun forEach(fn: (node: Phase1Node) -> Unit) {
         if (id != null) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/TopLevelGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/TopLevelGroup.kt
@@ -16,6 +16,8 @@
 
 package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel
 
+import mathlingua.frontend.chalktalk.phase1.ast.BlockComment
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
 import mathlingua.frontend.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
@@ -23,6 +25,20 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.UsingSecti
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.MetaDataSection
 
 abstract class TopLevelGroup(open val metaDataSection: MetaDataSection?) : Phase2Node
+
+class TopLevelBlockComment(private val blockComment: BlockComment) : TopLevelGroup(null) {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) {}
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeBlockComment(blockComment.text)
+        return writer
+    }
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
+        chalkTransformer(this)
+}
+
+fun isBlockComment(node: Phase1Node) = node is BlockComment
 
 fun topLevelToCode(
     writer: CodeWriter, isArg: Boolean, indent: Int, id: IdStatement?, vararg sections: Phase2Node?

--- a/src/test/resources/goldens/messages/invalid_phase1/Unrecognized_token/messages.txt
+++ b/src/test/resources/goldens/messages/invalid_phase1/Unrecognized_token/messages.txt
@@ -8,19 +8,19 @@ EndMessage:
 Row: 9
 Column: 0
 Message:
-Unrecognized token 'Result
+Unrecognized token Result
 EndMessage:
 
 
 Row: 10
 Column: 0
 Message:
-Unrecognized token '<Indent>
+Unrecognized token <Indent>
 EndMessage:
 
 
 Row: 10
 Column: 0
 Message:
-Unrecognized token '<Unindent>
+Unrecognized token <Unindent>
 EndMessage:


### PR DESCRIPTION
A text block is a sequence of text between `::` and `::`.  The
text in these blocks are rendered as LaTeX and appear in the
rendered output.  This differs from comments (that start with `--`)
that do not appear in rendered output.
