### PR TITLE
feat: add `existsUnique:` section

### DIFF
--- a/src/main/kotlin/mathlingua/backend/transform/VarUtil.kt
+++ b/src/main/kotlin/mathlingua/backend/transform/VarUtil.kt
@@ -28,6 +28,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.clause.Text
 import mathlingua.frontend.chalktalk.phase2.ast.clause.TupleNode
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.exists.ExistsGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.clause.existsUnique.ExistsUniqueGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.forAll.ForAllGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.given.GivenGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.HasUsingSection
@@ -330,6 +331,21 @@ private fun checkVarsImpl(
         is ExistsGroup -> {
             val existsVars =
                 node.existsSection.identifiers.map { getVars(it, ignoreParen) }.flatten()
+            for (v in existsVars) {
+                if (vars.contains(v)) {
+                    errors.add(
+                        ParseError(
+                            message = "Duplicate defined symbol '$v'",
+                            row = location.row,
+                            column = location.column))
+                }
+                vars.add(v)
+            }
+            varsToRemove.addAll(existsVars)
+        }
+        is ExistsUniqueGroup -> {
+            val existsVars =
+                node.existsUniqueSection.identifiers.map { getVars(it, ignoreParen) }.flatten()
             for (v in existsVars) {
                 if (vars.contains(v)) {
                     errors.add(

--- a/src/main/kotlin/mathlingua/cli/Mathlingua.kt
+++ b/src/main/kotlin/mathlingua/cli/Mathlingua.kt
@@ -701,7 +701,8 @@ private fun generateSignatureToPathJsCode(fs: VirtualFileSystem): String {
     val signatureToPathBuilder = StringBuilder()
     signatureToPathBuilder.append("const sigToPath = new Map();")
     for (entry in signatureToPath.entries) {
-        signatureToPathBuilder.append("sigToPath.set('${entry.key}', '${entry.value}');")
+        signatureToPathBuilder.append(
+            "sigToPath.set('${sanitizeHtmlForJs(entry.key)}', '${sanitizeHtmlForJs(entry.value)}');")
     }
     signatureToPathBuilder.append("return sigToPath;")
     return signatureToPathBuilder.toString()

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
@@ -53,6 +53,8 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.clause.collection.OfSectio
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.exists.ExistsGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.exists.ExistsSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.exists.SuchThatSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.clause.existsUnique.ExistsUniqueGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.clause.existsUnique.ExistsUniqueSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.expands.AsSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.expands.ExpandsGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.expands.ExpandsSection
@@ -407,9 +409,17 @@ val DEFAULT_STATES_SECTION = StatesSection()
 
 val DEFAULT_EXISTS_SECTION = ExistsSection(identifiers = emptyList())
 
+val DEFAULT_EXISTS_UNIQUE_SECTION = ExistsUniqueSection(identifiers = emptyList())
+
 val DEFAULT_EXISTS_GROUP =
     ExistsGroup(
         existsSection = DEFAULT_EXISTS_SECTION,
+        whereSection = null,
+        suchThatSection = DEFAULT_SUCH_THAT_SECTION)
+
+val DEFAULT_EXISTS_UNIQUE_GROUP =
+    ExistsUniqueGroup(
+        existsUniqueSection = DEFAULT_EXISTS_UNIQUE_SECTION,
         whereSection = null,
         suchThatSection = DEFAULT_SUCH_THAT_SECTION)
 
@@ -707,6 +717,7 @@ val DEFAULT_DEFINES_MAPS_GROUP =
         whenSection = DEFAULT_WHEN_SECTION,
         meansSection = DEFAULT_MEANS_SECTION,
         mapsSection = DEFAULT_MAPS_SECTION,
+        satisfyingSection = DEFAULT_SATISFYING_SECTION,
         viewingSection = DEFAULT_VIEWING_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/clause/Clause.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/clause/Clause.kt
@@ -31,6 +31,8 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.clause.collection.isCollec
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.collection.validateCollectionGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.exists.isExistsGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.exists.validateExistsGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.clause.existsUnique.isExistsUniqueGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.clause.existsUnique.validateExistsUniqueGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.expands.isExpandsGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.expands.validateExpandsGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.forAll.isForGroup
@@ -136,6 +138,7 @@ private val CLAUSE_VALIDATORS =
         ValidationPair(::isText, ::validateText),
         ValidationPair(::isForGroup, ::validateForGroup),
         ValidationPair(::isExistsGroup, ::validateExistsGroup),
+        ValidationPair(::isExistsUniqueGroup, ::validateExistsUniqueGroup),
         ValidationPair(::isNotGroup, ::validateNotGroup),
         ValidationPair(::isOrGroup, ::validateOrGroup),
         ValidationPair(::isAndGroup, ::validateAndGroup),

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/clause/existsUnique/ExistsUniqueGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/clause/existsUnique/ExistsUniqueGroup.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.frontend.chalktalk.phase2.ast.group.clause.existsUnique
+
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_EXISTS_UNIQUE_GROUP
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_EXISTS_UNIQUE_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_SUCH_THAT_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.clause.Clause
+import mathlingua.frontend.chalktalk.phase2.ast.clause.firstSectionMatchesName
+import mathlingua.frontend.chalktalk.phase2.ast.common.ThreePartNode
+import mathlingua.frontend.chalktalk.phase2.ast.group.clause.exists.SuchThatSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.clause.exists.validateSuchThatSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.WhereSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.shared.validateWhereSection
+import mathlingua.frontend.chalktalk.phase2.ast.section.ensureNonNull
+import mathlingua.frontend.chalktalk.phase2.ast.section.identifySections
+import mathlingua.frontend.chalktalk.phase2.ast.section.ifNonNull
+import mathlingua.frontend.chalktalk.phase2.ast.track
+import mathlingua.frontend.chalktalk.phase2.ast.validateGroup
+import mathlingua.frontend.support.MutableLocationTracker
+import mathlingua.frontend.support.ParseError
+
+data class ExistsUniqueGroup(
+    val existsUniqueSection: ExistsUniqueSection,
+    val whereSection: WhereSection?,
+    val suchThatSection: SuchThatSection
+) :
+    ThreePartNode<ExistsUniqueSection, WhereSection?, SuchThatSection>(
+        existsUniqueSection, whereSection, suchThatSection, ::ExistsUniqueGroup),
+    Clause
+
+fun isExistsUniqueGroup(node: Phase1Node) = firstSectionMatchesName(node, "existsUnique")
+
+fun validateExistsUniqueGroup(
+    node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
+) =
+    track(node, tracker) {
+        validateGroup(node.resolve(), errors, "existsUnique", DEFAULT_EXISTS_UNIQUE_GROUP) {
+        group ->
+            identifySections(
+                group,
+                errors,
+                DEFAULT_EXISTS_UNIQUE_GROUP,
+                listOf("existsUnique", "where?", "suchThat")) { sections ->
+                ExistsUniqueGroup(
+                    existsUniqueSection =
+                        ensureNonNull(sections["existsUnique"], DEFAULT_EXISTS_UNIQUE_SECTION) {
+                            validateExistsUniqueSection(it, errors, tracker)
+                        },
+                    whereSection =
+                        ifNonNull(sections["where"]) { validateWhereSection(it, errors, tracker) },
+                    suchThatSection =
+                        ensureNonNull(sections["suchThat"], DEFAULT_SUCH_THAT_SECTION) {
+                            validateSuchThatSection(it, errors, tracker)
+                        })
+            }
+        }
+    }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/clause/existsUnique/ExistsUniqueSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/clause/existsUnique/ExistsUniqueSection.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2021
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,47 +14,44 @@
  * limitations under the License.
  */
 
-package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines
+package mathlingua.frontend.chalktalk.phase2.ast.group.clause.existsUnique
 
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
-import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_SATISFYING_SECTION
-import mathlingua.frontend.chalktalk.phase2.ast.clause.ClauseListNode
-import mathlingua.frontend.chalktalk.phase2.ast.clause.Text
-import mathlingua.frontend.chalktalk.phase2.ast.clause.validateClauseListNode
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_EXISTS_UNIQUE_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.clause.Target
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.frontend.chalktalk.phase2.ast.section.appendTargetArgs
 import mathlingua.frontend.chalktalk.phase2.ast.track
-import mathlingua.frontend.chalktalk.phase2.ast.validateSection
+import mathlingua.frontend.chalktalk.phase2.ast.validateTargetSection
 import mathlingua.frontend.support.MutableLocationTracker
 import mathlingua.frontend.support.ParseError
 
-data class SatisfyingSection(val clauses: ClauseListNode) : Phase2Node {
-    override fun forEach(fn: (node: Phase2Node) -> Unit) = clauses.forEach(fn)
+data class ExistsUniqueSection(val identifiers: List<Target>) : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) = identifiers.forEach(fn)
 
     override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
         writer.writeIndent(isArg, indent)
-        writer.writeHeader("satisfying")
-        if (clauses.clauses.size == 1 && clauses.clauses[0] is Text) {
-            writer.append(clauses.clauses.first(), false, 1)
-        } else {
-            if (clauses.clauses.isNotEmpty()) {
-                writer.writeNewline()
-            }
-            writer.append(clauses, true, indent + 2)
-        }
+        writer.writeHeader("existsUnique")
+        appendTargetArgs(writer, identifiers, indent + 2)
         return writer
     }
 
     override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
         chalkTransformer(
-            SatisfyingSection(clauses = clauses.transform(chalkTransformer) as ClauseListNode))
+            ExistsUniqueSection(
+                identifiers = identifiers.map { it.transform(chalkTransformer) as Target }))
 }
 
-fun validateSatisfyingSection(
+fun validateExistsUniqueSection(
     node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
 ) =
     track(node, tracker) {
-        validateSection(node.resolve(), errors, "satisfying", DEFAULT_SATISFYING_SECTION) {
-            SatisfyingSection(clauses = validateClauseListNode(it, errors, tracker))
-        }
+        validateTargetSection(
+            node.resolve(),
+            errors,
+            "existsUnique",
+            DEFAULT_EXISTS_UNIQUE_SECTION,
+            tracker,
+            ::ExistsUniqueSection)
     }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
@@ -56,6 +56,7 @@ data class DefinesMapsGroup(
     override val whenSection: WhenSection?,
     val meansSection: MeansSection?,
     val mapsSection: MapsSection,
+    val satisfyingSection: SatisfyingSection?,
     override val viewingSection: ViewingSection?,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
@@ -75,6 +76,9 @@ data class DefinesMapsGroup(
             fn(meansSection)
         }
         fn(mapsSection)
+        if (satisfyingSection != null) {
+            fn(satisfyingSection)
+        }
         if (viewingSection != null) {
             fn(viewingSection)
         }
@@ -95,6 +99,7 @@ data class DefinesMapsGroup(
                 whenSection,
                 meansSection,
                 mapsSection,
+                satisfyingSection,
                 viewingSection,
                 usingSection,
                 writtenSection,
@@ -113,6 +118,8 @@ data class DefinesMapsGroup(
                 whenSection = whenSection?.transform(chalkTransformer) as WhenSection?,
                 meansSection = meansSection?.transform(chalkTransformer) as MeansSection?,
                 mapsSection = mapsSection.transform(chalkTransformer) as MapsSection,
+                satisfyingSection =
+                    satisfyingSection?.transform(chalkTransformer) as SatisfyingSection?,
                 viewingSection = viewingSection?.transform(chalkTransformer) as ViewingSection?,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
@@ -140,6 +147,7 @@ fun validateDefinesMapsGroup(
                     "when?",
                     "means?",
                     "maps",
+                    "satisfying?",
                     "viewing?",
                     "using?",
                     "written",
@@ -168,6 +176,10 @@ fun validateDefinesMapsGroup(
                         mapsSection =
                             ensureNonNull(sections["maps"], DEFAULT_MAPS_SECTION) {
                                 validateMapsSection(it, errors, tracker)
+                            },
+                        satisfyingSection =
+                            ifNonNull(sections["satisfying"]) {
+                                validateSatisfyingSection(it, errors, tracker)
                             },
                         viewingSection =
                             ifNonNull(sections["viewing"]) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMeansGroup.kt
@@ -168,7 +168,7 @@ fun validateDefinesMeansGroup(
                             },
                         satisfyingSection =
                             ifNonNull(sections["satisfying"]) {
-                                validateSpecifiesSection(it, errors, tracker)
+                                validateSatisfyingSection(it, errors, tracker)
                             },
                         viewingSection =
                             ifNonNull(sections["viewing"]) {

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
@@ -188,6 +188,7 @@ Document(
                    )
                  )
                )
+               satisfyingSection = null
                viewingSection = null
                usingSection = null
                writtenSection = WrittenSection(


### PR DESCRIPTION
Also a bug in rendering has been fixed where some backslashes
where not escaped.  Further, the `Defines:maps:` group has an
optional `satisfying:` section.
