### PR TITLE
feat: `Defines` and `States` have `called` section

### DIFF
--- a/src/main/kotlin/mathlingua/cli/Mathlingua.kt
+++ b/src/main/kotlin/mathlingua/cli/Mathlingua.kt
@@ -1559,6 +1559,15 @@ const val SHARED_CSS =
         font-style: italic;
     }
 
+    .mathlingua-called {
+        font-weight: bold;
+        display: table;
+        margin-top: -1em;
+        margin-left: auto;
+        margin-bottom: -1ex;
+        margin-right: auto;
+    }
+
     .display-mode {
         margin-left: auto;
         margin-right: auto;

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/CodeWriter.kt
@@ -203,6 +203,20 @@ open class HtmlCodeWriter(
         return builder.toString()
     }
 
+    private fun capitalizeWords(text: String): String {
+        val calledWords = mutableListOf<String>()
+        val words = text.split(" ")
+        for (i in words.indices) {
+            val word = words[i]
+            if (i > 0 && (word == "a" || word == "an" || word == "the")) {
+                calledWords.add(word)
+            } else {
+                calledWords.add(word.capitalize())
+            }
+        }
+        return calledWords.joinToString(" ")
+    }
+
     override fun generateCode(node: Phase2Node): String {
         if (literal) {
             return node.toCode(false, 0, this).getCode()
@@ -220,9 +234,32 @@ open class HtmlCodeWriter(
                 }
                 builder.toString()
             }
+            is StatesGroup -> {
+                val builder = StringBuilder()
+                builder.append("<span class='mathlingua-data'>")
+                builder.append("<span class='mathlingua-called'>")
+                val called =
+                    capitalizeWords(node.calledSection.forms.first().removeSurrounding("\"", "\""))
+                builder.append(parseMarkdown(called))
+                builder.append("</span>")
+                builder.append(
+                    node.copy(metaDataSection = null)
+                        .toCode(false, 0, writer = newCodeWriter(defines, states, foundations))
+                        .getCode())
+                builder.append("</span>")
+                if (node.metaDataSection != null) {
+                    builder.append(generateMetaDataSectionCode(node.metaDataSection!!))
+                }
+                builder.toString()
+            }
             is DefinesGroup -> {
                 val builder = StringBuilder()
                 builder.append("<span class='mathlingua-data'>")
+                builder.append("<span class='mathlingua-called'>")
+                val called =
+                    capitalizeWords(node.calledSection.forms.first().removeSurrounding("\"", "\""))
+                builder.append(parseMarkdown(called))
+                builder.append("</span>")
                 builder.append(
                     node.copyWithoutMetadata()
                         .toCode(false, 0, writer = newCodeWriter(defines, states, foundations))

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/Validation.kt
@@ -81,6 +81,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.group.clause.or.OrGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.or.OrSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.piecewise.PiecewiseGroup
 import mathlingua.frontend.chalktalk.phase2.ast.group.clause.piecewise.PiecewiseSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.CalledSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.CollectsSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.defines.DefinesCollectsGroup
@@ -435,6 +436,8 @@ val DEFAULT_EVALUATES_SECTION = EvaluatesSection()
 
 val DEFAULT_WRITTEN_SECTION = WrittenSection(forms = emptyList())
 
+val DEFAULT_CALLED_SECTION = CalledSection(forms = emptyList())
+
 val DEFAULT_META_DATA_SECTION = MetaDataSection(items = emptyList())
 
 val DEFAULT_COLLECTION_GROUP =
@@ -496,6 +499,7 @@ val DEFAULT_STATES_GROUP =
         thatSection = DEFAULT_THAT_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
+        calledSection = DEFAULT_CALLED_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)
 
 val DEFAULT_ENTRY_SECTION = TopicSection(names = emptyList())
@@ -678,6 +682,7 @@ val DEFAULT_DEFINES_MEANS_GROUP =
         meansSection = DEFAULT_MEANS_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
+        calledSection = DEFAULT_CALLED_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)
 
 val DEFAULT_DEFINES_EVALUATED_GROUP =
@@ -692,6 +697,7 @@ val DEFAULT_DEFINES_EVALUATED_GROUP =
         viewingSection = DEFAULT_VIEWING_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
+        calledSection = DEFAULT_CALLED_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)
 
 val DEFAULT_DEFINES_COLLECTS_GROUP =
@@ -706,6 +712,7 @@ val DEFAULT_DEFINES_COLLECTS_GROUP =
         viewingSection = DEFAULT_VIEWING_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
+        calledSection = DEFAULT_CALLED_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)
 
 val DEFAULT_DEFINES_MAPS_GROUP =
