### PR TITLE
feat: support `toc` files

### DIFF
--- a/src/main/kotlin/mathlingua/cli/VirtualFileSystem.kt
+++ b/src/main/kotlin/mathlingua/cli/VirtualFileSystem.kt
@@ -115,13 +115,15 @@ private class DiskFileSystem(private val cwd: List<String>) : VirtualFileSystem 
 
     override fun writeText(vf: VirtualFile, content: String) = vf.toFile().writeText(content)
 
-    override fun listFiles(vf: VirtualFile) =
-        (vf.toFile().listFiles() ?: arrayOf()).map {
+    override fun listFiles(vf: VirtualFile): List<VirtualFile> {
+        val children = vf.toFile().listFiles() ?: arrayOf()
+        return children.sortedBy { it.name }.map {
             VirtualFileImpl(
                 absolutePathParts = it.absolutePath.split(File.separator),
                 directory = it.isDirectory,
                 this)
         }
+    }
 
     override fun delete(vf: VirtualFile): Boolean {
         val file = vf.toFile()


### PR DESCRIPTION
Now a `toc` file can exist in any directory or subdirectory of
the `content` directory.  Its contents list the names of files
or directories in the directory which it resides.

It a `toc` file exists in a directory, `mlg render` will display
items in the file list in the order in the `toc` file and will
include an item if and only if it is in the `toc` file.

Thus, `toc` files allow one to both ignore certain files as well
as ensure a particular ordering of files in the file list in the
rendered html.

If a directory does not contain a `toc` file, all files and
directories in that directory will be listed in alphabetical
order.
