### PR TITLE
fix: make `mathlinguaViewSignature` work

### DIFF
--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
@@ -622,7 +622,7 @@ open class HtmlCodeWriter(
                     "<div class='mathlingua-dropdown-menu-hidden' id='statement-$dropdownIndex'>")
                 for (sig in signatures) {
                     builder.append(
-                        "<a class='mathlingua-dropdown-menu-item' onclick=\"mathlinguaViewSignature('${sig.form}', 'statement-$dropdownIndex')\">")
+                        "<a class='mathlingua-dropdown-menu-item' onclick=\"mathlinguaViewSignature('${sig.form.replace("\\", "\\\\")}', 'statement-$dropdownIndex')\">")
                     builder.append(sig.form)
                     builder.append("</a>")
                 }


### PR DESCRIPTION
The `mathlinguaViewSignature` JavaScript stopped working because
backslash characters were not properly escaped in Kotlin code
generating the Javascript code.