@@ -721,6 +728,7 @@ val DEFAULT_DEFINES_MAPS_GROUP =
         viewingSection = DEFAULT_VIEWING_SECTION,
         usingSection = DEFAULT_USING_SECTION,
         writtenSection = DEFAULT_WRITTEN_SECTION,
+        calledSection = DEFAULT_CALLED_SECTION,
         metaDataSection = DEFAULT_META_DATA_SECTION)
 
 val DEFAULT_FOUNDATION_SECTION = FoundationSection(content = DEFAULT_DEFINES_MEANS_GROUP)

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/CalledSection.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/CalledSection.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike
+
+import mathlingua.frontend.chalktalk.phase1.ast.ChalkTalkTokenType
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
+import mathlingua.frontend.chalktalk.phase1.ast.Phase1Token
+import mathlingua.frontend.chalktalk.phase1.ast.Section
+import mathlingua.frontend.chalktalk.phase1.ast.getColumn
+import mathlingua.frontend.chalktalk.phase1.ast.getRow
+import mathlingua.frontend.chalktalk.phase2.CodeWriter
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_CALLED_SECTION
+import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
+import mathlingua.frontend.chalktalk.phase2.ast.track
+import mathlingua.frontend.chalktalk.phase2.ast.validateSection
+import mathlingua.frontend.support.MutableLocationTracker
+import mathlingua.frontend.support.ParseError
+
+data class CalledSection(val forms: List<String>) : Phase2Node {
+    override fun forEach(fn: (node: Phase2Node) -> Unit) {}
+
+    override fun toCode(isArg: Boolean, indent: Int, writer: CodeWriter): CodeWriter {
+        writer.writeIndent(isArg, indent)
+        writer.writeHeader("called")
+        for (imp in forms) {
+            writer.writeNewline()
+            writer.writeIndent(true, indent + 2)
+            writer.writeText(imp)
+        }
+        return writer
+    }
+
+    override fun transform(chalkTransformer: (node: Phase2Node) -> Phase2Node) =
+        chalkTransformer(this)
+}
+
+fun isCalledSection(sec: Section) = sec.name.text == "written"
+
+fun validateCalledSection(
+    node: Phase1Node, errors: MutableList<ParseError>, tracker: MutableLocationTracker
+) =
+    track(node, tracker) {
+        validateSection(node.resolve(), errors, "called", DEFAULT_CALLED_SECTION) { section ->
+            if (section.args.isEmpty() ||
+                !section.args.all {
+                    it.chalkTalkTarget is Phase1Token &&
+                        it.chalkTalkTarget.type == ChalkTalkTokenType.String
+                }) {
+                errors.add(
+                    ParseError(
+                        message = "Expected a list of strings",
+                        row = getRow(section),
+                        column = getColumn(section)))
+                DEFAULT_CALLED_SECTION
+            } else {
+                CalledSection(forms = section.args.map { (it.chalkTalkTarget as Phase1Token).text })
+            }
+        }
+    }

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesCollectsGroup.kt
@@ -20,6 +20,7 @@ import mathlingua.backend.transform.Signature
 import mathlingua.backend.transform.signature
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_CALLED_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_COLLECTS_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_DEFINES_COLLECTS_GROUP
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_DEFINES_SECTION
@@ -29,7 +30,9 @@ import mathlingua.frontend.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.frontend.chalktalk.phase2.ast.clause.sectionsMatchNames
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getId
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.CalledSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateCalledSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.validateViewingSection
@@ -59,6 +62,7 @@ data class DefinesCollectsGroup(
     override val viewingSection: ViewingSection?,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
+    override val calledSection: CalledSection,
     override val metaDataSection: MetaDataSection?
 ) : DefinesGroup(metaDataSection) {
 
@@ -82,6 +86,7 @@ data class DefinesCollectsGroup(
             fn(usingSection)
         }
         fn(writtenSection)
+        fn(calledSection)
         if (metaDataSection != null) {
             fn(metaDataSection)
         }
@@ -98,6 +103,7 @@ data class DefinesCollectsGroup(
                 viewingSection,
                 usingSection,
                 writtenSection,
+                calledSection,
                 metaDataSection)
         return topLevelToCode(writer, isArg, indent, id, *sections.toTypedArray())
     }
