### PR TITLE
feat: support CommonMark in text blocks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile group: 'com.github.ajalt', name: 'clikt', version: '2.6.0'
     compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.4.2'
+    compile group: 'com.vladsch.flexmark', name: 'flexmark-all', version: '0.62.2'
     testImplementation 'com.willowtreeapps.assertk:assertk-jvm:0.19'
     testImplementation 'org.jetbrains.kotlin:kotlin-reflect:1.4.31'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'

--- a/src/main/kotlin/mathlingua/backend/SourceCollection.kt
+++ b/src/main/kotlin/mathlingua/backend/SourceCollection.kt
@@ -833,7 +833,8 @@ class SourceCollectionImpl(sources: List<SourceFile>) : SourceCollection {
                     defines = doExpand.thenUse { definesGroups.map { it.value } },
                     states = doExpand.thenUse { statesGroups.map { it.value } },
                     axioms = doExpand.thenUse { axiomGroups.map { it.value } },
-                    foundations = doExpand.thenUse { foundationGroups.map { it.value } })
+                    foundations = doExpand.thenUse { foundationGroups.map { it.value } },
+                    literal = false)
             } else {
                 MathLinguaCodeWriter(
                     defines = doExpand.thenUse { definesGroups.map { it.value } },

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Document.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Document.kt
@@ -77,7 +77,6 @@ data class Document(val groups: List<TopLevelGroup>) : Phase2Node {
     }
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
-        println("document toCode")
         for (i in groups.indices) {
             val grp = groups[i]
             if (grp is TopLevelBlockComment) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/clause/Text.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/clause/Text.kt
@@ -32,7 +32,7 @@ data class Text(val text: String) : Clause {
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
-        writer.writeText(text.removeSurrounding("\"", "\""))
+        writer.writeText(text)
         return writer
     }
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/resource/ResourceSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/resource/ResourceSection.kt
@@ -61,7 +61,7 @@ class ResourceSection(val items: List<StringSectionGroup>) : Phase2Node {
                 val values = item.section.values
                 if (values.size == 1) {
                     writer.writeSpace()
-                    writer.writeUrl(values[0].removeSurrounding("\"", "\""), null)
+                    writer.writeUrl(values[0], null)
                 } else {
                     for (j in values.indices) {
                         writer.writeNewline()
@@ -69,7 +69,7 @@ class ResourceSection(val items: List<StringSectionGroup>) : Phase2Node {
                         writer.writeSpace()
                         writer.writeDot()
                         writer.writeSpace()
-                        writer.writeUrl(values[j].removeSurrounding("\"", "\""), null)
+                        writer.writeUrl(values[j], null)
                     }
                 }
             } else {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/MetaDataUtil.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/MetaDataUtil.kt
@@ -26,7 +26,7 @@ internal fun indentedStringSection(
     writer.writeIndent(isArg, indent)
     writer.writeHeader(sectionName)
     writer.writeSpace()
-    writer.writeText(value.removeSurrounding("\"", "\""))
+    writer.writeText(value)
     return writer
 }
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/StringSectionGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/item/StringSectionGroup.kt
@@ -19,5 +19,5 @@ package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.
 import mathlingua.frontend.chalktalk.phase2.ast.common.OnePartNode
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.metadata.section.StringSection
 
-class StringSectionGroup(val section: StringSection) :
+data class StringSectionGroup(val section: StringSection) :
     OnePartNode<StringSection>(section, ::StringSectionGroup), MetaDataItem

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/SiteItemSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/SiteItemSection.kt
@@ -37,8 +37,7 @@ data class SiteItemSection(val url: String) : Phase2Node {
         writer.writeIndent(isArg, indent)
         writer.writeHeader("site")
         writer.writeSpace()
-        val urlNoSpace = url.removeSurrounding("\"", "\"")
-        writer.writeUrl(urlNoSpace, null)
+        writer.writeUrl(url, null)
         return writer
     }
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/StringSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/shared/metadata/section/StringSection.kt
@@ -29,7 +29,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.validateSection
 import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
 
-class StringSection(val name: String, val values: List<String>) : Phase2Node {
+data class StringSection(val name: String, val values: List<String>) : Phase2Node {
     override fun forEach(fn: (node: Phase2Node) -> Unit) {}
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
@@ -37,12 +37,12 @@ class StringSection(val name: String, val values: List<String>) : Phase2Node {
         writer.writeHeader(name)
         if (values.size == 1) {
             writer.writeSpace()
-            writer.writeText(values[0].removeSurrounding("\"", "\""))
+            writer.writeText(values[0])
         } else {
             for (value in values) {
                 writer.writeNewline()
                 writer.writeIndent(true, indent + 2)
-                writer.writeText(value.removeSurrounding("\"", "\""))
+                writer.writeText(value)
             }
         }
         return writer

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/topic/ContentSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/topic/ContentSection.kt
@@ -36,7 +36,7 @@ data class ContentSection(val text: String) : Phase2Node {
         writer.writeIndent(isArg, indent)
         writer.writeHeader("content")
         writer.writeIndent(false, 1)
-        writer.writeText(text.removeSurrounding("\"", "\""))
+        writer.writeText(text)
         return writer
     }
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/topic/TopicSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/topic/TopicSection.kt
@@ -37,12 +37,12 @@ data class TopicSection(val names: List<String>) : Phase2Node {
         writer.writeHeader("Topic")
         if (names.size == 1) {
             writer.writeIndent(false, 1)
-            writer.writeText(names[0].removeSurrounding("\"", "\""))
+            writer.writeText(names[0])
         } else if (names.isNotEmpty()) {
             writer.writeNewline()
             for (name in names) {
                 writer.writeIndent(true, indent + 2)
-                writer.writeText(name.removeSurrounding("\"", "\""))
+                writer.writeText(name)
             }
         }
         return writer


### PR DESCRIPTION
Text in text blocks `:: ... ::` can now be CommonMark.  In
addition to standard CommonMark, code in triple backticks of type
'math' will be rendered as MathLingua raw code (not rendered
code).  In addition, LaTeX can be entered in `$...$`, `$$...$$`,
`\(...\)` and`\[...\]` and will be rendered as math.
