### PR TITLE
feat: support commands in `using:` sections

### DIFF
--- a/src/main/kotlin/mathlingua/backend/transform/Matcher.kt
+++ b/src/main/kotlin/mathlingua/backend/transform/Matcher.kt
@@ -20,6 +20,7 @@ import kotlin.math.max
 import mathlingua.frontend.chalktalk.phase2.ast.clause.IdStatement
 import mathlingua.frontend.support.Location
 import mathlingua.frontend.support.MutableLocationTracker
+import mathlingua.frontend.textalk.ColonEqualsTexTalkNode
 import mathlingua.frontend.textalk.Command
 import mathlingua.frontend.textalk.CommandPart
 import mathlingua.frontend.textalk.ExpressionTexTalkNode
@@ -697,6 +698,12 @@ private fun expandAsWrittenImpl(
                     val result = expandAsWrittenImplImpl(it, sigToPatternExpansion)
                     errors.addAll(result.errors)
                     result.text
+                }
+                is ColonEqualsTexTalkNode -> {
+                    val lhsText = it.lhs.toCode()
+                    val rhsResult = expandAsWrittenImpl(it.rhs, sigToPatternExpansion, addParens)
+                    errors.addAll(rhsResult.errors)
+                    "$lhsText := ${rhsResult.text}"
                 }
                 else -> null
             }


### PR DESCRIPTION
Previously a `using:` section could only have aliases such as
```
using:
. 'f(x) := ...'
. 'x + y := ...'
```
Now the following are supported:
```
using:
. '\f(x) := ...'
. 'x \op/ y := ...'
```
Note that if an alias uses `f(x)`, the usage of that alias will be
rendered as `f(x)` while if it uses `\f(x)`, then the usage will
be rendered as the righ-hand-side of the alias.