@@ -116,6 +122,7 @@ data class DefinesCollectsGroup(
                 viewingSection = viewingSection?.transform(chalkTransformer) as ViewingSection?,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
+                calledSection = calledSection.transform(chalkTransformer) as CalledSection,
                 metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?))
 
     override fun copyWithoutMetadata(): DefinesGroup {
@@ -143,6 +150,7 @@ fun validateDefinesCollectsGroup(
                     "viewing?",
                     "using?",
                     "written",
+                    "called",
                     "Metadata?")) { sections ->
                 val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
                 val def =
@@ -180,6 +188,10 @@ fun validateDefinesCollectsGroup(
                         writtenSection =
                             ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
                                 validateWrittenSection(it, errors, tracker)
+                            },
+                        calledSection =
+                            ensureNonNull(sections["called"], DEFAULT_CALLED_SECTION) {
+                                validateCalledSection(it, errors, tracker)
                             },
                         metaDataSection =
                             ifNonNull(sections["Metadata"]) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesEvaluatedGroup.kt
@@ -20,6 +20,7 @@ import mathlingua.backend.transform.Signature
 import mathlingua.backend.transform.signature
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_CALLED_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_DEFINES_EVALUATED_GROUP
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_DEFINES_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_EVALUATED_SECTION
@@ -29,7 +30,9 @@ import mathlingua.frontend.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.frontend.chalktalk.phase2.ast.clause.sectionsMatchNames
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getId
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.CalledSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateCalledSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.validateViewingSection
@@ -59,6 +62,7 @@ data class DefinesEvaluatedGroup(
     override val viewingSection: ViewingSection?,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
+    override val calledSection: CalledSection,
     override val metaDataSection: MetaDataSection?
 ) : DefinesGroup(metaDataSection) {
 
@@ -82,6 +86,7 @@ data class DefinesEvaluatedGroup(
             fn(usingSection)
         }
         fn(writtenSection)
+        fn(calledSection)
         if (metaDataSection != null) {
             fn(metaDataSection)
         }
@@ -98,6 +103,7 @@ data class DefinesEvaluatedGroup(
                 viewingSection,
                 usingSection,
                 writtenSection,
+                calledSection,
                 metaDataSection)
         return topLevelToCode(writer, isArg, indent, id, *sections.toTypedArray())
     }
@@ -116,6 +122,7 @@ data class DefinesEvaluatedGroup(
                 viewingSection = viewingSection?.transform(chalkTransformer) as ViewingSection?,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
+                calledSection = calledSection.transform(chalkTransformer) as CalledSection,
                 metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?))
 
     override fun copyWithoutMetadata(): DefinesGroup {
@@ -143,6 +150,7 @@ fun validateDefinesEvaluatedGroup(
                     "viewing?",
                     "using?",
                     "written",
+                    "called",
                     "Metadata?")) { sections ->
                 val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
                 val def =
@@ -180,6 +188,10 @@ fun validateDefinesEvaluatedGroup(
                         writtenSection =
                             ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
                                 validateWrittenSection(it, errors, tracker)
+                            },
+                        calledSection =
+                            ensureNonNull(sections["called"], DEFAULT_CALLED_SECTION) {
+                                validateCalledSection(it, errors, tracker)
                             },
                         metaDataSection =
                             ifNonNull(sections["Metadata"]) {

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesGroup.kt
@@ -23,6 +23,7 @@ import mathlingua.frontend.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.frontend.chalktalk.phase2.ast.clause.firstSectionMatchesName
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.HasUsingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.TopLevelGroup
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.CalledSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.foundation.DefinesStatesOrViews
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
@@ -47,6 +48,7 @@ abstract class DefinesGroup(override val metaDataSection: MetaDataSection?) :
     abstract val whenSection: WhenSection?
     abstract val viewingSection: ViewingSection?
     abstract val writtenSection: WrittenSection
+    abstract val calledSection: CalledSection
     abstract fun copyWithoutMetadata(): DefinesGroup
 }
 

--- a/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
+++ b/src/main/kotlin/mathlingua/frontend/chalktalk/phase2/ast/group/toplevel/defineslike/defines/DefinesMapsGroup.kt
@@ -20,6 +20,7 @@ import mathlingua.backend.transform.Signature
 import mathlingua.backend.transform.signature
 import mathlingua.frontend.chalktalk.phase1.ast.Phase1Node
 import mathlingua.frontend.chalktalk.phase2.CodeWriter
+import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_CALLED_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_DEFINES_MAPS_GROUP
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_DEFINES_SECTION
 import mathlingua.frontend.chalktalk.phase2.ast.DEFAULT_ID_STATEMENT
@@ -29,7 +30,9 @@ import mathlingua.frontend.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.frontend.chalktalk.phase2.ast.clause.sectionsMatchNames
 import mathlingua.frontend.chalktalk.phase2.ast.common.Phase2Node
 import mathlingua.frontend.chalktalk.phase2.ast.getId
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.CalledSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.WrittenSection
+import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateCalledSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.validateWrittenSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.ViewingSection
 import mathlingua.frontend.chalktalk.phase2.ast.group.toplevel.defineslike.viewing.validateViewingSection
@@ -60,6 +63,7 @@ data class DefinesMapsGroup(
     override val viewingSection: ViewingSection?,
     override val usingSection: UsingSection?,
     override val writtenSection: WrittenSection,
+    override val calledSection: CalledSection,
     override val metaDataSection: MetaDataSection?
 ) : DefinesGroup(metaDataSection) {
 
@@ -86,6 +90,7 @@ data class DefinesMapsGroup(
             fn(usingSection)
         }
         fn(writtenSection)
+        fn(calledSection)
         if (metaDataSection != null) {
             fn(metaDataSection)
         }
@@ -103,6 +108,7 @@ data class DefinesMapsGroup(
                 viewingSection,
                 usingSection,
                 writtenSection,
+                calledSection,
                 metaDataSection)
         return topLevelToCode(writer, isArg, indent, id, *sections.toTypedArray())
     }
@@ -123,6 +129,7 @@ data class DefinesMapsGroup(
                 viewingSection = viewingSection?.transform(chalkTransformer) as ViewingSection?,
                 usingSection = usingSection?.transform(chalkTransformer) as UsingSection?,
                 writtenSection = writtenSection.transform(chalkTransformer) as WrittenSection,
+                calledSection = calledSection.transform(chalkTransformer) as CalledSection,
                 metaDataSection = metaDataSection?.transform(chalkTransformer) as MetaDataSection?))
 
     override fun copyWithoutMetadata(): DefinesGroup {
@@ -151,6 +158,7 @@ fun validateDefinesMapsGroup(
                     "viewing?",
                     "using?",
                     "written",
+                    "called",
                     "Metadata?")) { sections ->
                 val id = getId(group, errors, DEFAULT_ID_STATEMENT, tracker)
                 val def =
@@ -192,6 +200,10 @@ fun validateDefinesMapsGroup(
                         writtenSection =
                             ensureNonNull(sections["written"], DEFAULT_WRITTEN_SECTION) {
                                 validateWrittenSection(it, errors, tracker)
+                            },
+                        calledSection =
+                            ensureNonNull(sections["called"], DEFAULT_CALLED_SECTION) {
+                                validateCalledSection(it, errors, tracker)
                             },
                         metaDataSection =
                             ifNonNull(sections["Metadata"]) {

--- a/src/test/kotlin/mathlingua/MathLinguaTest.kt
+++ b/src/test/kotlin/mathlingua/MathLinguaTest.kt
@@ -130,18 +130,23 @@ internal class MathLinguaTest {
             means: 'X is \something'
             satisfying: '\something'
             written: "something"
+            called: "finite set"
+
 
             [\infinite.set]
             Defines: X
             means: 'X is \something'
             satisfying: '\something.else'
             written: "something"
+            called: "infinite set"
+
 
             [\finite.set]
             Defines: Y
             means: 'X is \something'
             satisfying: '\yet.something.else'
             written: "something"
+            called: "finite set"
         """.trimIndent(),
                 """
             [\set]
@@ -151,6 +156,7 @@ internal class MathLinguaTest {
             . if: X
               then: '\something.else'
             written: "something"
+            called: "set"
         """.trimIndent(),
                 """
             Theorem:
@@ -162,7 +168,7 @@ internal class MathLinguaTest {
         val dups = sourceCollection.getDuplicateDefinedSignatures().map { it.value }
         assertThat(dups)
             .isEqualTo(
-                listOf(Signature(form = "\\finite.set", location = Location(row = 12, column = 0))))
+                listOf(Signature(form = "\\finite.set", location = Location(row = 16, column = 0))))
     }
 
     @Test
@@ -275,12 +281,15 @@ internal class MathLinguaTest {
             means: 'X is \something'
             satisfying: '\something'
             written: "something"
+            called: "finite set"
+
 
             [\infinite.set]
             Defines: X
             means: 'X is \something'
             satisfying: '\something.else'
             written: "something"
+            called: "infinite set"
         """.trimIndent(),
                 """
             [\set]
@@ -290,6 +299,8 @@ internal class MathLinguaTest {
             . if: X
               then: '\something.else'
             written: "something"
+            called: "set"
+
 
             Theorem:
             then:
@@ -323,12 +334,15 @@ internal class MathLinguaTest {
             means: 'X is \something'
             satisfying: '\something'
             written: "something"
+            called: "finite set"
+
 
             [\infinite.set]
             Defines: X
             means: 'X is \something'
             satisfying: '\something.else'
             written: "something"
+            called: "infinite set"
         """.trimIndent(),
                 """
             [\set]
@@ -338,6 +352,7 @@ internal class MathLinguaTest {
             . if: X
               then: '\something.else'
             written: "something"
+            called: "set"
         """.trimIndent(),
                 """
             Theorem:
@@ -349,6 +364,7 @@ internal class MathLinguaTest {
             means: 'X is \something'
             satisfying: '\yet.something.else'
             written: "something"
+            called: "set"
         """.trimIndent())
 
         val collection = newSourceCollectionFromContent(input)
@@ -366,6 +382,7 @@ internal class MathLinguaTest {
             States:
             that: "something"
             written: "a? \text{ or } b?"
+            called: "something"
         """.trimIndent())
         assertThat(validation is ValidationSuccess)
         val doc = (validation as ValidationSuccess).value

--- a/src/test/kotlin/mathlingua/backend/transform/SignatureUtilKtTest.kt
+++ b/src/test/kotlin/mathlingua/backend/transform/SignatureUtilKtTest.kt
@@ -33,7 +33,7 @@ internal class SignatureUtilKtTest {
     fun findAllStatementSignaturesNonGluedTest() {
         val validation =
             FrontEnd.parse(
-                "[\\xyz{x}]\nDefines: y\nmeans: 'something'\nsatisfying: 'something'\nwritten: \"something\"")
+                "[\\xyz{x}]\nDefines: y\nmeans: 'something'\nsatisfying: 'something'\nwritten: \"something\"\ncalled: \"something\"")
         val doc = (validation as ValidationSuccess).value
         val defines = doc.defines()
         assertThat(defines.size).isEqualTo(1)
@@ -50,7 +50,7 @@ internal class SignatureUtilKtTest {
         val validation =
             FrontEnd.parse(
                 "[\\abc \\xyz{x}]\nDefines: y\nmeans: 'something'\nsatisfying: 'something'\n" +
-                    "written: \"something\"")
+                    "written: \"something\"\ncalled: \"something\"")
         assertThat(validation is ValidationFailure)
         assertThat((validation as ValidationFailure).errors)
             .isEqualTo(
@@ -66,7 +66,7 @@ internal class SignatureUtilKtTest {
         val validation =
             FrontEnd.parse(
                 "[x \\abc/ y]\nDefines: y\nmeans: 'something'\nsatisfying: 'something'\n" +
-                    "written: \"something\"")
+                    "written: \"something\"\ncalled: \"something\"")
         val doc = (validation as ValidationSuccess).value
         val defines = doc.defines()
         assertThat(defines.size).isEqualTo(1)

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/input.math
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/input.math
@@ -3,3 +3,4 @@ Defines: X...#x...
 means: 'X is \something'
 satisfying: "something for X...#x..."
 written: "something"
+called: "something"

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-output.math
@@ -7,3 +7,5 @@ satisfying:
 . "something for X...#x..."
 written:
 . "something"
+called:
+. "something"

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase1-structure.txt
@@ -85,6 +85,24 @@ Root(
                                          )
                                        )
                                      ]
+                            ),
+                            Section(
+                              name = Phase1Token(
+                                text = "called"
+                                type = ChalkTalkTokenType.Name
+                                row = 5
+                                column = 0
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Phase1Token(
+                                           text = ""something""
+                                           type = ChalkTalkTokenType.String
+                                           row = 5
+                                           column = 8
+                                         )
+                                       )
+                                     ]
                             )
                           ]
                id = Phase1Token(

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-output.math
@@ -4,3 +4,5 @@ means: 'X is \something'
 satisfying: "something for X...#x..."
 written:
 . "something"
+called:
+. "something"

--- a/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/args/handle_varargs_with_defined_length/phase2-structure.txt
@@ -156,6 +156,11 @@ Document(
                            ""something""
                          ]
                )
+               calledSection = CalledSection(
+                 forms = [
+                           ""something""
+                         ]
+               )
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/input.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/input.math
@@ -7,3 +7,4 @@ collects:
   all: '2*k'
   suchThat: 'k > 10'
 written: "\textrm{evens}"
+called: "evens"

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-output.math
@@ -14,3 +14,5 @@ collects:
   . 'k > 10'
 written:
 . "\textrm{evens}"
+called:
+. "evens"

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase1-structure.txt
@@ -168,6 +168,24 @@ Root(
                                          )
                                        )
                                      ]
+                            ),
+                            Section(
+                              name = Phase1Token(
+                                text = "called"
+                                type = ChalkTalkTokenType.Name
+                                row = 9
+                                column = 0
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Phase1Token(
+                                           text = ""evens""
+                                           type = ChalkTalkTokenType.String
+                                           row = 9
+                                           column = 8
+                                         )
+                                       )
+                                     ]
                             )
                           ]
                id = Phase1Token(

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-output.math
@@ -10,3 +10,5 @@ collects:
   . 'k > 10'
 written:
 . "\textrm{evens}"
+called:
+. "evens"

--- a/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_collection_groups/phase2-structure.txt
@@ -282,6 +282,11 @@ Document(
                            ""\textrm{evens}""
                          ]
                )
