### PR TITLE
chore: set the search input radius to zero

### DIFF
--- a/src/main/kotlin/mathlingua/cli/Mathlingua.kt
+++ b/src/main/kotlin/mathlingua/cli/Mathlingua.kt
@@ -1638,6 +1638,7 @@ fun buildIndexHtml(
 
             .search {
                 border: none;
+                border-radius: 0;
                 line-height: 1.75em;
                 background-color: #eeeeee;
             }


### PR DESCRIPTION
This is needed to make the search input component look correct
on iOS.
