### PR TITLE
fix: improve CSS for editor

### DIFF
--- a/src/main/webapp/src/App.module.css
+++ b/src/main/webapp/src/App.module.css
@@ -1,3 +1,7 @@
 .contentPanel {
-  padding-top: 1em;
+  /* padding-top: 1em; */
+  padding: 0;
+  margin: 0;
+  height: 95vh;
+  width: 100vw;
 }

--- a/src/main/webapp/src/App.tsx
+++ b/src/main/webapp/src/App.tsx
@@ -9,14 +9,12 @@ import { ContentPanel } from './components/content-panel/ContentPanel';
 export const App = () => {
   return (
     <HashRouter hashType="slash">
-      <ErrorBoundary>
-        <TopBar />
-        <div className={styles.contentPanel}>
-          <Switch>
-            <Route path="/:relativePath(.*)" children={<ContentPanel />} />
-          </Switch>
-        </div>
-      </ErrorBoundary>
+      <TopBar />
+      <div className={styles.contentPanel}>
+        <Switch>
+          <Route path="/:relativePath(.*)" children={<ContentPanel />} />
+        </Switch>
+      </div>
     </HashRouter>
   );
 };

--- a/src/main/webapp/src/components/content-panel/ContentPanel.module.css
+++ b/src/main/webapp/src/components/content-panel/ContentPanel.module.css
@@ -1,7 +1,7 @@
 .content {
   padding: 0;
   margin: 0;
-  margin-top: 4vh;
+  margin-top: 5vh;
   height: 95vh;
   width: 100vw;
 }