+               calledSection = CalledSection(
+                 forms = [
+                           ""evens""
+                         ]
+               )
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/input.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/input.math
@@ -5,3 +5,4 @@ maps:
 . from: 'A'
   to: 'A'
 written: "f(x?)"
+called: "f"

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-output.math
@@ -10,3 +10,5 @@ maps:
   . 'A'
 written:
 . "f(x?)"
+called:
+. "f"

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase1-structure.txt
@@ -127,6 +127,24 @@ Root(
                                          )
                                        )
                                      ]
+                            ),
+                            Section(
+                              name = Phase1Token(
+                                text = "called"
+                                type = ChalkTalkTokenType.Name
+                                row = 7
+                                column = 0
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Phase1Token(
+                                           text = ""f""
+                                           type = ChalkTalkTokenType.String
+                                           row = 7
+                                           column = 8
+                                         )
+                                       )
+                                     ]
                             )
                           ]
                id = Phase1Token(

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-output.math
@@ -6,3 +6,5 @@ maps:
   to: 'A'
 written:
 . "f(x?)"
+called:
+. "f"

--- a/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/groups/parses_mapping_groups/phase2-structure.txt
@@ -196,6 +196,11 @@ Document(
                            ""f(x?)""
                          ]
                )
+               calledSection = CalledSection(
+                 forms = [
+                           ""f""
+                         ]
+               )
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/input.math
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/input.math
@@ -3,3 +3,4 @@ Defines: B
 means: 'B is \something'
 satisfying: "C"
 written: "something"
