### PR TITLE
fix: improve html rendering of text

### DIFF
--- a/src/main/kotlin/mathlingua/cli/Mathlingua.kt
+++ b/src/main/kotlin/mathlingua/cli/Mathlingua.kt
@@ -967,7 +967,8 @@ const val SHARED_CSS =
         font-family: Georgia, 'Times New Roman', Times, serif;
         font-size: 80%;
         line-height: 1.3;
-        text-indent: -2.5ex !important;
+        text-align: left;
+        text-indent: 0;
         background-color: #ffffff;
         max-width: 90%;
         width: max-content;
@@ -1092,15 +1093,14 @@ const val SHARED_CSS =
     }
 
     .mathlingua-id {
+        font-size: 85%;
         color: #5500aa;
         overflow-x: scroll;
     }
 
     .mathlingua-text {
         color: #000000;
-        display: block;
-        margin: 0.2em 0 -1.2em 0;
-        padding: 0 0 0 2.5em;
+        display: inline-block;
         font-size: 80%;
         font-family: Georgia, 'Times New Roman', Times, serif;
         line-height: 1.3;
@@ -1108,9 +1108,7 @@ const val SHARED_CSS =
 
     .mathlingua-text-no-render {
         color: #000000;
-        display: block;
-        margin: 0.2em 0 -1.2em 0;
-        padding: 0 0 0 2.5em;
+        display: inline-block;
         font-size: 80%;
         font-family: Georgia, 'Times New Roman', Times, serif;
         line-height: 1.3;
@@ -1119,9 +1117,7 @@ const val SHARED_CSS =
     .mathlingua-url {
         color: #0000aa;
         text-decoration: none;
-        display: block;
-        margin: 0 0 -1em 0;
-        padding: 0 0 0 2.5em;
+        display: inline-block;
         font-size: 80%;
         font-family: Georgia, 'Times New Roman', Times, serif;
     }
@@ -1129,6 +1125,7 @@ const val SHARED_CSS =
     .mathlingua-link {
         color: #0000aa;
         text-decoration: none;
+        display: inline-block;
     }
 
     .mathlingua-statement-no-render {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
@@ -271,7 +271,7 @@ open class HtmlCodeWriter(
                     builder.append(")</span>")
                 }
                 builder.append("<span class='mathlingua-topic-content'>")
-                builder.append(node.contentSection.text)
+                builder.append(newlinesToHtml(node.contentSection.text))
                 builder.append("</span>")
                 builder.append("</span>")
                 builder.toString()
@@ -368,8 +368,7 @@ open class HtmlCodeWriter(
     }
 
     private fun newlinesToHtml(text: String): String {
-        return text
-            .split("\n")
+        return text.split("\n")
             .joinToString("\n") {
                 it.replaceCommandWithHtml("textbf", "b")
                     .replaceCommandWithHtml("emph", "i")
@@ -379,7 +378,7 @@ open class HtmlCodeWriter(
                     .replaceCommandWithHtml("subsubsection", "h4")
             }
             .split("\n\n")
-            .joinToString("\n") { "<p>$it</p>" }
+            .joinToString("<br/><br/>")
     }
 
     private fun getUrlWithoutSpaces(url: String) = url.replace(Regex("[ \\r\\n\\t]+"), "")

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/resultlike/axiom/AxiomSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/resultlike/axiom/AxiomSection.kt
@@ -36,6 +36,7 @@ data class AxiomSection(val names: List<String>) : Phase2Node {
         writer.writeIndent(isArg, indent)
         writer.writeHeader("Axiom")
         if (names.size == 1) {
+            writer.writeSpace()
             writer.writeText(names[0])
         } else if (names.size > 1) {
             writer.writeNewline()


### PR DESCRIPTION
The `mathlingua-block-comment`, `mathlingua-text`, and
`mathlingua-text-no-render` rendering was updated to make the
text flow more smoothly.  In addition, a blank line is placed
between paragraphs.
