### PR TITLE
chore: expansions don't include double parens

### DIFF
--- a/src/main/kotlin/mathlingua/backend/transform/Matcher.kt
+++ b/src/main/kotlin/mathlingua/backend/transform/Matcher.kt
@@ -704,7 +704,10 @@ private fun expandAsWrittenImpl(
 
     return Expansion(
         text =
-            if (addParens && shouldHaveParen(node)) {
+            if (addParens &&
+                shouldHaveParen(node) &&
+                !code.startsWith("(") &&
+                !code.endsWith(")")) {
                 "\\left ( $code \\right )"
             } else {
                 code

--- a/src/main/kotlin/mathlingua/cli/Mathlingua.kt
+++ b/src/main/kotlin/mathlingua/cli/Mathlingua.kt
@@ -1861,10 +1861,12 @@ fun buildIndexHtml(
                             new Mark(document.querySelector('.content'));
                         markInstance.unmark({
                             done: () => {
-                                markInstance.mark(search, {
-                                    caseSensitive: false,
-                                    separateWordSearch: true
-                                });
+                                if (search.length > 0) {
+                                    markInstance.mark(search, {
+                                        caseSensitive: false,
+                                        separateWordSearch: true
+                                    });
+                                }
                             }
                         });
                     }


### PR DESCRIPTION
Previously, double parens could appear when using `??` in
expansions.