+called: "A?"

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-output.math
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-output.math
@@ -7,3 +7,5 @@ satisfying:
 . "C"
 written:
 . "something"
+called:
+. "A?"

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-structure.txt
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase1-structure.txt
@@ -85,6 +85,24 @@ Root(
                                          )
                                        )
                                      ]
+                            ),
+                            Section(
+                              name = Phase1Token(
+                                text = "called"
+                                type = ChalkTalkTokenType.Name
+                                row = 5
+                                column = 0
+                              )
+                              args = [
+                                       Argument(
+                                         chalkTalkTarget = Phase1Token(
+                                           text = ""A?""
+                                           type = ChalkTalkTokenType.String
+                                           row = 5
+                                           column = 8
+                                         )
+                                       )
+                                     ]
                             )
                           ]
                id = Phase1Token(

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-output.math
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-output.math
@@ -4,3 +4,5 @@ means: 'B is \something'
 satisfying: "C"
 written:
 . "something"
+called:
+. "A?"

--- a/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-structure.txt
+++ b/src/test/resources/goldens/chalktalk/text/parses_text_elements/phase2-structure.txt
@@ -118,6 +118,11 @@ Document(
                            ""something""
                          ]
                )
+               calledSection = CalledSection(
+                 forms = [
+                           ""A?""
+                         ]
+               )
                metaDataSection = null
              )
            ]

