### PR TITLE
feat: support underscores in names and operators

### DIFF
--- a/src/main/kotlin/mathlingua/backend/SourceCollection.kt
+++ b/src/main/kotlin/mathlingua/backend/SourceCollection.kt
@@ -953,8 +953,12 @@ private fun <T> Boolean.thenUse(value: () -> List<T>) =
     }
 
 fun isOperatorName(text: String): Boolean {
-    for (c in text) {
-        if (!isOpChar(c)) {
+    var index = text.indexOf('_')
+    if (index < 0) {
+        index = text.length
+    }
+    for (i in 0 until index) {
+        if (!isOpChar(text[i])) {
             return false
         }
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase1/ChalkTalkLexer.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase1/ChalkTalkLexer.kt
@@ -171,6 +171,26 @@ private class ChalkTalkLexerImpl(private var text: String) : ChalkTalkLexer {
                     name += text[i++]
                     column++
                 }
+                if (i < text.length &&
+                    text[i] == '_' &&
+                    i + 1 < text.length &&
+                    text[i + 1] != '{') {
+                    name += text[i++] // absorb the _
+                    column++
+
+                    if (i >= text.length || !isNameChar(text[i])) {
+                        errors.add(
+                            ParseError(
+                                message = "Expected a name or a { after an underscore",
+                                row = startLine,
+                                column = startColumn))
+                    } else {
+                        while (i < text.length && isNameChar(text[i])) {
+                            name += text[i++]
+                            column++
+                        }
+                    }
+                }
                 this.chalkTalkTokens.add(
                     Phase1Token(name, ChalkTalkTokenType.Name, startLine, startColumn))
             } else if (isNameChar(c) || c == '?') {
@@ -190,6 +210,27 @@ private class ChalkTalkLexerImpl(private var text: String) : ChalkTalkLexer {
                 while (i < text.length && isNameChar(text[i])) {
                     name += text[i++]
                     column++
+                }
+
+                if (i < text.length &&
+                    text[i] == '_' &&
+                    i + 1 < text.length &&
+                    text[i + 1] != '{') {
+                    name += text[i++] // absorb the _
+                    column++
+
+                    if (i >= text.length || !isNameChar(text[i])) {
+                        errors.add(
+                            ParseError(
+                                message = "Expected a name or a { after an underscore",
+                                row = startLine,
+                                column = startColumn))
+                    } else {
+                        while (i < text.length && isNameChar(text[i])) {
+                            name += text[i++]
+                            column++
+                        }
+                    }
                 }
 
                 var hasQuestionMark = false

--- a/src/test/resources/goldens/chalktalk/abstractions/handles_sequence_abstractions/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/handles_sequence_abstractions/phase1-structure.txt
@@ -38,19 +38,12 @@ Root(
                                                                        parts = [
                                                                                  AbstractionPart(
                                                                                    name = Phase1Token(
-                                                                                     text = "a"
+                                                                                     text = "a_k"
                                                                                      type = ChalkTalkTokenType.Name
                                                                                      row = 2
                                                                                      column = 11
                                                                                    )
-                                                                                   subParams = [
-                                                                                                 Phase1Token(
-                                                                                                   text = "k"
-                                                                                                   type = ChalkTalkTokenType.Name
-                                                                                                   row = 2
-                                                                                                   column = 13
-                                                                                                 )
-                                                                                               ]
+                                                                                   subParams = null
                                                                                    params = null
                                                                                    tail = null
                                                                                  )

--- a/src/test/resources/goldens/chalktalk/abstractions/handles_sequence_abstractions/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/handles_sequence_abstractions/phase2-structure.txt
@@ -23,19 +23,12 @@ Document(
                                                    parts = [
                                                              AbstractionPart(
                                                                name = Phase1Token(
-                                                                 text = "a"
+                                                                 text = "a_k"
                                                                  type = ChalkTalkTokenType.Name
                                                                  row = 2
                                                                  column = 11
                                                                )
-                                                               subParams = [
-                                                                             Phase1Token(
-                                                                               text = "k"
-                                                                               type = ChalkTalkTokenType.Name
-                                                                               row = 2
-                                                                               column = 13
-                                                                             )
-                                                                           ]
+                                                               subParams = null
                                                                params = null
                                                                tail = null
                                                              )

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param/phase1-structure.txt
@@ -38,19 +38,12 @@ Root(
                                                                        parts = [
                                                                                  AbstractionPart(
                                                                                    name = Phase1Token(
-                                                                                     text = "a"
+                                                                                     text = "a_n"
                                                                                      type = ChalkTalkTokenType.Name
                                                                                      row = 2
                                                                                      column = 10
                                                                                    )
-                                                                                   subParams = [
-                                                                                                 Phase1Token(
-                                                                                                   text = "n"
-                                                                                                   type = ChalkTalkTokenType.Name
-                                                                                                   row = 2
-                                                                                                   column = 12
-                                                                                                 )
-                                                                                               ]
+                                                                                   subParams = null
                                                                                    params = null
                                                                                    tail = null
                                                                                  )

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param/phase2-structure.txt
@@ -23,19 +23,12 @@ Document(
                                                    parts = [
                                                              AbstractionPart(
                                                                name = Phase1Token(
-                                                                 text = "a"
+                                                                 text = "a_n"
                                                                  type = ChalkTalkTokenType.Name
                                                                  row = 2
                                                                  column = 10
                                                                )
-                                                               subParams = [
-                                                                             Phase1Token(
-                                                                               text = "n"
-                                                                               type = ChalkTalkTokenType.Name
-                                                                               row = 2
-                                                                               column = 12
-                                                                             )
-                                                                           ]
+                                                               subParams = null
                                                                params = null
                                                                tail = null
                                                              )

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param_and_multiple_params/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param_and_multiple_params/phase1-structure.txt
@@ -38,19 +38,12 @@ Root(
                                                                        parts = [
                                                                                  AbstractionPart(
                                                                                    name = Phase1Token(
-                                                                                     text = "a"
+                                                                                     text = "a_n"
                                                                                      type = ChalkTalkTokenType.Name
                                                                                      row = 2
                                                                                      column = 10
                                                                                    )
-                                                                                   subParams = [
-                                                                                                 Phase1Token(
-                                                                                                   text = "n"
-                                                                                                   type = ChalkTalkTokenType.Name
-                                                                                                   row = 2
-                                                                                                   column = 12
-                                                                                                 )
-                                                                                               ]
+                                                                                   subParams = null
                                                                                    params = [
                                                                                               Phase1Token(
                                                                                                 text = "x"

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param_and_multiple_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_abstractions_with_one_sub_param_and_multiple_params/phase2-structure.txt
@@ -23,19 +23,12 @@ Document(
                                                    parts = [
                                                              AbstractionPart(
                                                                name = Phase1Token(
-                                                                 text = "a"
+                                                                 text = "a_n"
                                                                  type = ChalkTalkTokenType.Name
                                                                  row = 2
                                                                  column = 10
                                                                )
-                                                               subParams = [
-                                                                             Phase1Token(
-                                                                               text = "n"
-                                                                               type = ChalkTalkTokenType.Name
-                                                                               row = 2
-                                                                               column = 12
-                                                                             )
-                                                                           ]
+                                                               subParams = null
                                                                params = [
                                                                           Phase1Token(
                                                                             text = "x"

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_enclosed_abstractions_with_sub_params/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_enclosed_abstractions_with_sub_params/phase1-structure.txt
@@ -38,19 +38,12 @@ Root(
                                                                        parts = [
                                                                                  AbstractionPart(
                                                                                    name = Phase1Token(
-                                                                                     text = "a"
+                                                                                     text = "a_i"
                                                                                      type = ChalkTalkTokenType.Name
                                                                                      row = 2
                                                                                      column = 11
                                                                                    )
-                                                                                   subParams = [
-                                                                                                 Phase1Token(
-                                                                                                   text = "i"
-                                                                                                   type = ChalkTalkTokenType.Name
-                                                                                                   row = 2
-                                                                                                   column = 13
-                                                                                                 )
-                                                                                               ]
+                                                                                   subParams = null
                                                                                    params = null
                                                                                    tail = null
                                                                                  )

--- a/src/test/resources/goldens/chalktalk/abstractions/parses_enclosed_abstractions_with_sub_params/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/abstractions/parses_enclosed_abstractions_with_sub_params/phase2-structure.txt
@@ -23,19 +23,12 @@ Document(
                                                    parts = [
                                                              AbstractionPart(
                                                                name = Phase1Token(
-                                                                 text = "a"
+                                                                 text = "a_i"
                                                                  type = ChalkTalkTokenType.Name
                                                                  row = 2
                                                                  column = 11
                                                                )
-                                                               subParams = [
-                                                                             Phase1Token(
-                                                                               text = "i"
-                                                                               type = ChalkTalkTokenType.Name
-                                                                               row = 2
-                                                                               column = 13
-                                                                             )
-                                                                           ]
+                                                               subParams = null
                                                                params = null
                                                                tail = null
                                                              )

--- a/src/test/resources/goldens/textalk/colon_equals/parses_colon_colon_equal/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/colon_equals/parses_colon_colon_equal/phase1-structure.txt
@@ -5,41 +5,32 @@ ExpressionTexTalkNode(
                    items = [
                              ExpressionTexTalkNode(
                                children = [
-                                            GroupTexTalkNode(
-                                              type = TexTalkNodeType.SyntheticGroup
-                                              parameters = ParametersTexTalkNode(
-                                                items = [
-                                                          ExpressionTexTalkNode(
-                                                            children = [
-                                                                         TextTexTalkNode(
-                                                                           type = TexTalkNodeType.Identifier
-                                                                           tokenType = TexTalkTokenType.Identifier
-                                                                           text = "f"
-                                                                           isVarArg = false
-                                                                         ),
-                                                                         GroupTexTalkNode(
-                                                                           type = TexTalkNodeType.ParenGroup
-                                                                           parameters = ParametersTexTalkNode(
-                                                                             items = [
-                                                                                       ExpressionTexTalkNode(
-                                                                                         children = [
-                                                                                                      TextTexTalkNode(
-                                                                                                        type = TexTalkNodeType.Identifier
-                                                                                                        tokenType = TexTalkTokenType.Identifier
-                                                                                                        text = "x?"
-                                                                                                        isVarArg = false
-                                                                                                      )
-                                                                                                    ]
-                                                                                       )
-                                                                                     ]
-                                                                           )
-                                                                           isVarArg = false
-                                                                         )
-                                                                       ]
-                                                          )
-                                                        ]
+                                            MappingNode(
+                                              name = TextTexTalkNode(
+                                                type = TexTalkNodeType.Identifier
+                                                tokenType = TexTalkTokenType.Identifier
+                                                text = "f"
+                                                isVarArg = false
                                               )
-                                              isVarArg = false
+                                              subGroup = null
+                                              parenGroup = GroupTexTalkNode(
+                                                type = TexTalkNodeType.ParenGroup
+                                                parameters = ParametersTexTalkNode(
+                                                  items = [
+                                                            ExpressionTexTalkNode(
+                                                              children = [
+                                                                           TextTexTalkNode(
+                                                                             type = TexTalkNodeType.Identifier
+                                                                             tokenType = TexTalkTokenType.Identifier
+                                                                             text = "x?"
+                                                                             isVarArg = false
+                                                                           )
+                                                                         ]
+                                                            )
+                                                          ]
+                                                )
+                                                isVarArg = false
+                                              )
                                             )
                                           ]
                              )

--- a/src/test/resources/goldens/textalk/colon_equals/parses_colon_equals/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/colon_equals/parses_colon_equals/phase1-structure.txt
@@ -5,41 +5,32 @@ ExpressionTexTalkNode(
                    items = [
                              ExpressionTexTalkNode(
                                children = [
-                                            GroupTexTalkNode(
-                                              type = TexTalkNodeType.SyntheticGroup
-                                              parameters = ParametersTexTalkNode(
-                                                items = [
-                                                          ExpressionTexTalkNode(
-                                                            children = [
-                                                                         TextTexTalkNode(
-                                                                           type = TexTalkNodeType.Identifier
-                                                                           tokenType = TexTalkTokenType.Identifier
-                                                                           text = "f"
-                                                                           isVarArg = false
-                                                                         ),
-                                                                         GroupTexTalkNode(
-                                                                           type = TexTalkNodeType.ParenGroup
-                                                                           parameters = ParametersTexTalkNode(
-                                                                             items = [
-                                                                                       ExpressionTexTalkNode(
-                                                                                         children = [
-                                                                                                      TextTexTalkNode(
-                                                                                                        type = TexTalkNodeType.Identifier
-                                                                                                        tokenType = TexTalkTokenType.Identifier
-                                                                                                        text = "x"
-                                                                                                        isVarArg = false
-                                                                                                      )
-                                                                                                    ]
-                                                                                       )
-                                                                                     ]
-                                                                           )
-                                                                           isVarArg = false
-                                                                         )
-                                                                       ]
-                                                          )
-                                                        ]
+                                            MappingNode(
+                                              name = TextTexTalkNode(
+                                                type = TexTalkNodeType.Identifier
+                                                tokenType = TexTalkTokenType.Identifier
+                                                text = "f"
+                                                isVarArg = false
                                               )
-                                              isVarArg = false
+                                              subGroup = null
+                                              parenGroup = GroupTexTalkNode(
+                                                type = TexTalkNodeType.ParenGroup
+                                                parameters = ParametersTexTalkNode(
+                                                  items = [
+                                                            ExpressionTexTalkNode(
+                                                              children = [
+                                                                           TextTexTalkNode(
+                                                                             type = TexTalkNodeType.Identifier
+                                                                             tokenType = TexTalkTokenType.Identifier
+                                                                             text = "x"
+                                                                             isVarArg = false
+                                                                           )
+                                                                         ]
+                                                            )
+                                                          ]
+                                                )
+                                                isVarArg = false
+                                              )
                                             )
                                           ]
                              )

--- a/src/test/resources/goldens/textalk/expressions/parses_expressions_with_parens/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/expressions/parses_expressions_with_parens/phase1-structure.txt
@@ -1,109 +1,100 @@
 ExpressionTexTalkNode(
   children = [
                OperatorTexTalkNode(
-                 lhs = GroupTexTalkNode(
-                   type = TexTalkNodeType.SyntheticGroup
-                   parameters = ParametersTexTalkNode(
-                     items = [
-                               ExpressionTexTalkNode(
-                                 children = [
-                                              TextTexTalkNode(
-                                                type = TexTalkNodeType.Identifier
-                                                tokenType = TexTalkTokenType.Identifier
-                                                text = "f"
-                                                isVarArg = false
-                                              ),
-                                              GroupTexTalkNode(
-                                                type = TexTalkNodeType.ParenGroup
-                                                parameters = ParametersTexTalkNode(
-                                                  items = [
-                                                            ExpressionTexTalkNode(
-                                                              children = [
-                                                                           OperatorTexTalkNode(
-                                                                             lhs = TextTexTalkNode(
-                                                                               type = TexTalkNodeType.Identifier
-                                                                               tokenType = TexTalkTokenType.Identifier
-                                                                               text = "x"
-                                                                               isVarArg = false
-                                                                             )
-                                                                             command = TextTexTalkNode(
-                                                                               type = TexTalkNodeType.Operator
-                                                                               tokenType = TexTalkTokenType.Operator
-                                                                               text = "+"
-                                                                               isVarArg = false
-                                                                             )
-                                                                             rhs = OperatorTexTalkNode(
-                                                                               lhs = TextTexTalkNode(
-                                                                                 type = TexTalkNodeType.Identifier
-                                                                                 tokenType = TexTalkTokenType.Identifier
-                                                                                 text = "2"
-                                                                                 isVarArg = false
-                                                                               )
-                                                                               command = TextTexTalkNode(
-                                                                                 type = TexTalkNodeType.Operator
-                                                                                 tokenType = TexTalkTokenType.Operator
-                                                                                 text = "*"
-                                                                                 isVarArg = false
-                                                                               )
-                                                                               rhs = OperatorTexTalkNode(
-                                                                                 lhs = GroupTexTalkNode(
-                                                                                   type = TexTalkNodeType.ParenGroup
-                                                                                   parameters = ParametersTexTalkNode(
-                                                                                     items = [
-                                                                                               ExpressionTexTalkNode(
-                                                                                                 children = [
-                                                                                                              OperatorTexTalkNode(
-                                                                                                                lhs = TextTexTalkNode(
-                                                                                                                  type = TexTalkNodeType.Identifier
-                                                                                                                  tokenType = TexTalkTokenType.Identifier
-                                                                                                                  text = "x"
-                                                                                                                  isVarArg = false
-                                                                                                                )
-                                                                                                                command = TextTexTalkNode(
-                                                                                                                  type = TexTalkNodeType.Operator
-                                                                                                                  tokenType = TexTalkTokenType.Operator
-                                                                                                                  text = "+"
-                                                                                                                  isVarArg = false
-                                                                                                                )
-                                                                                                                rhs = TextTexTalkNode(
-                                                                                                                  type = TexTalkNodeType.Identifier
-                                                                                                                  tokenType = TexTalkTokenType.Identifier
-                                                                                                                  text = "y"
-                                                                                                                  isVarArg = false
-                                                                                                                )
-                                                                                                              )
-                                                                                                            ]
-                                                                                               )
-                                                                                             ]
-                                                                                   )
-                                                                                   isVarArg = false
-                                                                                 )
-                                                                                 command = TextTexTalkNode(
-                                                                                   type = TexTalkNodeType.Operator
-                                                                                   tokenType = TexTalkTokenType.Caret
-                                                                                   text = "^"
-                                                                                   isVarArg = false
-                                                                                 )
-                                                                                 rhs = TextTexTalkNode(
-                                                                                   type = TexTalkNodeType.Identifier
-                                                                                   tokenType = TexTalkTokenType.Identifier
-                                                                                   text = "2"
-                                                                                   isVarArg = false
-                                                                                 )
-                                                                               )
-                                                                             )
-                                                                           )
-                                                                         ]
-                                                            )
-                                                          ]
-                                                )
-                                                isVarArg = false
-                                              )
-                                            ]
-                               )
-                             ]
+                 lhs = MappingNode(
+                   name = TextTexTalkNode(
+                     type = TexTalkNodeType.Identifier
+                     tokenType = TexTalkTokenType.Identifier
+                     text = "f"
+                     isVarArg = false
                    )
-                   isVarArg = false
+                   subGroup = null
+                   parenGroup = GroupTexTalkNode(
+                     type = TexTalkNodeType.ParenGroup
+                     parameters = ParametersTexTalkNode(
+                       items = [
+                                 ExpressionTexTalkNode(
+                                   children = [
+                                                OperatorTexTalkNode(
+                                                  lhs = TextTexTalkNode(
+                                                    type = TexTalkNodeType.Identifier
+                                                    tokenType = TexTalkTokenType.Identifier
+                                                    text = "x"
+                                                    isVarArg = false
+                                                  )
+                                                  command = TextTexTalkNode(
+                                                    type = TexTalkNodeType.Operator
+                                                    tokenType = TexTalkTokenType.Operator
+                                                    text = "+"
+                                                    isVarArg = false
+                                                  )
+                                                  rhs = OperatorTexTalkNode(
+                                                    lhs = TextTexTalkNode(
+                                                      type = TexTalkNodeType.Identifier
+                                                      tokenType = TexTalkTokenType.Identifier
+                                                      text = "2"
+                                                      isVarArg = false
+                                                    )
+                                                    command = TextTexTalkNode(
+                                                      type = TexTalkNodeType.Operator
+                                                      tokenType = TexTalkTokenType.Operator
+                                                      text = "*"
+                                                      isVarArg = false
+                                                    )
+                                                    rhs = OperatorTexTalkNode(
+                                                      lhs = GroupTexTalkNode(
+                                                        type = TexTalkNodeType.ParenGroup
+                                                        parameters = ParametersTexTalkNode(
+                                                          items = [
+                                                                    ExpressionTexTalkNode(
+                                                                      children = [
+                                                                                   OperatorTexTalkNode(
+                                                                                     lhs = TextTexTalkNode(
+                                                                                       type = TexTalkNodeType.Identifier
+                                                                                       tokenType = TexTalkTokenType.Identifier
+                                                                                       text = "x"
+                                                                                       isVarArg = false
+                                                                                     )
+                                                                                     command = TextTexTalkNode(
+                                                                                       type = TexTalkNodeType.Operator
+                                                                                       tokenType = TexTalkTokenType.Operator
+                                                                                       text = "+"
+                                                                                       isVarArg = false
+                                                                                     )
+                                                                                     rhs = TextTexTalkNode(
+                                                                                       type = TexTalkNodeType.Identifier
+                                                                                       tokenType = TexTalkTokenType.Identifier
+                                                                                       text = "y"
+                                                                                       isVarArg = false
+                                                                                     )
+                                                                                   )
+                                                                                 ]
+                                                                    )
+                                                                  ]
+                                                        )
+                                                        isVarArg = false
+                                                      )
+                                                      command = TextTexTalkNode(
+                                                        type = TexTalkNodeType.Operator
+                                                        tokenType = TexTalkTokenType.Caret
+                                                        text = "^"
+                                                        isVarArg = false
+                                                      )
+                                                      rhs = TextTexTalkNode(
+                                                        type = TexTalkNodeType.Identifier
+                                                        tokenType = TexTalkTokenType.Identifier
+                                                        text = "2"
+                                                        isVarArg = false
+                                                      )
+                                                    )
+                                                  )
+                                                )
+                                              ]
+                                 )
+                               ]
+                     )
+                     isVarArg = false
+                   )
                  )
                  command = TextTexTalkNode(
                    type = TexTalkNodeType.Operator

--- a/src/test/resources/goldens/textalk/varargs/handles_varargs_in_identifiers/phase1-structure.txt
+++ b/src/test/resources/goldens/textalk/varargs/handles_varargs_in_identifiers/phase1-structure.txt
@@ -19,55 +19,46 @@ ExpressionTexTalkNode(
                    items = [
                              ExpressionTexTalkNode(
                                children = [
-                                            GroupTexTalkNode(
-                                              type = TexTalkNodeType.SyntheticGroup
-                                              parameters = ParametersTexTalkNode(
-                                                items = [
-                                                          ExpressionTexTalkNode(
-                                                            children = [
-                                                                         TextTexTalkNode(
-                                                                           type = TexTalkNodeType.Identifier
-                                                                           tokenType = TexTalkTokenType.Identifier
-                                                                           text = "f"
-                                                                           isVarArg = false
-                                                                         ),
-                                                                         GroupTexTalkNode(
-                                                                           type = TexTalkNodeType.ParenGroup
-                                                                           parameters = ParametersTexTalkNode(
-                                                                             items = [
-                                                                                       ExpressionTexTalkNode(
-                                                                                         children = [
-                                                                                                      OperatorTexTalkNode(
-                                                                                                        lhs = TextTexTalkNode(
-                                                                                                          type = TexTalkNodeType.Identifier
-                                                                                                          tokenType = TexTalkTokenType.Identifier
-                                                                                                          text = "abc"
-                                                                                                          isVarArg = false
-                                                                                                        )
-                                                                                                        command = TextTexTalkNode(
-                                                                                                          type = TexTalkNodeType.Operator
-                                                                                                          tokenType = TexTalkTokenType.Operator
-                                                                                                          text = "+"
-                                                                                                          isVarArg = false
-                                                                                                        )
-                                                                                                        rhs = TextTexTalkNode(
-                                                                                                          type = TexTalkNodeType.Identifier
-                                                                                                          tokenType = TexTalkTokenType.Identifier
-                                                                                                          text = "x"
-                                                                                                          isVarArg = false
-                                                                                                        )
-                                                                                                      )
-                                                                                                    ]
-                                                                                       )
-                                                                                     ]
-                                                                           )
-                                                                           isVarArg = false
-                                                                         )
-                                                                       ]
-                                                          )
-                                                        ]
+                                            MappingNode(
+                                              name = TextTexTalkNode(
+                                                type = TexTalkNodeType.Identifier
+                                                tokenType = TexTalkTokenType.Identifier
+                                                text = "f"
+                                                isVarArg = false
                                               )
-                                              isVarArg = false
+                                              subGroup = null
+                                              parenGroup = GroupTexTalkNode(
+                                                type = TexTalkNodeType.ParenGroup
+                                                parameters = ParametersTexTalkNode(
+                                                  items = [
+                                                            ExpressionTexTalkNode(
+                                                              children = [
+                                                                           OperatorTexTalkNode(
+                                                                             lhs = TextTexTalkNode(
+                                                                               type = TexTalkNodeType.Identifier
+                                                                               tokenType = TexTalkTokenType.Identifier
+                                                                               text = "abc"
+                                                                               isVarArg = false
+                                                                             )
+                                                                             command = TextTexTalkNode(
+                                                                               type = TexTalkNodeType.Operator
+                                                                               tokenType = TexTalkTokenType.Operator
+                                                                               text = "+"
+                                                                               isVarArg = false
+                                                                             )
+                                                                             rhs = TextTexTalkNode(
+                                                                               type = TexTalkNodeType.Identifier
+                                                                               tokenType = TexTalkTokenType.Identifier
+                                                                               text = "x"
+                                                                               isVarArg = false
+                                                                             )
+                                                                           )
+                                                                         ]
+                                                            )
+                                                          ]
+                                                )
+                                                isVarArg = false
+                                              )
                                             )
                                           ]
                              )


### PR DESCRIPTION
Now identifiers and operators can contain underscores.  For
example, `a_0` or `*_1`.

Note that `a_{i}` is a function invocation using a subparam while
`a_i` is the identifier with name `a_i`.  This is similar to how
`f(i)` is a function call while `fi` is an identifier name.

Specifically, the `{}` in a subparam specifies a function call in
the same way that `()` indicates a function call.