--- a/src/main/webapp/src/components/content-panel/ContentPanel.module.css
+++ b/src/main/webapp/src/components/content-panel/ContentPanel.module.css
@@ -1,4 +1,7 @@
-.contentPanel {
+.content {
   padding: 0;
   margin: 0;
+  margin-top: 4vh;
+  height: 95vh;
+  width: 100vw;
 }

--- a/src/main/webapp/src/components/content-panel/ContentPanel.tsx
+++ b/src/main/webapp/src/components/content-panel/ContentPanel.tsx
@@ -21,7 +21,7 @@ function getHashLocation(location: {
 export const ContentPanel = () => {
   const hashLocation = getHashLocation(useLocation());
   return (
-    <div className={styles.contentPane}>
+    <div className={styles.content}>
       <SidePanel viewedPath={hashLocation.viewedPath} />
       <Page
         viewedPath={hashLocation.viewedPath}

--- a/src/main/webapp/src/components/edit-mode-button/EditModeButton.tsx
+++ b/src/main/webapp/src/components/edit-mode-button/EditModeButton.tsx
@@ -21,16 +21,8 @@ export const EditModeButton = () => {
         const newEditMode = !isEditMode;
         if (newEditMode) {
           document.body.style.position = 'fixed';
-          document.body.style.padding = '0';
-          document.body.style.margin = '0';
-          document.body.style.height = '100%';
-          document.body.style.width = '100%';
         } else {
           document.body.style.position = 'unset';
-          document.body.style.padding = 'unset';
-          document.body.style.margin = 'unset';
-          document.body.style.height = 'unset';
-          document.body.style.width = 'unset';
         }
         dispatch(isEditModeUpdated(newEditMode));
         const res = await check();

--- a/src/main/webapp/src/components/page/Page.module.css
+++ b/src/main/webapp/src/components/page/Page.module.css
@@ -1,7 +1,7 @@
 .mathlinguaPage {
-  padding-top: 1.5em;
+  padding-top: 0;
   padding-bottom: 1em;
-  margin-top: 2.5em;
+  margin-top: 0;
   margin-bottom: 1em;
   margin-left: auto; /* for centering content */
   margin-right: auto; /* for centering content */
@@ -15,6 +15,7 @@
   border-radius: 2px;
   box-shadow: rgba(0, 0, 0, 0.1) 0px 3px 10px,
     inset 0 0 0 0 rgba(240, 240, 240, 0.5);
+  height: max-content;
 }
 
 @media screen and (max-width: 500px) {
@@ -27,8 +28,21 @@
 
 .sideBySideView {
   width: 100%;
-  margin-top: 1.5em;
-  padding: 0;
+  height: max-content;
+  padding-top: 0;
+  padding-bottom: 1em;
+  margin-top: 0;
+  margin-bottom: 1em;
+  margin-left: auto; /* for centering content */
+  margin-right: auto; /* for centering content */
+  font-size: 1em;
+  background-color: white;
+  border: solid;
+  border-width: 1px;
+  border-color: rgba(210, 210, 210);
+  border-radius: 2px;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 3px 10px,
+    inset 0 0 0 0 rgba(240, 240, 240, 0.5);
 }
 
 .splitViewContainer {
@@ -41,7 +55,7 @@
 
 .splitViewRendered {
   flex: 1 1 0px;
-  max-height: 100vh;
+  max-height: 95vh;
   overflow: auto;
   border-left: solid;
   border-color: #eeeeee;

--- a/src/main/webapp/src/components/page/Page.module.css
+++ b/src/main/webapp/src/components/page/Page.module.css
@@ -1,7 +1,7 @@
 .mathlinguaPage {
   padding-top: 0;
   padding-bottom: 1em;
-  margin-top: 0;
+  margin-top: 8vh;
   margin-bottom: 1em;
   margin-left: auto; /* for centering content */
   margin-right: auto; /* for centering content */
@@ -28,7 +28,7 @@
 
 .sideBySideView {
   width: 100%;
-  height: max-content;
+  height: 95vh;
   padding-top: 0;
   padding-bottom: 1em;
   margin-top: 0;
@@ -47,6 +47,7 @@
 
 .splitViewContainer {
   display: flex;
+  height: 95vh;
 }
 
 .splitViewEditor {

--- a/src/main/webapp/src/components/page/Page.tsx
+++ b/src/main/webapp/src/components/page/Page.tsx
@@ -295,19 +295,20 @@ export const Page = (props: PageProps) => {
       enableBasicAutocompletion={true}
       enableLiveAutocompletion={true}
       fontSize="90%"
-      height="89vh"
-      width="100%"
+      style={{
+        height: '100%',
+        width: '100%',
+        position: 'relative',
+      }}
       annotations={annotations}
     ></AceEditor>
   );
 
   const sideBySideView = (
-    <div style={{ overflowY: 'scroll', height: '100%' }}>
-      <div className={styles.sideBySideView}>
-        <div className={styles.splitViewContainer}>
-          <div className={styles.splitViewEditor}>{editorView}</div>
-          <div className={styles.splitViewRendered}>{renderedContent}</div>
-        </div>
+    <div className={styles.sideBySideView}>
+      <div className={styles.splitViewContainer}>
+        <div className={styles.splitViewEditor}>{editorView}</div>
+        <div className={styles.splitViewRendered}>{renderedContent}</div>
       </div>
     </div>
   );

--- a/src/main/webapp/src/components/page/Page.tsx
+++ b/src/main/webapp/src/components/page/Page.tsx
@@ -295,20 +295,19 @@ export const Page = (props: PageProps) => {
       enableBasicAutocompletion={true}
       enableLiveAutocompletion={true}
       fontSize="90%"
-      style={{
-        width: '100%',
-        height: '100%',
-        minHeight: '100vh',
-      }}
+      height="89vh"
+      width="100%"
       annotations={annotations}
     ></AceEditor>
   );
 
   const sideBySideView = (
-    <div className={styles.mathlinguaPage + ' ' + styles.sideBySideView}>
-      <div className={styles.splitViewContainer}>
-        <div className={styles.splitViewEditor}>{editorView}</div>
-        <div className={styles.splitViewRendered}>{renderedContent}</div>
+    <div style={{ overflowY: 'scroll', height: '100%' }}>
+      <div className={styles.sideBySideView}>
+        <div className={styles.splitViewContainer}>
+          <div className={styles.splitViewEditor}>{editorView}</div>
+          <div className={styles.splitViewRendered}>{renderedContent}</div>
+        </div>
       </div>
     </div>
   );
@@ -323,6 +322,10 @@ export const Page = (props: PageProps) => {
       ref={ref}
       style={{
         transition: '0.2s',
+        margin: 0,
+        paddingTop: 0,
+        paddingBottom: 0,
+        paddingRight: 0,
         paddingLeft:
           isEditMode && !isOnMobile() && isSidePanelVisible ? '15em' : '0',
       }}

--- a/src/main/webapp/src/components/path-tree-item/PathTreeItem.tsx
+++ b/src/main/webapp/src/components/path-tree-item/PathTreeItem.tsx
@@ -103,7 +103,7 @@ export const PathTreeItem = (props: PathTreeItemProps) => {
     }
   }
   // remove the .math extension and replace underscores with spaces
-  name = name.replace('.math', '').replace('_', ' ');
+  name = name.replace('.math', '').replace(/_/g, ' ');
 
   const updateInputName = async () => {
     if (!inputName || (!props.node.isDir && !inputName.endsWith('.math'))) {

--- a/src/main/webapp/src/components/side-panel/SidePanel.module.css
+++ b/src/main/webapp/src/components/side-panel/SidePanel.module.css
@@ -1,9 +1,10 @@
 .sidePanel {
-  height: 95%;
+  height: 93vh;
   width: 15em;
   position: fixed;
   z-index: 5;
-  top: 2em;
+  margin: 0;
+  top: 4vh;
   left: 0;
   background-color: #fefefe;
   border-right: solid;

--- a/src/main/webapp/src/components/topbar/TopBar.module.css
+++ b/src/main/webapp/src/components/topbar/TopBar.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: row;
   align-content: space-between;
-  height: 2em;
+  height: 4vh;
   background-color: #444444;
   position: fixed;
   z-index: 7;

--- a/src/main/webapp/src/index.css
+++ b/src/main/webapp/src/index.css
@@ -1,4 +1,18 @@
+#root {
+  padding: 0;
+  margin: 0;
+}
+
 body {
   background-color: #dddddd;
   font-family: Georgia, 'Times New Roman', Times, serif;
+  padding: 0;
+  margin: 0;
+  height: 99vh;
+  width: 100vw;
+}
+
+html {
+  padding: 0;
+  margin: 0;
 }


### PR DESCRIPTION
The CSS for the editor mode has been improved so that there is not any padding around
the editor view.  The CSS works great on desktop but has the bottom few lines of the
editor and rendered view cut off on mobile.