--- a/src/test/resources/goldens/messages/defines/Defines_assuming_spelled_wrong/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_assuming_spelled_wrong/messages.txt
@@ -11,6 +11,7 @@ satisfying?:
 viewing?:
 using?:
 written:
+called:
 Metadata?:
 
 Expected 'means' but found 'assumes'

--- a/src/test/resources/goldens/messages/defines/Defines_id_paren_must_match_target/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_id_paren_must_match_target/messages.txt
@@ -11,6 +11,7 @@ satisfying?:
 viewing?:
 using?:
 written:
+called:
 Metadata?:
 
 Expected a written
@@ -30,6 +31,7 @@ satisfying?:
 viewing?:
 using?:
 written:
+called:
 Metadata?:
 
 Expected a written
@@ -49,6 +51,7 @@ satisfying?:
 viewing?:
 using?:
 written:
+called:
 Metadata?:
 
 Expected a written
@@ -68,6 +71,7 @@ satisfying?:
 viewing?:
 using?:
 written:
+called:
 Metadata?:
 
 Expected a written
@@ -87,6 +91,7 @@ satisfying?:
 viewing?:
 using?:
 written:
+called:
 Metadata?:
 
 Expected a written
@@ -106,6 +111,7 @@ satisfying?:
 viewing?:
 using?:
 written:
