### PR TITLE
chore: `mlg render` supports filenames with underscores

### DIFF
--- a/src/main/kotlin/mathlingua/cli/Mathlingua.kt
+++ b/src/main/kotlin/mathlingua/cli/Mathlingua.kt
@@ -657,7 +657,9 @@ private fun buildFileList(
             firstFilePath.setValue(src)
         }
         builder.append(
-            "<span $classDesc><a id='$id' $onclick><span $cssDesc><span id='$iconId'>$icon</span>${file.absolutePath().last().removeSuffix(".math")}</span></a></span>")
+            "<span $classDesc><a id='$id' $onclick><span $cssDesc><span id='$iconId'>$icon</span>${
+                file.absolutePath().last().removeSuffix(".math").replace('_', ' ')
+            }</span></a></span>")
         builder.append(childBuilder.toString())
     }
 }


### PR DESCRIPTION
In particular, any underscore in a filename is replaced with a
space.