+called:
 Metadata?:
 
 Expected a written

--- a/src/test/resources/goldens/messages/defines/Defines_must_have_id/messages.txt
+++ b/src/test/resources/goldens/messages/defines/Defines_must_have_id/messages.txt
@@ -11,6 +11,7 @@ satisfying?:
 viewing?:
 using?:
 written:
+called:
 Metadata?:
 
 Expected a written

--- a/src/test/resources/goldens/messages/states/States_without_id/input.math
+++ b/src/test/resources/goldens/messages/states/States_without_id/input.math
@@ -1,2 +1,4 @@
 States:
 that: x
+written: "something"
+states: "something"

--- a/src/test/resources/goldens/messages/states/States_without_id/messages.txt
+++ b/src/test/resources/goldens/messages/states/States_without_id/messages.txt
@@ -1,5 +1,16 @@
-Row: 0
+Row: 3
 Column: 0
 Message:
-Expected an Id
+For pattern:
+
+States:
+requiring?:
+when?:
+that:
+using?:
+written:
+called:
+Metadata?:
+
+Expected 'called' but found 'states'
 EndMessage:

--- a/src/test/resources/mathlingua.math
+++ b/src/test/resources/mathlingua.math
@@ -5,6 +5,7 @@ when: 'A is \something.else'
 means: 'X is \something.else'
 satisfying: 'X is \some.other.thing'
 written: "\textrm{something} A?"
+called: "something"
 
 
 [\something2{A}]
@@ -12,6 +13,7 @@ Defines: X
 when: 'A is \something.else'
 means: 'X is \some.other.thing'
 written: "\textrm{something} A?"
+called: "something2"
 
 
 [\some.function{A}(x)]
@@ -22,6 +24,7 @@ maps:
 . from: '\reals'
   to: '\reals'
 written: "\textrm{some.function}(x?)"
+called: "some function over $A?$"
 
 
 [\some.function2{A}(x)]
@@ -31,6 +34,7 @@ maps:
 . from: '\reals'
   to: '\reals'
 written: "\textrm{some.function}(x?)"
+called: "some function2 over $A?$"
 
 
 [\even.primes]
@@ -42,6 +46,7 @@ collects:
   all: 'p'
   suchThat: 'p is \even'
 written: "\textbf{even primes}"
+called: "even primes"
 
 
 [\even.primes2]
@@ -52,6 +57,7 @@ collects:
   all: 'p'
   suchThat: 'p is \even'
 written: "\textbf{even primes}"
+called: "even primes2"
 
 
 [\f1(x)]
@@ -59,12 +65,14 @@ Defines: f(x)
 means: 'f is \function'
 evaluated: 'f(x) := x + 1'
 written: "f1(x?)"
+called: "f1"
 
 
 [\f12(x)]
 Defines: f(x)
 evaluated: 'f(x) := x + 1'
 written: "f1(x?)"
+called: "f12"
 
 
 [\f3(x)]
@@ -78,6 +86,7 @@ evaluated:
   then: 'f(x) := -1'
   else: 'f(x) := 0'
 written: "f3(x?)"
+called: "f3"
 
 
 [\f32(x)]
@@ -90,6 +99,7 @@ evaluated:
   then: 'f(x) := -1'
   else: 'f(x) := 0'
 written: "f3(x?)"
+called: "f32"
 
 
 [\semigroup]
@@ -107,12 +117,15 @@ viewing:
 . membership:
   through: 'X'
 written: "\textrm{semigroup}"
+called: "semigroup"
 
 
 [\some.thing{A}:on{B}:to{C}]
 States:
 when: 'A, B, C is \something'
 that: 'A + B - C is \something'
+written: "something"
+called: "something"
 
 
 Foundation:
@@ -121,6 +134,7 @@ Foundation:
   means: 'X is \something'
   satisfying: 'X is \something.else'
   written: "X?"
+  called: "X?"
 
 
 Foundation:
@@ -133,6 +147,7 @@ Foundation:
     all: 'x'
     suchThat: 'x'
   written: "X"
+  called: "X?"
 
 
 [x + y]


### PR DESCRIPTION
The `called:` section is used to specify what a definition or
statement is called.  For example, "continuous function on $A?$
to $B?$".
